### PR TITLE
feat(theme-common, theme-classic): Improve CodeBlock Extensibility

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -405,11 +405,12 @@ declare module '@theme/BlogLayout' {
 
 declare module '@theme/CodeBlock' {
   import type {ReactNode} from 'react';
+  import type {CodeBlockMeta} from '@docusaurus/theme-common';
 
   export interface Props {
     readonly children: ReactNode;
     readonly className?: string;
-    readonly metastring?: string;
+    readonly metastring?: string | CodeBlockMeta;
     readonly title?: ReactNode;
     readonly language?: string;
     readonly showLineNumbers?: boolean | number;
@@ -481,11 +482,24 @@ declare module '@theme/CodeBlock/Line' {
     readonly line: Token[];
     readonly classNames: string[] | undefined;
     readonly showLineNumbers: boolean;
+    readonly meta?: CodeBlockMeta;
     readonly getLineProps: (input: LineInputProps) => LineOutputProps;
     readonly getTokenProps: (input: TokenInputProps) => TokenOutputProps;
   }
 
   export default function CodeBlockLine(props: Props): ReactNode;
+}
+
+declare module '@theme/CodeBlock/Token' {
+  import type {ReactNode} from 'react';
+  import type {TokenOutputProps} from 'prism-react-renderer';
+
+  export interface Props {
+    readonly output: TokenOutputProps;
+    readonly meta?: CodeBlockMeta;
+  }
+
+  export default function CodeBlockToken(props: Props): ReactNode;
 }
 
 declare module '@theme/CodeBlock/WordWrapButton' {

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
@@ -9,7 +9,6 @@ import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {useThemeConfig, usePrismTheme} from '@docusaurus/theme-common';
 import {
-  parseCodeBlockTitle,
   parseLanguage,
   parseLines,
   getLineNumbersStart,
@@ -51,19 +50,19 @@ export default function CodeBlockString({
   const wordWrap = useCodeWordWrap();
   const isBrowser = useIsBrowser();
 
-  // We still parse the metastring in case we want to support more syntax in the
-  // future. Note that MDX doesn't strip quotes when parsing metastring:
-  // "title=\"xyz\"" => title: "\"xyz\""
-  const title = parseCodeBlockTitle(metastring) || titleProp;
-
-  const {lineClassNames, code} = parseLines(children, {
+  const {meta, code} = parseLines(children, {
     metastring,
     language,
     magicComments,
   });
+
+  // Note that MDX doesn't strip quotes when parsing metastring:
+  // "title=\"xyz\"" => title: "\"xyz\""
+  const title = meta.options.title ?? titleProp;
+
   const lineNumbersStart = getLineNumbersStart({
     showLineNumbers: showLineNumbersProp,
-    metastring,
+    meta,
   });
 
   return (
@@ -105,7 +104,8 @@ export default function CodeBlockString({
                     line={line}
                     getLineProps={getLineProps}
                     getTokenProps={getTokenProps}
-                    classNames={lineClassNames[i]}
+                    classNames={meta.lineClassNames[i]}
+                    meta={meta}
                     showLineNumbers={lineNumbersStart !== undefined}
                   />
                 ))}

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Line/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Line/index.tsx
@@ -9,6 +9,7 @@ import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import type {Props} from '@theme/CodeBlock/Line';
 
+import CodeBlockToken from '@theme/CodeBlock/Token';
 import styles from './styles.module.css';
 
 type Token = Props['line'][number];
@@ -41,7 +42,7 @@ export default function CodeBlockLine({
   });
 
   const lineTokens = line.map((token, key) => (
-    <span key={key} {...getTokenProps({token})} />
+    <CodeBlockToken key={key} output={getTokenProps({token})} />
   ));
 
   return (

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Token/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Token/index.tsx
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {type ReactNode} from 'react';
+import type {Props} from '@theme/CodeBlock/Token';
+
+export default function CodeBlockToken({output}: Props): ReactNode {
+  return <span {...output} />;
+}

--- a/packages/docusaurus-theme-common/src/index.ts
+++ b/packages/docusaurus-theme-common/src/index.ts
@@ -144,3 +144,8 @@ export {
   ErrorBoundaryErrorMessageFallback,
   ErrorCauseBoundary,
 } from './utils/errorBoundaryUtils';
+
+export {
+  type CodeBlockMeta,
+  type CodeMetaOptionValue,
+} from './utils/codeBlockUtils';

--- a/packages/docusaurus-theme-common/src/internal.ts
+++ b/packages/docusaurus-theme-common/src/internal.ts
@@ -34,7 +34,7 @@ export {ColorModeProvider} from './contexts/colorMode';
 export {useAlternatePageUtils} from './utils/useAlternatePageUtils';
 
 export {
-  parseCodeBlockTitle,
+  parseCodeBlockMeta,
   parseLanguage,
   parseLines,
   getLineNumbersStart,

--- a/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
@@ -1,26 +1,150 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`parseLines does not parse content with metastring 1`] = `
+exports[`parseCodeBlockMeta parses mixed values 1`] = `
 {
-  "code": "aaaaa
-nnnnn",
   "lineClassNames": {
     "0": [
       "theme-code-block-highlighted-line",
     ],
+  },
+  "options": {
+    "a": "double'quote",
+    "b": "single"quote",
+    "c": "raw",
+    "d": true,
+    "e": false,
+    "f": 1,
+    "g": 0.5,
+  },
+}
+`;
+
+exports[`parseCodeBlockMeta parses range and options 1`] = `
+{
+  "lineClassNames": {
+    "0": [
+      "theme-code-block-highlighted-line",
+    ],
+    "1": [
+      "theme-code-block-highlighted-line",
+    ],
+    "2": [
+      "theme-code-block-highlighted-line",
+    ],
+  },
+  "options": {
+    "label": "JavaScript",
+    "title": "index.js",
+  },
+}
+`;
+
+exports[`parseCodeBlockMeta parses range and options end 1`] = `
+{
+  "lineClassNames": {
+    "0": [
+      "theme-code-block-highlighted-line",
+    ],
+    "1": [
+      "theme-code-block-highlighted-line",
+    ],
+    "2": [
+      "theme-code-block-highlighted-line",
+    ],
+  },
+  "options": {
+    "label": "JavaScript",
+    "title": "index.js",
+  },
+}
+`;
+
+exports[`parseCodeBlockMeta parses range and options middle 1`] = `
+{
+  "lineClassNames": {
+    "0": [
+      "theme-code-block-highlighted-line",
+    ],
+    "1": [
+      "theme-code-block-highlighted-line",
+    ],
+    "2": [
+      "theme-code-block-highlighted-line",
+    ],
+  },
+  "options": {
+    "label": "JavaScript",
+    "title": "index.js",
+  },
+}
+`;
+
+exports[`parseCodeBlockMeta parses range and options multiple 1`] = `
+{
+  "lineClassNames": {
+    "0": [
+      "theme-code-block-highlighted-line",
+    ],
+    "1": [
+      "theme-code-block-highlighted-line",
+    ],
+    "2": [
+      "theme-code-block-highlighted-line",
+    ],
+    "3": [
+      "theme-code-block-highlighted-line",
+    ],
+  },
+  "options": {
+    "label": "JavaScript",
+    "title": "index.js",
+  },
+}
+`;
+
+exports[`parseCodeBlockMeta parses range only 1`] = `
+{
+  "lineClassNames": {
+    "0": [
+      "theme-code-block-highlighted-line",
+    ],
+    "1": [
+      "theme-code-block-highlighted-line",
+    ],
+    "2": [
+      "theme-code-block-highlighted-line",
+    ],
+  },
+  "options": {},
+}
+`;
+
+exports[`parseLines does not parse content with metastring 1`] = `
+{
+  "code": "aaaaa
+nnnnn",
+  "meta": {
+    "lineClassNames": {
+      "0": [
+        "theme-code-block-highlighted-line",
+      ],
+    },
+    "options": {},
   },
 }
 `;
 
 exports[`parseLines does not parse content with metastring 2`] = `
 {
-  "code": "// highlight-next-line
-aaaaa
+  "code": "aaaaa
 bbbbb",
-  "lineClassNames": {
-    "0": [
-      "theme-code-block-highlighted-line",
-    ],
+  "meta": {
+    "lineClassNames": {
+      "0": [
+        "theme-code-block-highlighted-line",
+      ],
+    },
+    "options": {},
   },
 }
 `;
@@ -29,10 +153,13 @@ exports[`parseLines does not parse content with metastring 3`] = `
 {
   "code": "aaaaa
 bbbbb",
-  "lineClassNames": {
-    "0": [
-      "theme-code-block-highlighted-line",
-    ],
+  "meta": {
+    "lineClassNames": {
+      "0": [
+        "theme-code-block-highlighted-line",
+      ],
+    },
+    "options": {},
   },
 }
 `;
@@ -42,7 +169,10 @@ exports[`parseLines does not parse content with no language 1`] = `
   "code": "// highlight-next-line
 aaaaa
 bbbbb",
-  "lineClassNames": {},
+  "meta": {
+    "lineClassNames": {},
+    "options": {},
+  },
 }
 `;
 
@@ -58,40 +188,43 @@ highlighted and collapsed
 highlighted and collapsed
 Only collapsed
 highlighted and collapsed",
-  "lineClassNames": {
-    "1": [
-      "highlight",
-      "collapse",
-    ],
-    "2": [
-      "highlight",
-      "collapse",
-    ],
-    "3": [
-      "highlight",
-      "collapse",
-    ],
-    "4": [
-      "highlight",
-    ],
-    "5": [
-      "collapse",
-    ],
-    "6": [
-      "highlight",
-      "collapse",
-    ],
-    "7": [
-      "highlight",
-      "collapse",
-    ],
-    "8": [
-      "collapse",
-    ],
-    "9": [
-      "highlight",
-      "collapse",
-    ],
+  "meta": {
+    "lineClassNames": {
+      "1": [
+        "highlight",
+        "collapse",
+      ],
+      "2": [
+        "highlight",
+        "collapse",
+      ],
+      "3": [
+        "highlight",
+        "collapse",
+      ],
+      "4": [
+        "highlight",
+      ],
+      "5": [
+        "collapse",
+      ],
+      "6": [
+        "highlight",
+        "collapse",
+      ],
+      "7": [
+        "highlight",
+        "collapse",
+      ],
+      "8": [
+        "collapse",
+      ],
+      "9": [
+        "highlight",
+        "collapse",
+      ],
+    },
+    "options": {},
   },
 }
 `;
@@ -100,17 +233,20 @@ exports[`parseLines handles one line with multiple class names 2`] = `
 {
   "code": "line
 line",
-  "lineClassNames": {
-    "0": [
-      "a",
-      "b",
-      "c",
-      "d",
-    ],
-    "1": [
-      "b",
-      "d",
-    ],
+  "meta": {
+    "lineClassNames": {
+      "0": [
+        "a",
+        "b",
+        "c",
+        "d",
+      ],
+      "1": [
+        "b",
+        "d",
+      ],
+    },
+    "options": {},
   },
 }
 `;
@@ -122,19 +258,22 @@ highlighted
 collapsed
 collapsed
 collapsed",
-  "lineClassNames": {
-    "1": [
-      "highlight",
-    ],
-    "2": [
-      "collapse",
-    ],
-    "3": [
-      "collapse",
-    ],
-    "4": [
-      "collapse",
-    ],
+  "meta": {
+    "lineClassNames": {
+      "1": [
+        "highlight",
+      ],
+      "2": [
+        "collapse",
+      ],
+      "3": [
+        "collapse",
+      ],
+      "4": [
+        "collapse",
+      ],
+    },
+    "options": {},
   },
 }
 `;
@@ -143,10 +282,13 @@ exports[`parseLines removes lines correctly 1`] = `
 {
   "code": "aaaaa
 bbbbb",
-  "lineClassNames": {
-    "0": [
-      "theme-code-block-highlighted-line",
-    ],
+  "meta": {
+    "lineClassNames": {
+      "0": [
+        "theme-code-block-highlighted-line",
+      ],
+    },
+    "options": {},
   },
 }
 `;
@@ -155,10 +297,13 @@ exports[`parseLines removes lines correctly 2`] = `
 {
   "code": "aaaaa
 bbbbb",
-  "lineClassNames": {
-    "0": [
-      "theme-code-block-highlighted-line",
-    ],
+  "meta": {
+    "lineClassNames": {
+      "0": [
+        "theme-code-block-highlighted-line",
+      ],
+    },
+    "options": {},
   },
 }
 `;
@@ -168,17 +313,19 @@ exports[`parseLines removes lines correctly 3`] = `
   "code": "aaaaa
 bbbbbbb
 bbbbb",
-  "lineClassNames": {
-    "0": [
-      "theme-code-block-highlighted-line",
-      "theme-code-block-highlighted-line",
-    ],
-    "1": [
-      "theme-code-block-highlighted-line",
-    ],
-    "2": [
-      "theme-code-block-highlighted-line",
-    ],
+  "meta": {
+    "lineClassNames": {
+      "0": [
+        "theme-code-block-highlighted-line",
+      ],
+      "1": [
+        "theme-code-block-highlighted-line",
+      ],
+      "2": [
+        "theme-code-block-highlighted-line",
+      ],
+    },
+    "options": {},
   },
 }
 `;
@@ -189,13 +336,16 @@ exports[`parseLines respects language: html 1`] = `
 {/* highlight-next-line */}
 bbbbb
 dddd",
-  "lineClassNames": {
-    "0": [
-      "theme-code-block-highlighted-line",
-    ],
-    "3": [
-      "theme-code-block-highlighted-line",
-    ],
+  "meta": {
+    "lineClassNames": {
+      "0": [
+        "theme-code-block-highlighted-line",
+      ],
+      "3": [
+        "theme-code-block-highlighted-line",
+      ],
+    },
+    "options": {},
   },
 }
 `;
@@ -205,7 +355,10 @@ exports[`parseLines respects language: js 1`] = `
   "code": "# highlight-next-line
 aaaaa
 bbbbb",
-  "lineClassNames": {},
+  "meta": {
+    "lineClassNames": {},
+    "options": {},
+  },
 }
 `;
 
@@ -215,13 +368,16 @@ exports[`parseLines respects language: jsx 1`] = `
 bbbbb
 <!-- highlight-next-line -->
 dddd",
-  "lineClassNames": {
-    "0": [
-      "theme-code-block-highlighted-line",
-    ],
-    "1": [
-      "theme-code-block-highlighted-line",
-    ],
+  "meta": {
+    "lineClassNames": {
+      "0": [
+        "theme-code-block-highlighted-line",
+      ],
+      "1": [
+        "theme-code-block-highlighted-line",
+      ],
+    },
+    "options": {},
   },
 }
 `;
@@ -245,16 +401,19 @@ dddd
 // highlight-next-line
 console.log("preserved");
 \`\`\`",
-  "lineClassNames": {
-    "1": [
-      "theme-code-block-highlighted-line",
-    ],
-    "11": [
-      "theme-code-block-highlighted-line",
-    ],
-    "7": [
-      "theme-code-block-highlighted-line",
-    ],
+  "meta": {
+    "lineClassNames": {
+      "1": [
+        "theme-code-block-highlighted-line",
+      ],
+      "11": [
+        "theme-code-block-highlighted-line",
+      ],
+      "7": [
+        "theme-code-block-highlighted-line",
+      ],
+    },
+    "options": {},
   },
 }
 `;
@@ -265,19 +424,22 @@ exports[`parseLines respects language: none 1`] = `
 bbbbb
 ccccc
 dddd",
-  "lineClassNames": {
-    "0": [
-      "theme-code-block-highlighted-line",
-    ],
-    "1": [
-      "theme-code-block-highlighted-line",
-    ],
-    "2": [
-      "theme-code-block-highlighted-line",
-    ],
-    "3": [
-      "theme-code-block-highlighted-line",
-    ],
+  "meta": {
+    "lineClassNames": {
+      "0": [
+        "theme-code-block-highlighted-line",
+      ],
+      "1": [
+        "theme-code-block-highlighted-line",
+      ],
+      "2": [
+        "theme-code-block-highlighted-line",
+      ],
+      "3": [
+        "theme-code-block-highlighted-line",
+      ],
+    },
+    "options": {},
   },
 }
 `;
@@ -287,7 +449,10 @@ exports[`parseLines respects language: py 1`] = `
   "code": "/* highlight-next-line */
 aaaaa
 bbbbb",
-  "lineClassNames": {},
+  "meta": {
+    "lineClassNames": {},
+    "options": {},
+  },
 }
 `;
 
@@ -300,10 +465,13 @@ bbbbb
 ccccc
 <!-- highlight-next-line -->
 dddd",
-  "lineClassNames": {
-    "4": [
-      "theme-code-block-highlighted-line",
-    ],
+  "meta": {
+    "lineClassNames": {
+      "4": [
+        "theme-code-block-highlighted-line",
+      ],
+    },
+    "options": {},
   },
 }
 `;

--- a/packages/docusaurus-theme-live-codeblock/src/theme/Playground/index.tsx
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/Playground/index.tsx
@@ -18,6 +18,7 @@ import {
 } from '@docusaurus/theme-common';
 import ErrorBoundary from '@docusaurus/ErrorBoundary';
 
+import {parseCodeBlockMeta} from '@docusaurus/theme-common/internal';
 import type {Props} from '@theme/Playground';
 import type {ThemeConfig} from '@docusaurus/theme-live-codeblock';
 
@@ -115,7 +116,13 @@ export default function Playground({
   } = themeConfig as ThemeConfig;
   const prismTheme = usePrismTheme();
 
-  const noInline = props.metastring?.includes('noInline') ?? false;
+  const meta = parseCodeBlockMeta({
+    metastring: props.metastring,
+    language: undefined,
+    magicComments: [],
+  });
+
+  const noInline = meta.options.noinline === true;
 
   return (
     <div className={styles.playgroundContainer}>

--- a/project-words.txt
+++ b/project-words.txt
@@ -202,6 +202,7 @@ noflash
 noicon
 nojekyll
 noninteractive
+noinline
 npmjs
 Nuxt
 ödingers
@@ -297,6 +298,7 @@ SFNT
 shiki
 Shiki
 showinfo
+showlinenumbers
 Sida
 Simen
 slorber


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #11008) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

Closes #11008

## Test Plan

Verified and tested via unit tests. I primarily focused on `codeBlockUtils.test.ts` but all other tests locally are green. Looking at the rendered codeblocks on the website they are equal to before. 

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-11011--docusaurus-2.netlify.app/
Relevant Links:
* https://deploy-preview-11011--docusaurus-2.netlify.app/docs/markdown-features/code-blocks

## Related issues/PRs

#11008
<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
