### PR TITLE
test(theme-common): Add tests for getLineNumbersStart

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`getLineNumbersStart handles metadata combined with other options set as flag 1`] = `1`;
+
+exports[`getLineNumbersStart handles metadata combined with other options set with number 1`] = `10`;
+
+exports[`getLineNumbersStart handles metadata standalone set as flag 1`] = `1`;
+
+exports[`getLineNumbersStart handles metadata standalone set with number 1`] = `10`;
+
+exports[`getLineNumbersStart handles prop combined with metastring set to false 1`] = `undefined`;
+
+exports[`getLineNumbersStart handles prop combined with metastring set to number 1`] = `10`;
+
+exports[`getLineNumbersStart handles prop combined with metastring set to true 1`] = `1`;
+
+exports[`getLineNumbersStart handles prop standalone set to false 1`] = `undefined`;
+
+exports[`getLineNumbersStart handles prop standalone set to number 1`] = `10`;
+
+exports[`getLineNumbersStart handles prop standalone set to true 1`] = `1`;
+
+exports[`getLineNumbersStart with nothing set 1`] = `undefined`;
+
+exports[`getLineNumbersStart with nothing set 2`] = `undefined`;
+
 exports[`parseLines does not parse content with metastring 1`] = `
 {
   "code": "aaaaa

--- a/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  getLineNumbersStart,
   type MagicCommentConfig,
   parseCodeBlockTitle,
   parseLanguage,
@@ -358,5 +359,122 @@ line
         },
       ),
     ).toMatchSnapshot();
+  });
+});
+
+describe('getLineNumbersStart', () => {
+  it('with nothing set', () => {
+    expect(
+      getLineNumbersStart({
+        showLineNumbers: undefined,
+        metastring: undefined,
+      }),
+    ).toMatchSnapshot();
+    expect(
+      getLineNumbersStart({
+        showLineNumbers: undefined,
+        metastring: '',
+      }),
+    ).toMatchSnapshot();
+  });
+
+  describe('handles prop', () => {
+    describe('combined with metastring', () => {
+      it('set to true', () => {
+        expect(
+          getLineNumbersStart({
+            showLineNumbers: true,
+            metastring: 'showLineNumbers=2',
+          }),
+        ).toMatchSnapshot();
+      });
+
+      it('set to false', () => {
+        expect(
+          getLineNumbersStart({
+            showLineNumbers: false,
+            metastring: 'showLineNumbers=2',
+          }),
+        ).toMatchSnapshot();
+      });
+
+      it('set to number', () => {
+        expect(
+          getLineNumbersStart({
+            showLineNumbers: 10,
+            metastring: 'showLineNumbers=2',
+          }),
+        ).toMatchSnapshot();
+      });
+    });
+
+    describe('standalone', () => {
+      it('set to true', () => {
+        expect(
+          getLineNumbersStart({
+            showLineNumbers: true,
+            metastring: undefined,
+          }),
+        ).toMatchSnapshot();
+      });
+
+      it('set to false', () => {
+        expect(
+          getLineNumbersStart({
+            showLineNumbers: false,
+            metastring: undefined,
+          }),
+        ).toMatchSnapshot();
+      });
+
+      it('set to number', () => {
+        expect(
+          getLineNumbersStart({
+            showLineNumbers: 10,
+            metastring: undefined,
+          }),
+        ).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('handles metadata', () => {
+    describe('standalone', () => {
+      it('set as flag', () => {
+        expect(
+          getLineNumbersStart({
+            showLineNumbers: undefined,
+            metastring: 'showLineNumbers',
+          }),
+        ).toMatchSnapshot();
+      });
+      it('set with number', () => {
+        expect(
+          getLineNumbersStart({
+            showLineNumbers: undefined,
+            metastring: 'showLineNumbers=10',
+          }),
+        ).toMatchSnapshot();
+      });
+    });
+
+    describe('combined with other options', () => {
+      it('set as flag', () => {
+        expect(
+          getLineNumbersStart({
+            showLineNumbers: undefined,
+            metastring: '{1,2-3}  title="file.txt" showLineNumbers noInline',
+          }),
+        ).toMatchSnapshot();
+      });
+      it('set with number', () => {
+        expect(
+          getLineNumbersStart({
+            showLineNumbers: undefined,
+            metastring: '{1,2-3}  title="file.txt" showLineNumbers=10 noInline',
+          }),
+        ).toMatchSnapshot();
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

This PR is part of a series related to #11008 and it superceeds https://github.com/facebook/docusaurus/pull/11011 in the goal to splitup the work into more isolated refactoring/feature parts. 

Step 1 (this PR): Splitup current parseLines logic
Step 2 (#11019): Parse metastring into metaOptions and use it across components.
Step 3 (#11021): Add parsing of any options specified in the metastring.
Step 4 (#11022): Add CodeBlockToken component to customize DOM of highlighted tokens. 
Step 5 (#11023): Pass `metaOptions` to whole codeblock component tree.

The motivation of this part ~~is~~ was to prepare the codebase for the upcoming extensions and adaptions. Initially step 2 had the parsing added to `parseLines` so splitting things up and defining types was a good preparation for extension. 

With the final version of all changes, `parseLines` is not used for this purpose. I still kept this PR for two purposes:

1. The splitup and type definitions might make some things easier to maintain. 
2. The additional tests are ensuring correct behavior of the nest steps. 

## Test Plan

The code change aims to have 0 functional impact and is therefore covered by the current unit/integration tests. These tests are green. 

Manual testing by checking `/docs/markdown-features/code-blocks` showed no impact of the change. 

Additional tests for `getLineNumbersStart` were added to avoid regression bugs in upcoming PRs. more tests likely come in every step.  

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-11017--docusaurus-2.netlify.app
Code Blocks: https://deploy-preview-11017--docusaurus-2.netlify.app/docs/markdown-features/code-blocks/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop 
the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

* https://github.com/facebook/docusaurus/pull/11011
* #11008