### PR TITLE
refactor(theme-common, theme-classic, theme-live-codeblock): Parse `metastring` into `metaOptions` and use it across components

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -405,6 +405,7 @@ declare module '@theme/BlogLayout' {
 
 declare module '@theme/CodeBlock' {
   import type {ReactNode} from 'react';
+  import type {CodeBlockMetaOptions} from '@docusaurus/theme-common/internal';
 
   export interface Props {
     readonly children: ReactNode;
@@ -413,6 +414,7 @@ declare module '@theme/CodeBlock' {
     readonly title?: ReactNode;
     readonly language?: string;
     readonly showLineNumbers?: boolean | number;
+    readonly metaOptions?: CodeBlockMetaOptions;
   }
 
   export default function CodeBlock(props: Props): ReactNode;

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
@@ -70,7 +70,7 @@ export default function CodeBlockString({
   });
   const lineNumbersStart = getLineNumbersStart({
     showLineNumbers: showLineNumbersProp,
-    metastring,
+    metaOptions,
   });
 
   return (

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
@@ -9,9 +9,10 @@ import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {useThemeConfig, usePrismTheme} from '@docusaurus/theme-common';
 import {
-  parseCodeBlockTitle,
+  parseCodeBlockMetaOptions,
   parseLanguage,
   parseLines,
+  getCodeBlockTitle,
   getLineNumbersStart,
   useCodeWordWrap,
 } from '@docusaurus/theme-common/internal';
@@ -51,10 +52,15 @@ export default function CodeBlockString({
   const wordWrap = useCodeWordWrap();
   const isBrowser = useIsBrowser();
 
+  const metaOptions = parseCodeBlockMetaOptions(metastring);
+
   // We still parse the metastring in case we want to support more syntax in the
   // future. Note that MDX doesn't strip quotes when parsing metastring:
   // "title=\"xyz\"" => title: "\"xyz\""
-  const title = parseCodeBlockTitle(metastring) || titleProp;
+  const title = getCodeBlockTitle({
+    titleProp,
+    metaOptions,
+  });
 
   const {lineClassNames, code} = parseLines(children, {
     metastring,

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
@@ -40,6 +40,7 @@ export default function CodeBlockString({
   title: titleProp,
   showLineNumbers: showLineNumbersProp,
   language: languageProp,
+  metaOptions: metaOptionsProp,
 }: Props): ReactNode {
   const {
     prism: {defaultLanguage, magicComments},
@@ -52,7 +53,7 @@ export default function CodeBlockString({
   const wordWrap = useCodeWordWrap();
   const isBrowser = useIsBrowser();
 
-  const metaOptions = parseCodeBlockMetaOptions(metastring);
+  const metaOptions = parseCodeBlockMetaOptions(metastring, metaOptionsProp);
 
   // We still parse the metastring in case we want to support more syntax in the
   // future. Note that MDX doesn't strip quotes when parsing metastring:

--- a/packages/docusaurus-theme-common/src/internal.ts
+++ b/packages/docusaurus-theme-common/src/internal.ts
@@ -34,9 +34,10 @@ export {ColorModeProvider} from './contexts/colorMode';
 export {useAlternatePageUtils} from './utils/useAlternatePageUtils';
 
 export {
-  parseCodeBlockTitle,
+  parseCodeBlockMetaOptions,
   parseLanguage,
   parseLines,
+  getCodeBlockTitle,
   getLineNumbersStart,
 } from './utils/codeBlockUtils';
 

--- a/packages/docusaurus-theme-common/src/internal.ts
+++ b/packages/docusaurus-theme-common/src/internal.ts
@@ -39,6 +39,7 @@ export {
   parseLines,
   getCodeBlockTitle,
   getLineNumbersStart,
+  type CodeBlockMetaOptions,
 } from './utils/codeBlockUtils';
 
 export {DEFAULT_SEARCH_TAG} from './utils/searchUtils';

--- a/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
@@ -12,29 +12,33 @@ exports[`getCodeBlockTitle returns titleProp with empty string on option 1`] = `
 
 exports[`getCodeBlockTitle with nothing set 1`] = `undefined`;
 
-exports[`getLineNumbersStart handles metadata combined with other options set as flag 1`] = `1`;
+exports[`getLineNumbersStart from metastring parses flags as 1 1`] = `1`;
 
-exports[`getLineNumbersStart handles metadata combined with other options set with number 1`] = `10`;
+exports[`getLineNumbersStart from metastring parses value 1`] = `10`;
 
-exports[`getLineNumbersStart handles metadata standalone set as flag 1`] = `1`;
+exports[`getLineNumbersStart with parsed metaoption handles metadata combined with other options set as flag 1`] = `1`;
 
-exports[`getLineNumbersStart handles metadata standalone set with number 1`] = `10`;
+exports[`getLineNumbersStart with parsed metaoption handles metadata combined with other options set with number 1`] = `10`;
 
-exports[`getLineNumbersStart handles prop combined with metaoptions set to false 1`] = `undefined`;
+exports[`getLineNumbersStart with parsed metaoption handles metadata standalone set as flag 1`] = `1`;
 
-exports[`getLineNumbersStart handles prop combined with metaoptions set to number 1`] = `10`;
+exports[`getLineNumbersStart with parsed metaoption handles metadata standalone set with number 1`] = `10`;
 
-exports[`getLineNumbersStart handles prop combined with metaoptions set to true 1`] = `1`;
+exports[`getLineNumbersStart with parsed metaoption handles prop combined with metaoptions set to false 1`] = `undefined`;
 
-exports[`getLineNumbersStart handles prop standalone set to false 1`] = `undefined`;
+exports[`getLineNumbersStart with parsed metaoption handles prop combined with metaoptions set to number 1`] = `10`;
 
-exports[`getLineNumbersStart handles prop standalone set to number 1`] = `10`;
+exports[`getLineNumbersStart with parsed metaoption handles prop combined with metaoptions set to true 1`] = `1`;
 
-exports[`getLineNumbersStart handles prop standalone set to true 1`] = `1`;
+exports[`getLineNumbersStart with parsed metaoption handles prop standalone set to false 1`] = `undefined`;
 
-exports[`getLineNumbersStart with nothing set 1`] = `undefined`;
+exports[`getLineNumbersStart with parsed metaoption handles prop standalone set to number 1`] = `10`;
 
-exports[`getLineNumbersStart with nothing set 2`] = `undefined`;
+exports[`getLineNumbersStart with parsed metaoption handles prop standalone set to true 1`] = `1`;
+
+exports[`getLineNumbersStart with parsed metaoption with nothing set 1`] = `undefined`;
+
+exports[`getLineNumbersStart with parsed metaoption with nothing set 2`] = `undefined`;
 
 exports[`parseLines does not parse content with metastring 1`] = `
 {

--- a/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`getCodeBlockTitle returns option with empty prop 1`] = `"Option"`;
+
+exports[`getCodeBlockTitle returns option with filled prop 1`] = `"Option"`;
+
+exports[`getCodeBlockTitle returns option with undefined prop 1`] = `"Option"`;
+
+exports[`getCodeBlockTitle returns titleProp with empty options 1`] = `"Prop"`;
+
+exports[`getCodeBlockTitle returns titleProp with empty string on option 1`] = `"Prop"`;
+
+exports[`getCodeBlockTitle with nothing set 1`] = `undefined`;
+
 exports[`getLineNumbersStart handles metadata combined with other options set as flag 1`] = `1`;
 
 exports[`getLineNumbersStart handles metadata combined with other options set with number 1`] = `10`;

--- a/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
@@ -20,11 +20,11 @@ exports[`getLineNumbersStart handles metadata standalone set as flag 1`] = `1`;
 
 exports[`getLineNumbersStart handles metadata standalone set with number 1`] = `10`;
 
-exports[`getLineNumbersStart handles prop combined with metastring set to false 1`] = `undefined`;
+exports[`getLineNumbersStart handles prop combined with metaoptions set to false 1`] = `undefined`;
 
-exports[`getLineNumbersStart handles prop combined with metastring set to number 1`] = `10`;
+exports[`getLineNumbersStart handles prop combined with metaoptions set to number 1`] = `10`;
 
-exports[`getLineNumbersStart handles prop combined with metastring set to true 1`] = `1`;
+exports[`getLineNumbersStart handles prop combined with metaoptions set to true 1`] = `1`;
 
 exports[`getLineNumbersStart handles prop standalone set to false 1`] = `undefined`;
 

--- a/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
@@ -39,15 +39,19 @@ describe('parseCodeBlockMetaOptions', () => {
     it('does not parse mismatched quote delimiters', () => {
       expect(
         parseCodeBlockMetaOptions(`title="index.js'`, undefined).title,
-      ).toBe(``);
+      ).toBeUndefined();
     });
 
     it('parses undefined metastring', () => {
-      expect(parseCodeBlockMetaOptions(undefined, undefined).title).toBe(``);
+      expect(
+        parseCodeBlockMetaOptions(undefined, undefined).title,
+      ).toBeUndefined();
     });
 
     it('parses metastring with no title specified', () => {
-      expect(parseCodeBlockMetaOptions(`{1,2-3}`, undefined).title).toBe(``);
+      expect(
+        parseCodeBlockMetaOptions(`{1,2-3}`, undefined).title,
+      ).toBeUndefined();
     });
 
     it('parses with multiple metadata title first', () => {
@@ -86,7 +90,34 @@ describe('parseCodeBlockMetaOptions', () => {
       ).toBe(`console.log('Hello, World!')`);
     });
   });
+
+  // showLineNumber logic is tested in combination with getLineNumber below
+
+  describe('live', () => {
+    it('parses live as true', () => {
+      expect(parseCodeBlockMetaOptions(`live`, undefined).live).toBe(true);
+    });
+    it('parses no live as undefined', () => {
+      expect(
+        parseCodeBlockMetaOptions(` otherOption `, undefined).live,
+      ).toBeUndefined();
+    });
+  });
+
+  describe('noInline', () => {
+    it('parses noInline as true', () => {
+      expect(parseCodeBlockMetaOptions(`noInline`, undefined).noInline).toBe(
+        true,
+      );
+    });
+    it('parses no noInline as undefined', () => {
+      expect(
+        parseCodeBlockMetaOptions(` otherOption `, undefined).noInline,
+      ).toBeUndefined();
+    });
+  });
 });
+
 describe('parseLanguage', () => {
   it('works', () => {
     expect(parseLanguage('language-foo xxx yyy')).toBe('foo');
@@ -423,142 +454,170 @@ line
 });
 
 describe('getLineNumbersStart', () => {
-  it('with nothing set', () => {
-    expect(
-      getLineNumbersStart({
-        showLineNumbers: undefined,
-        metaOptions: {},
-      }),
-    ).toMatchSnapshot();
-    expect(
-      getLineNumbersStart({
-        showLineNumbers: undefined,
-        metaOptions: {},
-      }),
-    ).toMatchSnapshot();
+  describe('with parsed metaoption', () => {
+    it('with nothing set', () => {
+      expect(
+        getLineNumbersStart({
+          showLineNumbers: undefined,
+          metaOptions: {},
+        }),
+      ).toMatchSnapshot();
+      expect(
+        getLineNumbersStart({
+          showLineNumbers: undefined,
+          metaOptions: {},
+        }),
+      ).toMatchSnapshot();
+    });
+
+    describe('handles prop', () => {
+      describe('combined with metaoptions', () => {
+        it('set to true', () => {
+          expect(
+            getLineNumbersStart({
+              showLineNumbers: true,
+              metaOptions: {
+                showLineNumbers: 2,
+              },
+            }),
+          ).toMatchSnapshot();
+        });
+
+        it('set to false', () => {
+          expect(
+            getLineNumbersStart({
+              showLineNumbers: false,
+              metaOptions: {
+                showLineNumbers: 2,
+              },
+            }),
+          ).toMatchSnapshot();
+        });
+
+        it('set to number', () => {
+          expect(
+            getLineNumbersStart({
+              showLineNumbers: 10,
+              metaOptions: {
+                showLineNumbers: 2,
+              },
+            }),
+          ).toMatchSnapshot();
+        });
+      });
+
+      describe('standalone', () => {
+        it('set to true', () => {
+          expect(
+            getLineNumbersStart({
+              showLineNumbers: true,
+              metaOptions: {
+                showLineNumbers: 2,
+              },
+            }),
+          ).toMatchSnapshot();
+        });
+
+        it('set to false', () => {
+          expect(
+            getLineNumbersStart({
+              showLineNumbers: false,
+              metaOptions: {
+                showLineNumbers: 2,
+              },
+            }),
+          ).toMatchSnapshot();
+        });
+
+        it('set to number', () => {
+          expect(
+            getLineNumbersStart({
+              showLineNumbers: 10,
+              metaOptions: {
+                showLineNumbers: 2,
+              },
+            }),
+          ).toMatchSnapshot();
+        });
+      });
+    });
+
+    describe('handles metadata', () => {
+      describe('standalone', () => {
+        it('set as flag', () => {
+          expect(
+            getLineNumbersStart({
+              showLineNumbers: undefined,
+              metaOptions: {
+                showLineNumbers: true,
+              },
+            }),
+          ).toMatchSnapshot();
+        });
+        it('set with number', () => {
+          expect(
+            getLineNumbersStart({
+              showLineNumbers: undefined,
+              metaOptions: {
+                showLineNumbers: 10,
+              },
+            }),
+          ).toMatchSnapshot();
+        });
+      });
+
+      describe('combined with other options', () => {
+        it('set as flag', () => {
+          expect(
+            getLineNumbersStart({
+              showLineNumbers: undefined,
+              metaOptions: {
+                title: 'file.txt',
+                showLineNumbers: true,
+                noInline: true,
+              },
+            }),
+          ).toMatchSnapshot();
+        });
+        it('set with number', () => {
+          expect(
+            getLineNumbersStart({
+              showLineNumbers: undefined,
+              metaOptions: {
+                title: 'file.txt',
+                showLineNumbers: 10,
+                noInline: true,
+              },
+            }),
+          ).toMatchSnapshot();
+        });
+      });
+    });
   });
 
-  describe('handles prop', () => {
-    describe('combined with metaoptions', () => {
-      it('set to true', () => {
-        expect(
-          getLineNumbersStart({
-            showLineNumbers: true,
-            metaOptions: {
-              showLineNumbers: 2,
-            },
-          }),
-        ).toMatchSnapshot();
-      });
-
-      it('set to false', () => {
-        expect(
-          getLineNumbersStart({
-            showLineNumbers: false,
-            metaOptions: {
-              showLineNumbers: 2,
-            },
-          }),
-        ).toMatchSnapshot();
-      });
-
-      it('set to number', () => {
-        expect(
-          getLineNumbersStart({
-            showLineNumbers: 10,
-            metaOptions: {
-              showLineNumbers: 2,
-            },
-          }),
-        ).toMatchSnapshot();
-      });
+  describe('from metastring', () => {
+    it('parses flags as 1', () => {
+      expect(
+        getLineNumbersStart({
+          showLineNumbers: undefined,
+          metaOptions: parseCodeBlockMetaOptions(
+            ' showLineNumbers ',
+            undefined,
+          ),
+        }),
+      ).toMatchSnapshot();
     });
 
-    describe('standalone', () => {
-      it('set to true', () => {
-        expect(
-          getLineNumbersStart({
-            showLineNumbers: true,
-            metaOptions: {
-              showLineNumbers: 2,
-            },
-          }),
-        ).toMatchSnapshot();
-      });
-
-      it('set to false', () => {
-        expect(
-          getLineNumbersStart({
-            showLineNumbers: false,
-            metaOptions: {
-              showLineNumbers: 2,
-            },
-          }),
-        ).toMatchSnapshot();
-      });
-
-      it('set to number', () => {
-        expect(
-          getLineNumbersStart({
-            showLineNumbers: 10,
-            metaOptions: {
-              showLineNumbers: 2,
-            },
-          }),
-        ).toMatchSnapshot();
-      });
-    });
-  });
-
-  describe('handles metadata', () => {
-    describe('standalone', () => {
-      it('set as flag', () => {
-        expect(
-          getLineNumbersStart({
-            showLineNumbers: undefined,
-            metaOptions: {
-              showLineNumbers: true,
-            },
-          }),
-        ).toMatchSnapshot();
-      });
-      it('set with number', () => {
-        expect(
-          getLineNumbersStart({
-            showLineNumbers: undefined,
-            metaOptions: {
-              showLineNumbers: 10,
-            },
-          }),
-        ).toMatchSnapshot();
-      });
-    });
-
-    describe('combined with other options', () => {
-      it('set as flag', () => {
-        expect(
-          getLineNumbersStart({
-            showLineNumbers: undefined,
-            metaOptions: {
-              title: 'file.txt',
-              showLineNumbers: true,
-              noInline: true,
-            },
-          }),
-        ).toMatchSnapshot();
-      });
-      it('set with number', () => {
-        expect(
-          getLineNumbersStart({
-            showLineNumbers: undefined,
-            metaOptions: {
-              title: 'file.txt',
-              showLineNumbers: 10,
-              noInline: true,
-            },
-          }),
-        ).toMatchSnapshot();
-      });
+    it('parses value', () => {
+      expect(
+        getLineNumbersStart({
+          showLineNumbers: undefined,
+          metaOptions: parseCodeBlockMetaOptions(
+            ' showLineNumbers=10 ',
+            undefined,
+          ),
+        }),
+      ).toMatchSnapshot();
     });
   });
 });

--- a/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
@@ -25,50 +25,64 @@ const defaultMagicComments: MagicCommentConfig[] = [
 describe('parseCodeBlockMetaOptions', () => {
   describe('title', () => {
     it('parses double quote delimited title', () => {
-      expect(parseCodeBlockMetaOptions(`title="index.js"`).title).toBe(
-        `index.js`,
-      );
+      expect(
+        parseCodeBlockMetaOptions(`title="index.js"`, undefined).title,
+      ).toBe(`index.js`);
     });
 
     it('parses single quote delimited title', () => {
-      expect(parseCodeBlockMetaOptions(`title='index.js'`).title).toBe(
-        `index.js`,
-      );
+      expect(
+        parseCodeBlockMetaOptions(`title='index.js'`, undefined).title,
+      ).toBe(`index.js`);
     });
 
     it('does not parse mismatched quote delimiters', () => {
-      expect(parseCodeBlockMetaOptions(`title="index.js'`).title).toBe(``);
+      expect(
+        parseCodeBlockMetaOptions(`title="index.js'`, undefined).title,
+      ).toBe(``);
     });
 
     it('parses undefined metastring', () => {
-      expect(parseCodeBlockMetaOptions(undefined).title).toBe(``);
+      expect(parseCodeBlockMetaOptions(undefined, undefined).title).toBe(``);
     });
 
     it('parses metastring with no title specified', () => {
-      expect(parseCodeBlockMetaOptions(`{1,2-3}`).title).toBe(``);
+      expect(parseCodeBlockMetaOptions(`{1,2-3}`, undefined).title).toBe(``);
     });
 
     it('parses with multiple metadata title first', () => {
       expect(
-        parseCodeBlockMetaOptions(`title="index.js" label="JavaScript"`).title,
+        parseCodeBlockMetaOptions(
+          `title="index.js" label="JavaScript"`,
+          undefined,
+        ).title,
       ).toBe(`index.js`);
     });
 
     it('parses with multiple metadata title last', () => {
       expect(
-        parseCodeBlockMetaOptions(`label="JavaScript" title="index.js"`).title,
+        parseCodeBlockMetaOptions(
+          `label="JavaScript" title="index.js"`,
+          undefined,
+        ).title,
       ).toBe(`index.js`);
     });
 
     it('parses double quotes when delimited by single quotes', () => {
       expect(
-        parseCodeBlockMetaOptions(`title='console.log("Hello, World!")'`).title,
+        parseCodeBlockMetaOptions(
+          `title='console.log("Hello, World!")'`,
+          undefined,
+        ).title,
       ).toBe(`console.log("Hello, World!")`);
     });
 
     it('parses single quotes when delimited by double quotes', () => {
       expect(
-        parseCodeBlockMetaOptions(`title="console.log('Hello, World!')"`).title,
+        parseCodeBlockMetaOptions(
+          `title="console.log('Hello, World!')"`,
+          undefined,
+        ).title,
       ).toBe(`console.log('Hello, World!')`);
     });
   });
@@ -148,7 +162,11 @@ bbbbb`,
         `// highlight-next-line
 aaaaa
 bbbbb`,
-        {metastring: '', language: 'js', magicComments: defaultMagicComments},
+        {
+          metastring: '',
+          language: 'js',
+          magicComments: defaultMagicComments,
+        },
       ),
     ).toMatchSnapshot();
     expect(
@@ -157,7 +175,11 @@ bbbbb`,
 aaaaa
 // highlight-end
 bbbbb`,
-        {metastring: '', language: 'js', magicComments: defaultMagicComments},
+        {
+          metastring: '',
+          language: 'js',
+          magicComments: defaultMagicComments,
+        },
       ),
     ).toMatchSnapshot();
     expect(
@@ -169,7 +191,11 @@ bbbbbbb
 // highlight-next-line
 // highlight-end
 bbbbb`,
-        {metastring: '', language: 'js', magicComments: defaultMagicComments},
+        {
+          metastring: '',
+          language: 'js',
+          magicComments: defaultMagicComments,
+        },
       ),
     ).toMatchSnapshot();
   });
@@ -179,7 +205,11 @@ bbbbb`,
         `# highlight-next-line
 aaaaa
 bbbbb`,
-        {metastring: '', language: 'js', magicComments: defaultMagicComments},
+        {
+          metastring: '',
+          language: 'js',
+          magicComments: defaultMagicComments,
+        },
       ),
     ).toMatchSnapshot('js');
     expect(
@@ -187,7 +217,11 @@ bbbbb`,
         `/* highlight-next-line */
 aaaaa
 bbbbb`,
-        {metastring: '', language: 'py', magicComments: defaultMagicComments},
+        {
+          metastring: '',
+          language: 'py',
+          magicComments: defaultMagicComments,
+        },
       ),
     ).toMatchSnapshot('py');
     expect(
@@ -200,7 +234,11 @@ bbbbb
 ccccc
 <!-- highlight-next-line -->
 dddd`,
-        {metastring: '', language: 'py', magicComments: defaultMagicComments},
+        {
+          metastring: '',
+          language: 'py',
+          magicComments: defaultMagicComments,
+        },
       ),
     ).toMatchSnapshot('py');
     expect(
@@ -213,7 +251,11 @@ bbbbb
 ccccc
 <!-- highlight-next-line -->
 dddd`,
-        {metastring: '', language: '', magicComments: defaultMagicComments},
+        {
+          metastring: '',
+          language: '',
+          magicComments: defaultMagicComments,
+        },
       ),
     ).toMatchSnapshot('none');
     expect(
@@ -224,7 +266,11 @@ aaaa
 bbbbb
 <!-- highlight-next-line -->
 dddd`,
-        {metastring: '', language: 'jsx', magicComments: defaultMagicComments},
+        {
+          metastring: '',
+          language: 'jsx',
+          magicComments: defaultMagicComments,
+        },
       ),
     ).toMatchSnapshot('jsx');
     expect(
@@ -235,7 +281,11 @@ aaaa
 bbbbb
 <!-- highlight-next-line -->
 dddd`,
-        {metastring: '', language: 'html', magicComments: defaultMagicComments},
+        {
+          metastring: '',
+          language: 'html',
+          magicComments: defaultMagicComments,
+        },
       ),
     ).toMatchSnapshot('html');
     expect(
@@ -261,7 +311,11 @@ dddd
 console.log("preserved");
 \`\`\`
 `,
-        {metastring: '', language: 'md', magicComments: defaultMagicComments},
+        {
+          metastring: '',
+          language: 'md',
+          magicComments: defaultMagicComments,
+        },
       ),
     ).toMatchSnapshot('md');
   });
@@ -373,24 +427,26 @@ describe('getLineNumbersStart', () => {
     expect(
       getLineNumbersStart({
         showLineNumbers: undefined,
-        metastring: undefined,
+        metaOptions: {},
       }),
     ).toMatchSnapshot();
     expect(
       getLineNumbersStart({
         showLineNumbers: undefined,
-        metastring: '',
+        metaOptions: {},
       }),
     ).toMatchSnapshot();
   });
 
   describe('handles prop', () => {
-    describe('combined with metastring', () => {
+    describe('combined with metaoptions', () => {
       it('set to true', () => {
         expect(
           getLineNumbersStart({
             showLineNumbers: true,
-            metastring: 'showLineNumbers=2',
+            metaOptions: {
+              showLineNumbers: 2,
+            },
           }),
         ).toMatchSnapshot();
       });
@@ -399,7 +455,9 @@ describe('getLineNumbersStart', () => {
         expect(
           getLineNumbersStart({
             showLineNumbers: false,
-            metastring: 'showLineNumbers=2',
+            metaOptions: {
+              showLineNumbers: 2,
+            },
           }),
         ).toMatchSnapshot();
       });
@@ -408,7 +466,9 @@ describe('getLineNumbersStart', () => {
         expect(
           getLineNumbersStart({
             showLineNumbers: 10,
-            metastring: 'showLineNumbers=2',
+            metaOptions: {
+              showLineNumbers: 2,
+            },
           }),
         ).toMatchSnapshot();
       });
@@ -419,7 +479,9 @@ describe('getLineNumbersStart', () => {
         expect(
           getLineNumbersStart({
             showLineNumbers: true,
-            metastring: undefined,
+            metaOptions: {
+              showLineNumbers: 2,
+            },
           }),
         ).toMatchSnapshot();
       });
@@ -428,7 +490,9 @@ describe('getLineNumbersStart', () => {
         expect(
           getLineNumbersStart({
             showLineNumbers: false,
-            metastring: undefined,
+            metaOptions: {
+              showLineNumbers: 2,
+            },
           }),
         ).toMatchSnapshot();
       });
@@ -437,7 +501,9 @@ describe('getLineNumbersStart', () => {
         expect(
           getLineNumbersStart({
             showLineNumbers: 10,
-            metastring: undefined,
+            metaOptions: {
+              showLineNumbers: 2,
+            },
           }),
         ).toMatchSnapshot();
       });
@@ -450,7 +516,9 @@ describe('getLineNumbersStart', () => {
         expect(
           getLineNumbersStart({
             showLineNumbers: undefined,
-            metastring: 'showLineNumbers',
+            metaOptions: {
+              showLineNumbers: true,
+            },
           }),
         ).toMatchSnapshot();
       });
@@ -458,7 +526,9 @@ describe('getLineNumbersStart', () => {
         expect(
           getLineNumbersStart({
             showLineNumbers: undefined,
-            metastring: 'showLineNumbers=10',
+            metaOptions: {
+              showLineNumbers: 10,
+            },
           }),
         ).toMatchSnapshot();
       });
@@ -469,7 +539,11 @@ describe('getLineNumbersStart', () => {
         expect(
           getLineNumbersStart({
             showLineNumbers: undefined,
-            metastring: '{1,2-3}  title="file.txt" showLineNumbers noInline',
+            metaOptions: {
+              title: 'file.txt',
+              showLineNumbers: true,
+              noInline: true,
+            },
           }),
         ).toMatchSnapshot();
       });
@@ -477,7 +551,11 @@ describe('getLineNumbersStart', () => {
         expect(
           getLineNumbersStart({
             showLineNumbers: undefined,
-            metastring: '{1,2-3}  title="file.txt" showLineNumbers=10 noInline',
+            metaOptions: {
+              title: 'file.txt',
+              showLineNumbers: 10,
+              noInline: true,
+            },
           }),
         ).toMatchSnapshot();
       });

--- a/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
@@ -8,57 +8,71 @@
 import {
   getLineNumbersStart,
   type MagicCommentConfig,
-  parseCodeBlockTitle,
+  getCodeBlockTitle,
   parseLanguage,
   parseLines,
+  parseCodeBlockMetaOptions,
 } from '../codeBlockUtils';
 
-describe('parseCodeBlockTitle', () => {
-  it('parses double quote delimited title', () => {
-    expect(parseCodeBlockTitle(`title="index.js"`)).toBe(`index.js`);
-  });
+const defaultMagicComments: MagicCommentConfig[] = [
+  {
+    className: 'theme-code-block-highlighted-line',
+    line: 'highlight-next-line',
+    block: {start: 'highlight-start', end: 'highlight-end'},
+  },
+];
 
-  it('parses single quote delimited title', () => {
-    expect(parseCodeBlockTitle(`title='index.js'`)).toBe(`index.js`);
-  });
+describe('parseCodeBlockMetaOptions', () => {
+  describe('title', () => {
+    it('parses double quote delimited title', () => {
+      expect(parseCodeBlockMetaOptions(`title="index.js"`).title).toBe(
+        `index.js`,
+      );
+    });
 
-  it('does not parse mismatched quote delimiters', () => {
-    expect(parseCodeBlockTitle(`title="index.js'`)).toBe(``);
-  });
+    it('parses single quote delimited title', () => {
+      expect(parseCodeBlockMetaOptions(`title='index.js'`).title).toBe(
+        `index.js`,
+      );
+    });
 
-  it('parses undefined metastring', () => {
-    expect(parseCodeBlockTitle(undefined)).toBe(``);
-  });
+    it('does not parse mismatched quote delimiters', () => {
+      expect(parseCodeBlockMetaOptions(`title="index.js'`).title).toBe(``);
+    });
 
-  it('parses metastring with no title specified', () => {
-    expect(parseCodeBlockTitle(`{1,2-3}`)).toBe(``);
-  });
+    it('parses undefined metastring', () => {
+      expect(parseCodeBlockMetaOptions(undefined).title).toBe(``);
+    });
 
-  it('parses with multiple metadata title first', () => {
-    expect(parseCodeBlockTitle(`title="index.js" label="JavaScript"`)).toBe(
-      `index.js`,
-    );
-  });
+    it('parses metastring with no title specified', () => {
+      expect(parseCodeBlockMetaOptions(`{1,2-3}`).title).toBe(``);
+    });
 
-  it('parses with multiple metadata title last', () => {
-    expect(parseCodeBlockTitle(`label="JavaScript" title="index.js"`)).toBe(
-      `index.js`,
-    );
-  });
+    it('parses with multiple metadata title first', () => {
+      expect(
+        parseCodeBlockMetaOptions(`title="index.js" label="JavaScript"`).title,
+      ).toBe(`index.js`);
+    });
 
-  it('parses double quotes when delimited by single quotes', () => {
-    expect(parseCodeBlockTitle(`title='console.log("Hello, World!")'`)).toBe(
-      `console.log("Hello, World!")`,
-    );
-  });
+    it('parses with multiple metadata title last', () => {
+      expect(
+        parseCodeBlockMetaOptions(`label="JavaScript" title="index.js"`).title,
+      ).toBe(`index.js`);
+    });
 
-  it('parses single quotes when delimited by double quotes', () => {
-    expect(parseCodeBlockTitle(`title="console.log('Hello, World!')"`)).toBe(
-      `console.log('Hello, World!')`,
-    );
+    it('parses double quotes when delimited by single quotes', () => {
+      expect(
+        parseCodeBlockMetaOptions(`title='console.log("Hello, World!")'`).title,
+      ).toBe(`console.log("Hello, World!")`);
+    });
+
+    it('parses single quotes when delimited by double quotes', () => {
+      expect(
+        parseCodeBlockMetaOptions(`title="console.log('Hello, World!')"`).title,
+      ).toBe(`console.log('Hello, World!')`);
+    });
   });
 });
-
 describe('parseLanguage', () => {
   it('works', () => {
     expect(parseLanguage('language-foo xxx yyy')).toBe('foo');
@@ -69,14 +83,6 @@ describe('parseLanguage', () => {
 });
 
 describe('parseLines', () => {
-  const defaultMagicComments: MagicCommentConfig[] = [
-    {
-      className: 'theme-code-block-highlighted-line',
-      line: 'highlight-next-line',
-      block: {start: 'highlight-start', end: 'highlight-end'},
-    },
-  ];
-
   it('does not parse content with metastring', () => {
     expect(
       parseLines('aaaaa\nnnnnn', {
@@ -475,6 +481,71 @@ describe('getLineNumbersStart', () => {
           }),
         ).toMatchSnapshot();
       });
+    });
+  });
+});
+
+describe('getCodeBlockTitle', () => {
+  it('with nothing set', () => {
+    expect(
+      getCodeBlockTitle({
+        titleProp: undefined,
+        metaOptions: {},
+      }),
+    ).toMatchSnapshot();
+  });
+
+  describe('returns titleProp', () => {
+    it('with empty options', () => {
+      expect(
+        getCodeBlockTitle({
+          titleProp: 'Prop',
+          metaOptions: {},
+        }),
+      ).toMatchSnapshot();
+    });
+    it('with empty string on option', () => {
+      expect(
+        getCodeBlockTitle({
+          titleProp: 'Prop',
+          metaOptions: {
+            title: '',
+          },
+        }),
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('returns option', () => {
+    it('with undefined prop', () => {
+      expect(
+        getCodeBlockTitle({
+          titleProp: undefined,
+          metaOptions: {
+            title: 'Option',
+          },
+        }),
+      ).toMatchSnapshot();
+    });
+    it('with empty prop', () => {
+      expect(
+        getCodeBlockTitle({
+          titleProp: '',
+          metaOptions: {
+            title: 'Option',
+          },
+        }),
+      ).toMatchSnapshot();
+    });
+    it('with filled prop', () => {
+      expect(
+        getCodeBlockTitle({
+          titleProp: 'Prop',
+          metaOptions: {
+            title: 'Option',
+          },
+        }),
+      ).toMatchSnapshot();
     });
   });
 });

--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
@@ -371,7 +371,7 @@ export function parseCodeBlockMetaOptions(
 
   // interactive code editor (theme-live-codeblock => Playground)
   parsedOptions.live = metastring?.split(' ').includes('live');
-  // parsedOptions.noInline = TODO;
+  parsedOptions.noInline = metastring?.includes('noInline');
 
   return parsedOptions;
 }

--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
@@ -147,7 +147,7 @@ function getAllMagicCommentDirectiveStyles(
   }
 }
 
-export function parseCodeBlockTitle(metastring?: string): string {
+function parseCodeBlockTitle(metastring?: string): string {
   return metastring?.match(codeBlockTitleRegex)?.groups!.title ?? '';
 }
 
@@ -165,6 +165,33 @@ function getMetaLineNumbersStart(metastring?: string): number | undefined {
   }
 
   return undefined;
+}
+
+/**
+ * The supported types for {@link CodeBlockMetaOptions} values.
+ */
+export type CodeMetaOptionValue = string | number | boolean | undefined;
+
+/**
+ * A property bag for custom options specified by the user via metastring
+ * to control aspects like title and line numbers.
+ */
+export type CodeBlockMetaOptions = {
+  [key: string]: CodeMetaOptionValue;
+};
+
+export function getCodeBlockTitle({
+  titleProp,
+  metaOptions,
+}: {
+  titleProp: React.ReactNode;
+  metaOptions: CodeBlockMetaOptions;
+}): React.ReactNode {
+  // NOTE: historically the metastring option overruled
+  // any `title=""` prop specified on `<CodeBlock />`
+  // this is the reversed logic to getLineNumbersStart
+  // but would be a breaking change so we keep it.
+  return metaOptions.title || titleProp;
 }
 
 export function getLineNumbersStart({
@@ -316,6 +343,26 @@ export function parseLines(
     });
   });
   return {lineClassNames, code};
+}
+
+/**
+ * Parses {@link CodeBlockParsedLines.metaOptions} from the given metastring.
+ * @param metastring The metastring to parse
+ * @returns The parsed options.
+ */
+export function parseCodeBlockMetaOptions(
+  metastring: string | undefined,
+): CodeBlockMetaOptions {
+  const parsedOptions: CodeBlockMetaOptions = {};
+
+  parsedOptions.title = parseCodeBlockTitle(metastring);
+
+  // parsedOptions.live = TODO;
+  // parsedOptions.noInline = TODO;
+
+  // parsedOptions.showLineNumbers = TODO;
+
+  return parsedOptions;
 }
 
 export function getPrismCssVariables(prismTheme: PrismTheme): CSSProperties {

--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
@@ -196,19 +196,22 @@ export function getCodeBlockTitle({
 
 export function getLineNumbersStart({
   showLineNumbers,
-  metastring,
+  metaOptions,
 }: {
   showLineNumbers: boolean | number | undefined;
-  metastring: string | undefined;
+  metaOptions: CodeBlockMetaOptions;
 }): number | undefined {
+  const showLineNumbersValue = showLineNumbers ?? metaOptions.showLineNumbers;
+
   const defaultStart = 1;
-  if (typeof showLineNumbers === 'boolean') {
-    return showLineNumbers ? defaultStart : undefined;
+  if (typeof showLineNumbersValue === 'boolean') {
+    return showLineNumbersValue ? defaultStart : undefined;
   }
-  if (typeof showLineNumbers === 'number') {
-    return showLineNumbers;
+  if (typeof showLineNumbersValue === 'number') {
+    return showLineNumbersValue;
   }
-  return getMetaLineNumbersStart(metastring);
+
+  return undefined;
 }
 
 /**
@@ -367,7 +370,7 @@ export function parseCodeBlockMetaOptions(
 
   // normal codeblock
   parsedOptions.title = parseCodeBlockTitle(metastring);
-  // parsedOptions.showLineNumbers = TODO;
+  parsedOptions.showLineNumbers = getMetaLineNumbersStart(metastring);
 
   // interactive code editor (theme-live-codeblock => Playground)
   parsedOptions.live = metastring?.split(' ').includes('live');

--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
@@ -147,10 +147,6 @@ function getAllMagicCommentDirectiveStyles(
   }
 }
 
-function parseCodeBlockTitle(metastring?: string): string {
-  return metastring?.match(codeBlockTitleRegex)?.groups!.title ?? '';
-}
-
 function getMetaLineNumbersStart(metastring?: string): number | undefined {
   const showLineNumbersMeta = metastring
     ?.split(' ')
@@ -369,12 +365,23 @@ export function parseCodeBlockMetaOptions(
   // we keep the old custom logic which was moved from their old spots to here.
 
   // normal codeblock
-  parsedOptions.title = parseCodeBlockTitle(metastring);
-  parsedOptions.showLineNumbers = getMetaLineNumbersStart(metastring);
+  const title = metastring?.match(codeBlockTitleRegex)?.groups!.title;
+  if (title !== undefined) {
+    parsedOptions.title = title;
+  }
+  const showLineNumbers = getMetaLineNumbersStart(metastring);
+  if (showLineNumbers !== undefined) {
+    parsedOptions.showLineNumbers = showLineNumbers;
+  }
 
   // interactive code editor (theme-live-codeblock => Playground)
-  parsedOptions.live = metastring?.split(' ').includes('live');
-  parsedOptions.noInline = metastring?.includes('noInline');
+  if (metastring?.split(' ').includes('live')) {
+    parsedOptions.live = true;
+  }
+
+  if (metastring?.includes('noInline')) {
+    parsedOptions.noInline = true;
+  }
 
   return parsedOptions;
 }

--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
@@ -348,19 +348,30 @@ export function parseLines(
 /**
  * Parses {@link CodeBlockParsedLines.metaOptions} from the given metastring.
  * @param metastring The metastring to parse
+ * @param metaOptionsProp any meta options defined via component props.
  * @returns The parsed options.
  */
 export function parseCodeBlockMetaOptions(
   metastring: string | undefined,
+  metaOptionsProp: CodeBlockMetaOptions | undefined,
 ): CodeBlockMetaOptions {
+  // If we already have options via props use them as they are
+  if (metaOptionsProp) {
+    return metaOptionsProp;
+  }
+
   const parsedOptions: CodeBlockMetaOptions = {};
 
+  // NOTE: until we parse generally all options contained in this string
+  // we keep the old custom logic which was moved from their old spots to here.
+
+  // normal codeblock
   parsedOptions.title = parseCodeBlockTitle(metastring);
-
-  // parsedOptions.live = TODO;
-  // parsedOptions.noInline = TODO;
-
   // parsedOptions.showLineNumbers = TODO;
+
+  // interactive code editor (theme-live-codeblock => Playground)
+  parsedOptions.live = metastring?.split(' ').includes('live');
+  // parsedOptions.noInline = TODO;
 
   return parsedOptions;
 }

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.tsx
@@ -6,17 +6,30 @@
  */
 
 import React from 'react';
+import {parseCodeBlockMetaOptions} from '@docusaurus/theme-common/internal';
 import Playground from '@theme/Playground';
 import ReactLiveScope from '@theme/ReactLiveScope';
 import CodeBlock, {type Props} from '@theme-init/CodeBlock';
 
 const withLiveEditor = (Component: typeof CodeBlock) => {
   function WrappedComponent(props: Props) {
-    if (props.live) {
-      return <Playground scope={ReactLiveScope} {...props} />;
+    const metaOptions = parseCodeBlockMetaOptions(
+      props.metastring,
+      props.metaOptions,
+    );
+
+    const live = props.live ?? metaOptions.live;
+    if (live) {
+      return (
+        <Playground
+          scope={ReactLiveScope}
+          metaOptions={metaOptions}
+          {...props}
+        />
+      );
     }
 
-    return <Component {...props} />;
+    return <Component metaOptions={metaOptions} {...props} />;
   }
 
   return WrappedComponent;

--- a/packages/docusaurus-theme-live-codeblock/src/theme/Playground/index.tsx
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/Playground/index.tsx
@@ -16,6 +16,7 @@ import {
   ErrorBoundaryErrorMessageFallback,
   usePrismTheme,
 } from '@docusaurus/theme-common';
+import {parseCodeBlockMetaOptions} from '@docusaurus/theme-common/internal';
 import ErrorBoundary from '@docusaurus/ErrorBoundary';
 
 import type {Props} from '@theme/Playground';
@@ -105,6 +106,8 @@ const DEFAULT_TRANSFORM_CODE = (code: string) => `${code};`;
 export default function Playground({
   children,
   transformCode,
+  metastring,
+  metaOptions: metaOptionsProp,
   ...props
 }: Props): ReactNode {
   const {
@@ -115,7 +118,8 @@ export default function Playground({
   } = themeConfig as ThemeConfig;
   const prismTheme = usePrismTheme();
 
-  const noInline = props.metastring?.includes('noInline') ?? false;
+  const metaOptions = parseCodeBlockMetaOptions(metastring, metaOptionsProp);
+  const noInline = !!metaOptions.noInline;
 
   return (
     <div className={styles.playgroundContainer}>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

This PR is part of a series related to #11008 and it superceeds https://github.com/facebook/docusaurus/pull/11011 in the goal to splitup the work into more isolated refactoring/feature parts. 

Note that this PR also includes the changes of previous steps and therefore the overall diff can be misleading. The best approach will be to review and merge every step individually and then rebase accordingly. 

Intermediately the specific changes can be checked here: https://github.com/Danielku15/docusaurus/compare/feature/codeblock-meta...Danielku15:docusaurus:feature/codeblock-meta-2

Step 1 (#11017): Splitup current parseLines logic (separation of concerns) 
Step 2 (this PR): Parse metastring into metaOptions and use it across components.
Step 3 (#11021): Add parsing of any options specified in the metastring.
Step 4 (#11022): Add CodeBlockToken component to customize DOM of highlighted tokens. 
Step 5 (#11023): Pass `metaOptions` to whole codeblock component tree.

The motivation of this part is to centralize the `metastring` parsing across components to a central location without changing the parsing logic itself. 

To achieve the central parsing a new `metaOptions` is introduced and the old inline logic is adapted everywhere.

Due to the way the live code editor works the `metaOptions` is introduced as component prop. This way we can parse it once and pass it through. The possible overlap between prop<->metaOptions is the same like prop<->metastring before. 

We could split this PR further but I think it makes sense to update all components to use `metaOptions` in one go. The refactoring per component of clearly visible in individual commits. 

## Test Plan

Automatic testing relies on existing integration tests. 

Manual testing by checking `/docs/markdown-features/code-blocks` showed no impact of the change. 

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-11019--docusaurus-2.netlify.app
Code Blocks: https://deploy-preview-11019--docusaurus-2.netlify.app/docs/markdown-features/code-blocks/

## Related issues/PRs

* https://github.com/facebook/docusaurus/pull/11011
* #11008