### PR TITLE
feat(theme-classic): Pass metaOptions to whole codeblock component tree.

### DIFF
--- a/packages/docusaurus-mdx-loader/src/remark/mdx1Compat/codeCompatPlugin.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/mdx1Compat/codeCompatPlugin.ts
@@ -24,10 +24,6 @@ const plugin: Plugin<unknown[], Root> = function plugin(): Transformer<Root> {
 
       node.data.hProperties = node.data.hProperties || {};
       node.data.hProperties.metastring = node.meta;
-
-      // Retrocompatible support for live codeblock metastring
-      // Not really the appropriate place to handle that :s
-      node.data.hProperties.live = node.meta?.split(' ').includes('live');
     });
   };
 };

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -405,6 +405,7 @@ declare module '@theme/BlogLayout' {
 
 declare module '@theme/CodeBlock' {
   import type {ReactNode} from 'react';
+  import type {CodeBlockMetaOptions} from '@docusaurus/theme-common/internal';
 
   export interface Props {
     readonly children: ReactNode;
@@ -413,6 +414,7 @@ declare module '@theme/CodeBlock' {
     readonly title?: ReactNode;
     readonly language?: string;
     readonly showLineNumbers?: boolean | number;
+    readonly metaOptions?: CodeBlockMetaOptions;
   }
 
   export default function CodeBlock(props: Props): ReactNode;

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -471,6 +471,7 @@ declare module '@theme/CodeBlock/Content/String' {
 
 declare module '@theme/CodeBlock/Line' {
   import type {ReactNode} from 'react';
+  import type {CodeBlockMetaOptions} from '@docusaurus/theme-common/internal';
   import type {
     LineInputProps,
     LineOutputProps,
@@ -483,6 +484,7 @@ declare module '@theme/CodeBlock/Line' {
     readonly line: Token[];
     readonly classNames: string[] | undefined;
     readonly showLineNumbers: boolean;
+    readonly metaOptions: CodeBlockMetaOptions;
     readonly getLineProps: (input: LineInputProps) => LineOutputProps;
     readonly getTokenProps: (input: TokenInputProps) => TokenOutputProps;
   }

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -502,6 +502,18 @@ declare module '@theme/CodeBlock/WordWrapButton' {
   export default function WordWrapButton(props: Props): ReactNode;
 }
 
+declare module '@theme/CodeBlock/Token' {
+  import type {ReactNode} from 'react';
+  import type {Props as LineProps} from '@theme/CodeBlock/Line';
+  import type {TokenOutputProps} from 'prism-react-renderer';
+
+  export interface Props extends TokenOutputProps {
+    line: LineProps;
+  }
+
+  export default function CodeBlockToken(props: Props): ReactNode;
+}
+
 declare module '@theme/DocCard' {
   import type {ReactNode} from 'react';
   import type {PropSidebarItem} from '@docusaurus/plugin-content-docs';

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
@@ -110,6 +110,7 @@ export default function CodeBlockString({
                   <Line
                     key={i}
                     line={line}
+                    metaOptions={metaOptions}
                     getLineProps={getLineProps}
                     getTokenProps={getTokenProps}
                     classNames={lineClassNames[i]}

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
@@ -70,7 +70,7 @@ export default function CodeBlockString({
   });
   const lineNumbersStart = getLineNumbersStart({
     showLineNumbers: showLineNumbersProp,
-    metastring,
+    metaOptions,
   });
 
   return (

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
@@ -9,9 +9,10 @@ import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {useThemeConfig, usePrismTheme} from '@docusaurus/theme-common';
 import {
-  parseCodeBlockTitle,
+  parseCodeBlockMetaOptions,
   parseLanguage,
   parseLines,
+  getCodeBlockTitle,
   getLineNumbersStart,
   useCodeWordWrap,
 } from '@docusaurus/theme-common/internal';
@@ -51,10 +52,15 @@ export default function CodeBlockString({
   const wordWrap = useCodeWordWrap();
   const isBrowser = useIsBrowser();
 
+  const metaOptions = parseCodeBlockMetaOptions(metastring);
+
   // We still parse the metastring in case we want to support more syntax in the
   // future. Note that MDX doesn't strip quotes when parsing metastring:
   // "title=\"xyz\"" => title: "\"xyz\""
-  const title = parseCodeBlockTitle(metastring) || titleProp;
+  const title = getCodeBlockTitle({
+    titleProp,
+    metaOptions,
+  });
 
   const {lineClassNames, code} = parseLines(children, {
     metastring,

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
@@ -40,6 +40,7 @@ export default function CodeBlockString({
   title: titleProp,
   showLineNumbers: showLineNumbersProp,
   language: languageProp,
+  metaOptions: metaOptionsProp,
 }: Props): ReactNode {
   const {
     prism: {defaultLanguage, magicComments},
@@ -52,7 +53,7 @@ export default function CodeBlockString({
   const wordWrap = useCodeWordWrap();
   const isBrowser = useIsBrowser();
 
-  const metaOptions = parseCodeBlockMetaOptions(metastring);
+  const metaOptions = parseCodeBlockMetaOptions(metastring, metaOptionsProp);
 
   // We still parse the metastring in case we want to support more syntax in the
   // future. Note that MDX doesn't strip quotes when parsing metastring:

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Line/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Line/index.tsx
@@ -8,6 +8,7 @@
 import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import type {Props} from '@theme/CodeBlock/Line';
+import CodeBlockToken from '@theme/CodeBlock/Token';
 
 import styles from './styles.module.css';
 
@@ -26,13 +27,14 @@ function fixLineBreak(line: Token[]) {
   return line;
 }
 
-export default function CodeBlockLine({
-  line: lineProp,
-  classNames,
-  showLineNumbers,
-  getLineProps,
-  getTokenProps,
-}: Props): ReactNode {
+export default function CodeBlockLine(props: Props): ReactNode {
+  const {
+    line: lineProp,
+    classNames,
+    showLineNumbers,
+    getLineProps,
+    getTokenProps,
+  } = props;
   const line = fixLineBreak(lineProp);
 
   const lineProps = getLineProps({
@@ -41,7 +43,7 @@ export default function CodeBlockLine({
   });
 
   const lineTokens = line.map((token, key) => (
-    <span key={key} {...getTokenProps({token})} />
+    <CodeBlockToken key={key} line={props} {...getTokenProps({token})} />
   ));
 
   return (

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Token/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Token/index.tsx
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {type ReactNode} from 'react';
+import type {Props} from '@theme/CodeBlock/Token';
+
+export default function CodeBlockToken(props: Props): ReactNode {
+  // We omit the "line" information in the default rendering,
+  // but its meant for devs who devs who Swizzle this component.
+  const {line, ...tokenProps} = props;
+  return <span {...tokenProps} />;
+}

--- a/packages/docusaurus-theme-common/src/internal.ts
+++ b/packages/docusaurus-theme-common/src/internal.ts
@@ -34,9 +34,10 @@ export {ColorModeProvider} from './contexts/colorMode';
 export {useAlternatePageUtils} from './utils/useAlternatePageUtils';
 
 export {
-  parseCodeBlockTitle,
+  parseCodeBlockMetaOptions,
   parseLanguage,
   parseLines,
+  getCodeBlockTitle,
   getLineNumbersStart,
 } from './utils/codeBlockUtils';
 

--- a/packages/docusaurus-theme-common/src/internal.ts
+++ b/packages/docusaurus-theme-common/src/internal.ts
@@ -39,6 +39,7 @@ export {
   parseLines,
   getCodeBlockTitle,
   getLineNumbersStart,
+  type CodeBlockMetaOptions,
 } from './utils/codeBlockUtils';
 
 export {DEFAULT_SEARCH_TAG} from './utils/searchUtils';

--- a/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`getLineNumbersStart handles metadata combined with other options set as flag 1`] = `1`;
+
+exports[`getLineNumbersStart handles metadata combined with other options set with number 1`] = `10`;
+
+exports[`getLineNumbersStart handles metadata standalone set as flag 1`] = `1`;
+
+exports[`getLineNumbersStart handles metadata standalone set with number 1`] = `10`;
+
+exports[`getLineNumbersStart handles prop combined with metastring set to false 1`] = `undefined`;
+
+exports[`getLineNumbersStart handles prop combined with metastring set to number 1`] = `10`;
+
+exports[`getLineNumbersStart handles prop combined with metastring set to true 1`] = `1`;
+
+exports[`getLineNumbersStart handles prop standalone set to false 1`] = `undefined`;
+
+exports[`getLineNumbersStart handles prop standalone set to number 1`] = `10`;
+
+exports[`getLineNumbersStart handles prop standalone set to true 1`] = `1`;
+
+exports[`getLineNumbersStart with nothing set 1`] = `undefined`;
+
+exports[`getLineNumbersStart with nothing set 2`] = `undefined`;
+
 exports[`parseLines does not parse content with metastring 1`] = `
 {
   "code": "aaaaa

--- a/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
@@ -12,6 +12,10 @@ exports[`getCodeBlockTitle returns titleProp with empty string on option 1`] = `
 
 exports[`getCodeBlockTitle with nothing set 1`] = `undefined`;
 
+exports[`getLineNumbersStart from metastring parses flags as 1 1`] = `1`;
+
+exports[`getLineNumbersStart from metastring parses value 1`] = `10`;
+
 exports[`getLineNumbersStart handles metadata combined with other options set as flag 1`] = `1`;
 
 exports[`getLineNumbersStart handles metadata combined with other options set with number 1`] = `10`;
@@ -35,6 +39,30 @@ exports[`getLineNumbersStart handles prop standalone set to true 1`] = `1`;
 exports[`getLineNumbersStart with nothing set 1`] = `undefined`;
 
 exports[`getLineNumbersStart with nothing set 2`] = `undefined`;
+
+exports[`getLineNumbersStart with parsed metaoption handles metadata combined with other options set as flag 1`] = `1`;
+
+exports[`getLineNumbersStart with parsed metaoption handles metadata combined with other options set with number 1`] = `10`;
+
+exports[`getLineNumbersStart with parsed metaoption handles metadata standalone set as flag 1`] = `1`;
+
+exports[`getLineNumbersStart with parsed metaoption handles metadata standalone set with number 1`] = `10`;
+
+exports[`getLineNumbersStart with parsed metaoption handles prop combined with metaoptions set to false 1`] = `undefined`;
+
+exports[`getLineNumbersStart with parsed metaoption handles prop combined with metaoptions set to number 1`] = `10`;
+
+exports[`getLineNumbersStart with parsed metaoption handles prop combined with metaoptions set to true 1`] = `1`;
+
+exports[`getLineNumbersStart with parsed metaoption handles prop standalone set to false 1`] = `undefined`;
+
+exports[`getLineNumbersStart with parsed metaoption handles prop standalone set to number 1`] = `10`;
+
+exports[`getLineNumbersStart with parsed metaoption handles prop standalone set to true 1`] = `1`;
+
+exports[`getLineNumbersStart with parsed metaoption with nothing set 1`] = `undefined`;
+
+exports[`getLineNumbersStart with parsed metaoption with nothing set 2`] = `undefined`;
 
 exports[`parseLines does not parse content with metastring 1`] = `
 {

--- a/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
@@ -64,6 +64,86 @@ exports[`getLineNumbersStart with parsed metaoption with nothing set 1`] = `unde
 
 exports[`getLineNumbersStart with parsed metaoption with nothing set 2`] = `undefined`;
 
+exports[`parseCodeBlockMetaOptions any option double quotes as string 1`] = `
+{
+  "PascalCase": "Hello'Docusaurus Options",
+  "UPPER_CASE": "Hello'Docusaurus Options",
+  "camelCase": "Hello'Docusaurus Options",
+  "kebab-case": "Hello'Docusaurus Options",
+  "lowercase": "Hello'Docusaurus Options",
+}
+`;
+
+exports[`parseCodeBlockMetaOptions any option false 1`] = `
+{
+  "PascalCase": false,
+  "UPPER_CASE": false,
+  "camelCase": false,
+  "kebab-case": false,
+  "lowercase": false,
+}
+`;
+
+exports[`parseCodeBlockMetaOptions any option flag as true 1`] = `
+{
+  "PascalCase": true,
+  "UPPER_CASE": true,
+  "camelCase": true,
+  "kebab-case": true,
+  "lowercase": true,
+}
+`;
+
+exports[`parseCodeBlockMetaOptions any option float numbers 1`] = `
+{
+  "PascalCase": 3.3,
+  "UPPER_CASE": 4.4,
+  "camelCase": 2.2,
+  "kebab-case": 5.5,
+  "lowercase": 1.1,
+}
+`;
+
+exports[`parseCodeBlockMetaOptions any option integer numbers 1`] = `
+{
+  "PascalCase": 3,
+  "UPPER_CASE": 4,
+  "camelCase": 2,
+  "kebab-case": 5,
+  "lowercase": 1,
+}
+`;
+
+exports[`parseCodeBlockMetaOptions any option non quoted value as string 1`] = `
+{
+  "PascalCase": "simple",
+  "UPPER_CASE": "simple",
+  "camelCase": "simple",
+  "kebab-case": "simple",
+  "lowercase": "simple",
+}
+`;
+
+exports[`parseCodeBlockMetaOptions any option single quotes as string 1`] = `
+{
+  "PascalCase": "Hello"Docusaurus Options",
+  "UPPER_CASE": "Hello"Docusaurus Options",
+  "camelCase": "Hello"Docusaurus Options",
+  "kebab-case": "Hello"Docusaurus Options",
+  "lowercase": "Hello"Docusaurus Options",
+}
+`;
+
+exports[`parseCodeBlockMetaOptions any option true 1`] = `
+{
+  "PascalCase": true,
+  "UPPER_CASE": true,
+  "camelCase": true,
+  "kebab-case": true,
+  "lowercase": true,
+}
+`;
+
 exports[`parseLines does not parse content with metastring 1`] = `
 {
   "code": "aaaaa

--- a/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`getCodeBlockTitle returns option with empty prop 1`] = `"Option"`;
+
+exports[`getCodeBlockTitle returns option with filled prop 1`] = `"Option"`;
+
+exports[`getCodeBlockTitle returns option with undefined prop 1`] = `"Option"`;
+
+exports[`getCodeBlockTitle returns titleProp with empty options 1`] = `"Prop"`;
+
+exports[`getCodeBlockTitle returns titleProp with empty string on option 1`] = `"Prop"`;
+
+exports[`getCodeBlockTitle with nothing set 1`] = `undefined`;
+
 exports[`getLineNumbersStart handles metadata combined with other options set as flag 1`] = `1`;
 
 exports[`getLineNumbersStart handles metadata combined with other options set with number 1`] = `10`;

--- a/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
@@ -20,11 +20,11 @@ exports[`getLineNumbersStart handles metadata standalone set as flag 1`] = `1`;
 
 exports[`getLineNumbersStart handles metadata standalone set with number 1`] = `10`;
 
-exports[`getLineNumbersStart handles prop combined with metastring set to false 1`] = `undefined`;
+exports[`getLineNumbersStart handles prop combined with metaoptions set to false 1`] = `undefined`;
 
-exports[`getLineNumbersStart handles prop combined with metastring set to number 1`] = `10`;
+exports[`getLineNumbersStart handles prop combined with metaoptions set to number 1`] = `10`;
 
-exports[`getLineNumbersStart handles prop combined with metastring set to true 1`] = `1`;
+exports[`getLineNumbersStart handles prop combined with metaoptions set to true 1`] = `1`;
 
 exports[`getLineNumbersStart handles prop standalone set to false 1`] = `undefined`;
 

--- a/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  getLineNumbersStart,
   type MagicCommentConfig,
   parseCodeBlockTitle,
   parseLanguage,
@@ -358,5 +359,122 @@ line
         },
       ),
     ).toMatchSnapshot();
+  });
+});
+
+describe('getLineNumbersStart', () => {
+  it('with nothing set', () => {
+    expect(
+      getLineNumbersStart({
+        showLineNumbers: undefined,
+        metastring: undefined,
+      }),
+    ).toMatchSnapshot();
+    expect(
+      getLineNumbersStart({
+        showLineNumbers: undefined,
+        metastring: '',
+      }),
+    ).toMatchSnapshot();
+  });
+
+  describe('handles prop', () => {
+    describe('combined with metastring', () => {
+      it('set to true', () => {
+        expect(
+          getLineNumbersStart({
+            showLineNumbers: true,
+            metastring: 'showLineNumbers=2',
+          }),
+        ).toMatchSnapshot();
+      });
+
+      it('set to false', () => {
+        expect(
+          getLineNumbersStart({
+            showLineNumbers: false,
+            metastring: 'showLineNumbers=2',
+          }),
+        ).toMatchSnapshot();
+      });
+
+      it('set to number', () => {
+        expect(
+          getLineNumbersStart({
+            showLineNumbers: 10,
+            metastring: 'showLineNumbers=2',
+          }),
+        ).toMatchSnapshot();
+      });
+    });
+
+    describe('standalone', () => {
+      it('set to true', () => {
+        expect(
+          getLineNumbersStart({
+            showLineNumbers: true,
+            metastring: undefined,
+          }),
+        ).toMatchSnapshot();
+      });
+
+      it('set to false', () => {
+        expect(
+          getLineNumbersStart({
+            showLineNumbers: false,
+            metastring: undefined,
+          }),
+        ).toMatchSnapshot();
+      });
+
+      it('set to number', () => {
+        expect(
+          getLineNumbersStart({
+            showLineNumbers: 10,
+            metastring: undefined,
+          }),
+        ).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('handles metadata', () => {
+    describe('standalone', () => {
+      it('set as flag', () => {
+        expect(
+          getLineNumbersStart({
+            showLineNumbers: undefined,
+            metastring: 'showLineNumbers',
+          }),
+        ).toMatchSnapshot();
+      });
+      it('set with number', () => {
+        expect(
+          getLineNumbersStart({
+            showLineNumbers: undefined,
+            metastring: 'showLineNumbers=10',
+          }),
+        ).toMatchSnapshot();
+      });
+    });
+
+    describe('combined with other options', () => {
+      it('set as flag', () => {
+        expect(
+          getLineNumbersStart({
+            showLineNumbers: undefined,
+            metastring: '{1,2-3}  title="file.txt" showLineNumbers noInline',
+          }),
+        ).toMatchSnapshot();
+      });
+      it('set with number', () => {
+        expect(
+          getLineNumbersStart({
+            showLineNumbers: undefined,
+            metastring: '{1,2-3}  title="file.txt" showLineNumbers=10 noInline',
+          }),
+        ).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
@@ -39,15 +39,19 @@ describe('parseCodeBlockMetaOptions', () => {
     it('does not parse mismatched quote delimiters', () => {
       expect(
         parseCodeBlockMetaOptions(`title="index.js'`, undefined).title,
-      ).toBe(``);
+      ).toBeUndefined();
     });
 
     it('parses undefined metastring', () => {
-      expect(parseCodeBlockMetaOptions(undefined, undefined).title).toBe(``);
+      expect(
+        parseCodeBlockMetaOptions(undefined, undefined).title,
+      ).toBeUndefined();
     });
 
     it('parses metastring with no title specified', () => {
-      expect(parseCodeBlockMetaOptions(`{1,2-3}`, undefined).title).toBe(``);
+      expect(
+        parseCodeBlockMetaOptions(`{1,2-3}`, undefined).title,
+      ).toBeUndefined();
     });
 
     it('parses with multiple metadata title first', () => {
@@ -86,7 +90,34 @@ describe('parseCodeBlockMetaOptions', () => {
       ).toBe(`console.log('Hello, World!')`);
     });
   });
+
+  // showLineNumber logic is tested in combination with getLineNumber below
+
+  describe('live', () => {
+    it('parses live as true', () => {
+      expect(parseCodeBlockMetaOptions(`live`, undefined).live).toBe(true);
+    });
+    it('parses no live as undefined', () => {
+      expect(
+        parseCodeBlockMetaOptions(` otherOption `, undefined).live,
+      ).toBeUndefined();
+    });
+  });
+
+  describe('noInline', () => {
+    it('parses noInline as true', () => {
+      expect(parseCodeBlockMetaOptions(`noInline`, undefined).noInline).toBe(
+        true,
+      );
+    });
+    it('parses no noInline as undefined', () => {
+      expect(
+        parseCodeBlockMetaOptions(` otherOption `, undefined).noInline,
+      ).toBeUndefined();
+    });
+  });
 });
+
 describe('parseLanguage', () => {
   it('works', () => {
     expect(parseLanguage('language-foo xxx yyy')).toBe('foo');
@@ -423,142 +454,170 @@ line
 });
 
 describe('getLineNumbersStart', () => {
-  it('with nothing set', () => {
-    expect(
-      getLineNumbersStart({
-        showLineNumbers: undefined,
-        metaOptions: {},
-      }),
-    ).toMatchSnapshot();
-    expect(
-      getLineNumbersStart({
-        showLineNumbers: undefined,
-        metaOptions: {},
-      }),
-    ).toMatchSnapshot();
+  describe('with parsed metaoption', () => {
+    it('with nothing set', () => {
+      expect(
+        getLineNumbersStart({
+          showLineNumbers: undefined,
+          metaOptions: {},
+        }),
+      ).toMatchSnapshot();
+      expect(
+        getLineNumbersStart({
+          showLineNumbers: undefined,
+          metaOptions: {},
+        }),
+      ).toMatchSnapshot();
+    });
+
+    describe('handles prop', () => {
+      describe('combined with metaoptions', () => {
+        it('set to true', () => {
+          expect(
+            getLineNumbersStart({
+              showLineNumbers: true,
+              metaOptions: {
+                showLineNumbers: 2,
+              },
+            }),
+          ).toMatchSnapshot();
+        });
+
+        it('set to false', () => {
+          expect(
+            getLineNumbersStart({
+              showLineNumbers: false,
+              metaOptions: {
+                showLineNumbers: 2,
+              },
+            }),
+          ).toMatchSnapshot();
+        });
+
+        it('set to number', () => {
+          expect(
+            getLineNumbersStart({
+              showLineNumbers: 10,
+              metaOptions: {
+                showLineNumbers: 2,
+              },
+            }),
+          ).toMatchSnapshot();
+        });
+      });
+
+      describe('standalone', () => {
+        it('set to true', () => {
+          expect(
+            getLineNumbersStart({
+              showLineNumbers: true,
+              metaOptions: {
+                showLineNumbers: 2,
+              },
+            }),
+          ).toMatchSnapshot();
+        });
+
+        it('set to false', () => {
+          expect(
+            getLineNumbersStart({
+              showLineNumbers: false,
+              metaOptions: {
+                showLineNumbers: 2,
+              },
+            }),
+          ).toMatchSnapshot();
+        });
+
+        it('set to number', () => {
+          expect(
+            getLineNumbersStart({
+              showLineNumbers: 10,
+              metaOptions: {
+                showLineNumbers: 2,
+              },
+            }),
+          ).toMatchSnapshot();
+        });
+      });
+    });
+
+    describe('handles metadata', () => {
+      describe('standalone', () => {
+        it('set as flag', () => {
+          expect(
+            getLineNumbersStart({
+              showLineNumbers: undefined,
+              metaOptions: {
+                showLineNumbers: true,
+              },
+            }),
+          ).toMatchSnapshot();
+        });
+        it('set with number', () => {
+          expect(
+            getLineNumbersStart({
+              showLineNumbers: undefined,
+              metaOptions: {
+                showLineNumbers: 10,
+              },
+            }),
+          ).toMatchSnapshot();
+        });
+      });
+
+      describe('combined with other options', () => {
+        it('set as flag', () => {
+          expect(
+            getLineNumbersStart({
+              showLineNumbers: undefined,
+              metaOptions: {
+                title: 'file.txt',
+                showLineNumbers: true,
+                noInline: true,
+              },
+            }),
+          ).toMatchSnapshot();
+        });
+        it('set with number', () => {
+          expect(
+            getLineNumbersStart({
+              showLineNumbers: undefined,
+              metaOptions: {
+                title: 'file.txt',
+                showLineNumbers: 10,
+                noInline: true,
+              },
+            }),
+          ).toMatchSnapshot();
+        });
+      });
+    });
   });
 
-  describe('handles prop', () => {
-    describe('combined with metaoptions', () => {
-      it('set to true', () => {
-        expect(
-          getLineNumbersStart({
-            showLineNumbers: true,
-            metaOptions: {
-              showLineNumbers: 2,
-            },
-          }),
-        ).toMatchSnapshot();
-      });
-
-      it('set to false', () => {
-        expect(
-          getLineNumbersStart({
-            showLineNumbers: false,
-            metaOptions: {
-              showLineNumbers: 2,
-            },
-          }),
-        ).toMatchSnapshot();
-      });
-
-      it('set to number', () => {
-        expect(
-          getLineNumbersStart({
-            showLineNumbers: 10,
-            metaOptions: {
-              showLineNumbers: 2,
-            },
-          }),
-        ).toMatchSnapshot();
-      });
+  describe('from metastring', () => {
+    it('parses flags as 1', () => {
+      expect(
+        getLineNumbersStart({
+          showLineNumbers: undefined,
+          metaOptions: parseCodeBlockMetaOptions(
+            ' showLineNumbers ',
+            undefined,
+          ),
+        }),
+      ).toMatchSnapshot();
     });
 
-    describe('standalone', () => {
-      it('set to true', () => {
-        expect(
-          getLineNumbersStart({
-            showLineNumbers: true,
-            metaOptions: {
-              showLineNumbers: 2,
-            },
-          }),
-        ).toMatchSnapshot();
-      });
-
-      it('set to false', () => {
-        expect(
-          getLineNumbersStart({
-            showLineNumbers: false,
-            metaOptions: {
-              showLineNumbers: 2,
-            },
-          }),
-        ).toMatchSnapshot();
-      });
-
-      it('set to number', () => {
-        expect(
-          getLineNumbersStart({
-            showLineNumbers: 10,
-            metaOptions: {
-              showLineNumbers: 2,
-            },
-          }),
-        ).toMatchSnapshot();
-      });
-    });
-  });
-
-  describe('handles metadata', () => {
-    describe('standalone', () => {
-      it('set as flag', () => {
-        expect(
-          getLineNumbersStart({
-            showLineNumbers: undefined,
-            metaOptions: {
-              showLineNumbers: true,
-            },
-          }),
-        ).toMatchSnapshot();
-      });
-      it('set with number', () => {
-        expect(
-          getLineNumbersStart({
-            showLineNumbers: undefined,
-            metaOptions: {
-              showLineNumbers: 10,
-            },
-          }),
-        ).toMatchSnapshot();
-      });
-    });
-
-    describe('combined with other options', () => {
-      it('set as flag', () => {
-        expect(
-          getLineNumbersStart({
-            showLineNumbers: undefined,
-            metaOptions: {
-              title: 'file.txt',
-              showLineNumbers: true,
-              noInline: true,
-            },
-          }),
-        ).toMatchSnapshot();
-      });
-      it('set with number', () => {
-        expect(
-          getLineNumbersStart({
-            showLineNumbers: undefined,
-            metaOptions: {
-              title: 'file.txt',
-              showLineNumbers: 10,
-              noInline: true,
-            },
-          }),
-        ).toMatchSnapshot();
-      });
+    it('parses value', () => {
+      expect(
+        getLineNumbersStart({
+          showLineNumbers: undefined,
+          metaOptions: parseCodeBlockMetaOptions(
+            ' showLineNumbers=10 ',
+            undefined,
+          ),
+        }),
+      ).toMatchSnapshot();
     });
   });
 });

--- a/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
@@ -36,10 +36,10 @@ describe('parseCodeBlockMetaOptions', () => {
       ).toBe(`index.js`);
     });
 
-    it('does not parse mismatched quote delimiters', () => {
+    it('parses mismatched quote delimiters as literal', () => {
       expect(
         parseCodeBlockMetaOptions(`title="index.js'`, undefined).title,
-      ).toBeUndefined();
+      ).toBe(`"index.js'`);
     });
 
     it('parses undefined metastring', () => {
@@ -114,6 +114,80 @@ describe('parseCodeBlockMetaOptions', () => {
       expect(
         parseCodeBlockMetaOptions(` otherOption `, undefined).noInline,
       ).toBeUndefined();
+    });
+  });
+
+  describe('any option', () => {
+    it('flag as true', () => {
+      expect(
+        parseCodeBlockMetaOptions(
+          `lowercase camelCase PascalCase UPPER_CASE kebab-case`,
+          undefined,
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('single quotes as string', () => {
+      expect(
+        parseCodeBlockMetaOptions(
+          `lowercase='Hello"Docusaurus Options' camelCase='Hello"Docusaurus Options' PascalCase='Hello"Docusaurus Options' UPPER_CASE='Hello"Docusaurus Options' kebab-case='Hello"Docusaurus Options'`,
+          undefined,
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('double quotes as string', () => {
+      expect(
+        parseCodeBlockMetaOptions(
+          `lowercase="Hello'Docusaurus Options" camelCase="Hello'Docusaurus Options" PascalCase="Hello'Docusaurus Options" UPPER_CASE="Hello'Docusaurus Options" kebab-case="Hello'Docusaurus Options"`,
+          undefined,
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('true', () => {
+      expect(
+        parseCodeBlockMetaOptions(
+          `lowercase=true camelCase=true PascalCase=true UPPER_CASE=true kebab-case=true`,
+          undefined,
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('false', () => {
+      expect(
+        parseCodeBlockMetaOptions(
+          `lowercase=false camelCase=false PascalCase=false UPPER_CASE=false kebab-case=false`,
+          undefined,
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('integer numbers', () => {
+      expect(
+        parseCodeBlockMetaOptions(
+          `lowercase=1 camelCase=2 PascalCase=3 UPPER_CASE=4 kebab-case=5`,
+          undefined,
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('float numbers', () => {
+      expect(
+        parseCodeBlockMetaOptions(
+          `lowercase=1.1 camelCase=2.2 PascalCase=3.3 UPPER_CASE=4.4 kebab-case=5.5`,
+          undefined,
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('non quoted value as string', () => {
+      expect(
+        parseCodeBlockMetaOptions(
+          `lowercase=simple camelCase=simple PascalCase=simple UPPER_CASE=simple kebab-case=simple`,
+          undefined,
+        ),
+      ).toMatchSnapshot();
     });
   });
 });

--- a/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
@@ -25,50 +25,64 @@ const defaultMagicComments: MagicCommentConfig[] = [
 describe('parseCodeBlockMetaOptions', () => {
   describe('title', () => {
     it('parses double quote delimited title', () => {
-      expect(parseCodeBlockMetaOptions(`title="index.js"`).title).toBe(
-        `index.js`,
-      );
+      expect(
+        parseCodeBlockMetaOptions(`title="index.js"`, undefined).title,
+      ).toBe(`index.js`);
     });
 
     it('parses single quote delimited title', () => {
-      expect(parseCodeBlockMetaOptions(`title='index.js'`).title).toBe(
-        `index.js`,
-      );
+      expect(
+        parseCodeBlockMetaOptions(`title='index.js'`, undefined).title,
+      ).toBe(`index.js`);
     });
 
     it('does not parse mismatched quote delimiters', () => {
-      expect(parseCodeBlockMetaOptions(`title="index.js'`).title).toBe(``);
+      expect(
+        parseCodeBlockMetaOptions(`title="index.js'`, undefined).title,
+      ).toBe(``);
     });
 
     it('parses undefined metastring', () => {
-      expect(parseCodeBlockMetaOptions(undefined).title).toBe(``);
+      expect(parseCodeBlockMetaOptions(undefined, undefined).title).toBe(``);
     });
 
     it('parses metastring with no title specified', () => {
-      expect(parseCodeBlockMetaOptions(`{1,2-3}`).title).toBe(``);
+      expect(parseCodeBlockMetaOptions(`{1,2-3}`, undefined).title).toBe(``);
     });
 
     it('parses with multiple metadata title first', () => {
       expect(
-        parseCodeBlockMetaOptions(`title="index.js" label="JavaScript"`).title,
+        parseCodeBlockMetaOptions(
+          `title="index.js" label="JavaScript"`,
+          undefined,
+        ).title,
       ).toBe(`index.js`);
     });
 
     it('parses with multiple metadata title last', () => {
       expect(
-        parseCodeBlockMetaOptions(`label="JavaScript" title="index.js"`).title,
+        parseCodeBlockMetaOptions(
+          `label="JavaScript" title="index.js"`,
+          undefined,
+        ).title,
       ).toBe(`index.js`);
     });
 
     it('parses double quotes when delimited by single quotes', () => {
       expect(
-        parseCodeBlockMetaOptions(`title='console.log("Hello, World!")'`).title,
+        parseCodeBlockMetaOptions(
+          `title='console.log("Hello, World!")'`,
+          undefined,
+        ).title,
       ).toBe(`console.log("Hello, World!")`);
     });
 
     it('parses single quotes when delimited by double quotes', () => {
       expect(
-        parseCodeBlockMetaOptions(`title="console.log('Hello, World!')"`).title,
+        parseCodeBlockMetaOptions(
+          `title="console.log('Hello, World!')"`,
+          undefined,
+        ).title,
       ).toBe(`console.log('Hello, World!')`);
     });
   });
@@ -148,7 +162,11 @@ bbbbb`,
         `// highlight-next-line
 aaaaa
 bbbbb`,
-        {metastring: '', language: 'js', magicComments: defaultMagicComments},
+        {
+          metastring: '',
+          language: 'js',
+          magicComments: defaultMagicComments,
+        },
       ),
     ).toMatchSnapshot();
     expect(
@@ -157,7 +175,11 @@ bbbbb`,
 aaaaa
 // highlight-end
 bbbbb`,
-        {metastring: '', language: 'js', magicComments: defaultMagicComments},
+        {
+          metastring: '',
+          language: 'js',
+          magicComments: defaultMagicComments,
+        },
       ),
     ).toMatchSnapshot();
     expect(
@@ -169,7 +191,11 @@ bbbbbbb
 // highlight-next-line
 // highlight-end
 bbbbb`,
-        {metastring: '', language: 'js', magicComments: defaultMagicComments},
+        {
+          metastring: '',
+          language: 'js',
+          magicComments: defaultMagicComments,
+        },
       ),
     ).toMatchSnapshot();
   });
@@ -179,7 +205,11 @@ bbbbb`,
         `# highlight-next-line
 aaaaa
 bbbbb`,
-        {metastring: '', language: 'js', magicComments: defaultMagicComments},
+        {
+          metastring: '',
+          language: 'js',
+          magicComments: defaultMagicComments,
+        },
       ),
     ).toMatchSnapshot('js');
     expect(
@@ -187,7 +217,11 @@ bbbbb`,
         `/* highlight-next-line */
 aaaaa
 bbbbb`,
-        {metastring: '', language: 'py', magicComments: defaultMagicComments},
+        {
+          metastring: '',
+          language: 'py',
+          magicComments: defaultMagicComments,
+        },
       ),
     ).toMatchSnapshot('py');
     expect(
@@ -200,7 +234,11 @@ bbbbb
 ccccc
 <!-- highlight-next-line -->
 dddd`,
-        {metastring: '', language: 'py', magicComments: defaultMagicComments},
+        {
+          metastring: '',
+          language: 'py',
+          magicComments: defaultMagicComments,
+        },
       ),
     ).toMatchSnapshot('py');
     expect(
@@ -213,7 +251,11 @@ bbbbb
 ccccc
 <!-- highlight-next-line -->
 dddd`,
-        {metastring: '', language: '', magicComments: defaultMagicComments},
+        {
+          metastring: '',
+          language: '',
+          magicComments: defaultMagicComments,
+        },
       ),
     ).toMatchSnapshot('none');
     expect(
@@ -224,7 +266,11 @@ aaaa
 bbbbb
 <!-- highlight-next-line -->
 dddd`,
-        {metastring: '', language: 'jsx', magicComments: defaultMagicComments},
+        {
+          metastring: '',
+          language: 'jsx',
+          magicComments: defaultMagicComments,
+        },
       ),
     ).toMatchSnapshot('jsx');
     expect(
@@ -235,7 +281,11 @@ aaaa
 bbbbb
 <!-- highlight-next-line -->
 dddd`,
-        {metastring: '', language: 'html', magicComments: defaultMagicComments},
+        {
+          metastring: '',
+          language: 'html',
+          magicComments: defaultMagicComments,
+        },
       ),
     ).toMatchSnapshot('html');
     expect(
@@ -261,7 +311,11 @@ dddd
 console.log("preserved");
 \`\`\`
 `,
-        {metastring: '', language: 'md', magicComments: defaultMagicComments},
+        {
+          metastring: '',
+          language: 'md',
+          magicComments: defaultMagicComments,
+        },
       ),
     ).toMatchSnapshot('md');
   });
@@ -373,24 +427,26 @@ describe('getLineNumbersStart', () => {
     expect(
       getLineNumbersStart({
         showLineNumbers: undefined,
-        metastring: undefined,
+        metaOptions: {},
       }),
     ).toMatchSnapshot();
     expect(
       getLineNumbersStart({
         showLineNumbers: undefined,
-        metastring: '',
+        metaOptions: {},
       }),
     ).toMatchSnapshot();
   });
 
   describe('handles prop', () => {
-    describe('combined with metastring', () => {
+    describe('combined with metaoptions', () => {
       it('set to true', () => {
         expect(
           getLineNumbersStart({
             showLineNumbers: true,
-            metastring: 'showLineNumbers=2',
+            metaOptions: {
+              showLineNumbers: 2,
+            },
           }),
         ).toMatchSnapshot();
       });
@@ -399,7 +455,9 @@ describe('getLineNumbersStart', () => {
         expect(
           getLineNumbersStart({
             showLineNumbers: false,
-            metastring: 'showLineNumbers=2',
+            metaOptions: {
+              showLineNumbers: 2,
+            },
           }),
         ).toMatchSnapshot();
       });
@@ -408,7 +466,9 @@ describe('getLineNumbersStart', () => {
         expect(
           getLineNumbersStart({
             showLineNumbers: 10,
-            metastring: 'showLineNumbers=2',
+            metaOptions: {
+              showLineNumbers: 2,
+            },
           }),
         ).toMatchSnapshot();
       });
@@ -419,7 +479,9 @@ describe('getLineNumbersStart', () => {
         expect(
           getLineNumbersStart({
             showLineNumbers: true,
-            metastring: undefined,
+            metaOptions: {
+              showLineNumbers: 2,
+            },
           }),
         ).toMatchSnapshot();
       });
@@ -428,7 +490,9 @@ describe('getLineNumbersStart', () => {
         expect(
           getLineNumbersStart({
             showLineNumbers: false,
-            metastring: undefined,
+            metaOptions: {
+              showLineNumbers: 2,
+            },
           }),
         ).toMatchSnapshot();
       });
@@ -437,7 +501,9 @@ describe('getLineNumbersStart', () => {
         expect(
           getLineNumbersStart({
             showLineNumbers: 10,
-            metastring: undefined,
+            metaOptions: {
+              showLineNumbers: 2,
+            },
           }),
         ).toMatchSnapshot();
       });
@@ -450,7 +516,9 @@ describe('getLineNumbersStart', () => {
         expect(
           getLineNumbersStart({
             showLineNumbers: undefined,
-            metastring: 'showLineNumbers',
+            metaOptions: {
+              showLineNumbers: true,
+            },
           }),
         ).toMatchSnapshot();
       });
@@ -458,7 +526,9 @@ describe('getLineNumbersStart', () => {
         expect(
           getLineNumbersStart({
             showLineNumbers: undefined,
-            metastring: 'showLineNumbers=10',
+            metaOptions: {
+              showLineNumbers: 10,
+            },
           }),
         ).toMatchSnapshot();
       });
@@ -469,7 +539,11 @@ describe('getLineNumbersStart', () => {
         expect(
           getLineNumbersStart({
             showLineNumbers: undefined,
-            metastring: '{1,2-3}  title="file.txt" showLineNumbers noInline',
+            metaOptions: {
+              title: 'file.txt',
+              showLineNumbers: true,
+              noInline: true,
+            },
           }),
         ).toMatchSnapshot();
       });
@@ -477,7 +551,11 @@ describe('getLineNumbersStart', () => {
         expect(
           getLineNumbersStart({
             showLineNumbers: undefined,
-            metastring: '{1,2-3}  title="file.txt" showLineNumbers=10 noInline',
+            metaOptions: {
+              title: 'file.txt',
+              showLineNumbers: 10,
+              noInline: true,
+            },
           }),
         ).toMatchSnapshot();
       });

--- a/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
@@ -8,57 +8,71 @@
 import {
   getLineNumbersStart,
   type MagicCommentConfig,
-  parseCodeBlockTitle,
+  getCodeBlockTitle,
   parseLanguage,
   parseLines,
+  parseCodeBlockMetaOptions,
 } from '../codeBlockUtils';
 
-describe('parseCodeBlockTitle', () => {
-  it('parses double quote delimited title', () => {
-    expect(parseCodeBlockTitle(`title="index.js"`)).toBe(`index.js`);
-  });
+const defaultMagicComments: MagicCommentConfig[] = [
+  {
+    className: 'theme-code-block-highlighted-line',
+    line: 'highlight-next-line',
+    block: {start: 'highlight-start', end: 'highlight-end'},
+  },
+];
 
-  it('parses single quote delimited title', () => {
-    expect(parseCodeBlockTitle(`title='index.js'`)).toBe(`index.js`);
-  });
+describe('parseCodeBlockMetaOptions', () => {
+  describe('title', () => {
+    it('parses double quote delimited title', () => {
+      expect(parseCodeBlockMetaOptions(`title="index.js"`).title).toBe(
+        `index.js`,
+      );
+    });
 
-  it('does not parse mismatched quote delimiters', () => {
-    expect(parseCodeBlockTitle(`title="index.js'`)).toBe(``);
-  });
+    it('parses single quote delimited title', () => {
+      expect(parseCodeBlockMetaOptions(`title='index.js'`).title).toBe(
+        `index.js`,
+      );
+    });
 
-  it('parses undefined metastring', () => {
-    expect(parseCodeBlockTitle(undefined)).toBe(``);
-  });
+    it('does not parse mismatched quote delimiters', () => {
+      expect(parseCodeBlockMetaOptions(`title="index.js'`).title).toBe(``);
+    });
 
-  it('parses metastring with no title specified', () => {
-    expect(parseCodeBlockTitle(`{1,2-3}`)).toBe(``);
-  });
+    it('parses undefined metastring', () => {
+      expect(parseCodeBlockMetaOptions(undefined).title).toBe(``);
+    });
 
-  it('parses with multiple metadata title first', () => {
-    expect(parseCodeBlockTitle(`title="index.js" label="JavaScript"`)).toBe(
-      `index.js`,
-    );
-  });
+    it('parses metastring with no title specified', () => {
+      expect(parseCodeBlockMetaOptions(`{1,2-3}`).title).toBe(``);
+    });
 
-  it('parses with multiple metadata title last', () => {
-    expect(parseCodeBlockTitle(`label="JavaScript" title="index.js"`)).toBe(
-      `index.js`,
-    );
-  });
+    it('parses with multiple metadata title first', () => {
+      expect(
+        parseCodeBlockMetaOptions(`title="index.js" label="JavaScript"`).title,
+      ).toBe(`index.js`);
+    });
 
-  it('parses double quotes when delimited by single quotes', () => {
-    expect(parseCodeBlockTitle(`title='console.log("Hello, World!")'`)).toBe(
-      `console.log("Hello, World!")`,
-    );
-  });
+    it('parses with multiple metadata title last', () => {
+      expect(
+        parseCodeBlockMetaOptions(`label="JavaScript" title="index.js"`).title,
+      ).toBe(`index.js`);
+    });
 
-  it('parses single quotes when delimited by double quotes', () => {
-    expect(parseCodeBlockTitle(`title="console.log('Hello, World!')"`)).toBe(
-      `console.log('Hello, World!')`,
-    );
+    it('parses double quotes when delimited by single quotes', () => {
+      expect(
+        parseCodeBlockMetaOptions(`title='console.log("Hello, World!")'`).title,
+      ).toBe(`console.log("Hello, World!")`);
+    });
+
+    it('parses single quotes when delimited by double quotes', () => {
+      expect(
+        parseCodeBlockMetaOptions(`title="console.log('Hello, World!')"`).title,
+      ).toBe(`console.log('Hello, World!')`);
+    });
   });
 });
-
 describe('parseLanguage', () => {
   it('works', () => {
     expect(parseLanguage('language-foo xxx yyy')).toBe('foo');
@@ -69,14 +83,6 @@ describe('parseLanguage', () => {
 });
 
 describe('parseLines', () => {
-  const defaultMagicComments: MagicCommentConfig[] = [
-    {
-      className: 'theme-code-block-highlighted-line',
-      line: 'highlight-next-line',
-      block: {start: 'highlight-start', end: 'highlight-end'},
-    },
-  ];
-
   it('does not parse content with metastring', () => {
     expect(
       parseLines('aaaaa\nnnnnn', {
@@ -475,6 +481,71 @@ describe('getLineNumbersStart', () => {
           }),
         ).toMatchSnapshot();
       });
+    });
+  });
+});
+
+describe('getCodeBlockTitle', () => {
+  it('with nothing set', () => {
+    expect(
+      getCodeBlockTitle({
+        titleProp: undefined,
+        metaOptions: {},
+      }),
+    ).toMatchSnapshot();
+  });
+
+  describe('returns titleProp', () => {
+    it('with empty options', () => {
+      expect(
+        getCodeBlockTitle({
+          titleProp: 'Prop',
+          metaOptions: {},
+        }),
+      ).toMatchSnapshot();
+    });
+    it('with empty string on option', () => {
+      expect(
+        getCodeBlockTitle({
+          titleProp: 'Prop',
+          metaOptions: {
+            title: '',
+          },
+        }),
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('returns option', () => {
+    it('with undefined prop', () => {
+      expect(
+        getCodeBlockTitle({
+          titleProp: undefined,
+          metaOptions: {
+            title: 'Option',
+          },
+        }),
+      ).toMatchSnapshot();
+    });
+    it('with empty prop', () => {
+      expect(
+        getCodeBlockTitle({
+          titleProp: '',
+          metaOptions: {
+            title: 'Option',
+          },
+        }),
+      ).toMatchSnapshot();
+    });
+    it('with filled prop', () => {
+      expect(
+        getCodeBlockTitle({
+          titleProp: 'Prop',
+          metaOptions: {
+            title: 'Option',
+          },
+        }),
+      ).toMatchSnapshot();
     });
   });
 });

--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
@@ -147,10 +147,6 @@ function getAllMagicCommentDirectiveStyles(
   }
 }
 
-function parseCodeBlockTitle(metastring?: string): string {
-  return metastring?.match(codeBlockTitleRegex)?.groups!.title ?? '';
-}
-
 function getMetaLineNumbersStart(metastring?: string): number | undefined {
   const showLineNumbersMeta = metastring
     ?.split(' ')
@@ -356,12 +352,23 @@ export function parseCodeBlockMetaOptions(
   // we keep the old custom logic which was moved from their old spots to here.
 
   // normal codeblock
-  parsedOptions.title = parseCodeBlockTitle(metastring);
-  parsedOptions.showLineNumbers = getMetaLineNumbersStart(metastring);
+  const title = metastring?.match(codeBlockTitleRegex)?.groups!.title;
+  if (title !== undefined) {
+    parsedOptions.title = title;
+  }
+  const showLineNumbers = getMetaLineNumbersStart(metastring);
+  if (showLineNumbers !== undefined) {
+    parsedOptions.showLineNumbers = showLineNumbers;
+  }
 
   // interactive code editor (theme-live-codeblock => Playground)
-  parsedOptions.live = metastring?.split(' ').includes('live');
-  parsedOptions.noInline = metastring?.includes('noInline');
+  if (metastring?.split(' ').includes('live')) {
+    parsedOptions.live = true;
+  }
+
+  if (metastring?.includes('noInline')) {
+    parsedOptions.noInline = true;
+  }
 
   return parsedOptions;
 }

--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
@@ -183,19 +183,22 @@ export function getCodeBlockTitle({
 
 export function getLineNumbersStart({
   showLineNumbers,
-  metastring,
+  metaOptions,
 }: {
   showLineNumbers: boolean | number | undefined;
-  metastring: string | undefined;
+  metaOptions: CodeBlockMetaOptions;
 }): number | undefined {
+  const showLineNumbersValue = showLineNumbers ?? metaOptions.showLineNumbers;
+
   const defaultStart = 1;
-  if (typeof showLineNumbers === 'boolean') {
-    return showLineNumbers ? defaultStart : undefined;
+  if (typeof showLineNumbersValue === 'boolean') {
+    return showLineNumbersValue ? defaultStart : undefined;
   }
-  if (typeof showLineNumbers === 'number') {
-    return showLineNumbers;
+  if (typeof showLineNumbersValue === 'number') {
+    return showLineNumbersValue;
   }
-  return getMetaLineNumbersStart(metastring);
+
+  return undefined;
 }
 
 /**
@@ -354,7 +357,7 @@ export function parseCodeBlockMetaOptions(
 
   // normal codeblock
   parsedOptions.title = parseCodeBlockTitle(metastring);
-  // parsedOptions.showLineNumbers = TODO;
+  parsedOptions.showLineNumbers = getMetaLineNumbersStart(metastring);
 
   // interactive code editor (theme-live-codeblock => Playground)
   parsedOptions.live = metastring?.split(' ').includes('live');

--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
@@ -335,19 +335,30 @@ export function parseLines(
 /**
  * Parses {@link CodeBlockParsedLines.metaOptions} from the given metastring.
  * @param metastring The metastring to parse
+ * @param metaOptionsProp any meta options defined via component props.
  * @returns The parsed options.
  */
 export function parseCodeBlockMetaOptions(
   metastring: string | undefined,
+  metaOptionsProp: CodeBlockMetaOptions | undefined,
 ): CodeBlockMetaOptions {
+  // If we already have options via props use them as they are
+  if (metaOptionsProp) {
+    return metaOptionsProp;
+  }
+
   const parsedOptions: CodeBlockMetaOptions = {};
 
+  // NOTE: until we parse generally all options contained in this string
+  // we keep the old custom logic which was moved from their old spots to here.
+
+  // normal codeblock
   parsedOptions.title = parseCodeBlockTitle(metastring);
-
-  // parsedOptions.live = TODO;
-  // parsedOptions.noInline = TODO;
-
   // parsedOptions.showLineNumbers = TODO;
+
+  // interactive code editor (theme-live-codeblock => Playground)
+  parsedOptions.live = metastring?.split(' ').includes('live');
+  // parsedOptions.noInline = TODO;
 
   return parsedOptions;
 }

--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
@@ -358,7 +358,7 @@ export function parseCodeBlockMetaOptions(
 
   // interactive code editor (theme-live-codeblock => Playground)
   parsedOptions.live = metastring?.split(' ').includes('live');
-  // parsedOptions.noInline = TODO;
+  parsedOptions.noInline = metastring?.includes('noInline');
 
   return parsedOptions;
 }

--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
@@ -147,7 +147,7 @@ function getAllMagicCommentDirectiveStyles(
   }
 }
 
-export function parseCodeBlockTitle(metastring?: string): string {
+function parseCodeBlockTitle(metastring?: string): string {
   return metastring?.match(codeBlockTitleRegex)?.groups!.title ?? '';
 }
 
@@ -165,6 +165,20 @@ function getMetaLineNumbersStart(metastring?: string): number | undefined {
   }
 
   return undefined;
+}
+
+export function getCodeBlockTitle({
+  titleProp,
+  metaOptions,
+}: {
+  titleProp: React.ReactNode;
+  metaOptions: CodeBlockMetaOptions;
+}): React.ReactNode {
+  // NOTE: historically the metastring option overruled
+  // any `title=""` prop specified on `<CodeBlock />`
+  // this is the reversed logic to getLineNumbersStart
+  // but would be a breaking change so we keep it.
+  return metaOptions.title || titleProp;
 }
 
 export function getLineNumbersStart({
@@ -316,6 +330,26 @@ export function parseLines(
     });
   });
   return {lineClassNames, code};
+}
+
+/**
+ * Parses {@link CodeBlockParsedLines.metaOptions} from the given metastring.
+ * @param metastring The metastring to parse
+ * @returns The parsed options.
+ */
+export function parseCodeBlockMetaOptions(
+  metastring: string | undefined,
+): CodeBlockMetaOptions {
+  const parsedOptions: CodeBlockMetaOptions = {};
+
+  parsedOptions.title = parseCodeBlockTitle(metastring);
+
+  // parsedOptions.live = TODO;
+  // parsedOptions.noInline = TODO;
+
+  // parsedOptions.showLineNumbers = TODO;
+
+  return parsedOptions;
 }
 
 export function getPrismCssVariables(prismTheme: PrismTheme): CSSProperties {

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.tsx
@@ -6,17 +6,30 @@
  */
 
 import React from 'react';
+import {parseCodeBlockMetaOptions} from '@docusaurus/theme-common/internal';
 import Playground from '@theme/Playground';
 import ReactLiveScope from '@theme/ReactLiveScope';
 import CodeBlock, {type Props} from '@theme-init/CodeBlock';
 
 const withLiveEditor = (Component: typeof CodeBlock) => {
   function WrappedComponent(props: Props) {
-    if (props.live) {
-      return <Playground scope={ReactLiveScope} {...props} />;
+    const metaOptions = parseCodeBlockMetaOptions(
+      props.metastring,
+      props.metaOptions,
+    );
+
+    const live = props.live ?? metaOptions.live;
+    if (live) {
+      return (
+        <Playground
+          scope={ReactLiveScope}
+          metaOptions={metaOptions}
+          {...props}
+        />
+      );
     }
 
-    return <Component {...props} />;
+    return <Component metaOptions={metaOptions} {...props} />;
   }
 
   return WrappedComponent;

--- a/packages/docusaurus-theme-live-codeblock/src/theme/Playground/index.tsx
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/Playground/index.tsx
@@ -16,6 +16,7 @@ import {
   ErrorBoundaryErrorMessageFallback,
   usePrismTheme,
 } from '@docusaurus/theme-common';
+import {parseCodeBlockMetaOptions} from '@docusaurus/theme-common/internal';
 import ErrorBoundary from '@docusaurus/ErrorBoundary';
 
 import type {Props} from '@theme/Playground';
@@ -105,6 +106,8 @@ const DEFAULT_TRANSFORM_CODE = (code: string) => `${code};`;
 export default function Playground({
   children,
   transformCode,
+  metastring,
+  metaOptions: metaOptionsProp,
   ...props
 }: Props): ReactNode {
   const {
@@ -115,7 +118,8 @@ export default function Playground({
   } = themeConfig as ThemeConfig;
   const prismTheme = usePrismTheme();
 
-  const noInline = props.metastring?.includes('noInline') ?? false;
+  const metaOptions = parseCodeBlockMetaOptions(metastring, metaOptionsProp);
+  const noInline = !!metaOptions.noInline;
 
   return (
     <div className={styles.playgroundContainer}>

--- a/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
@@ -390,6 +390,12 @@ npm run swizzle @docusaurus/theme-classic CodeBlock/Line
 
 The `Line` component will receive the list of class names, based on which you can conditionally render different markup.
 
+```bash npm2yarn
+npm run swizzle @docusaurus/theme-classic CodeBlock/Token
+```
+
+The `Token` component will receive the CSS styles, a className, and the raw syntax token content, based on which you can conditionally render different markup. You also have access to the parent line via `props.line` to access information like the class names applied from magic comments.
+
 ## Line numbering {#line-numbering}
 
 You can enable line numbering for your code block by using `showLineNumbers` key within the language meta string (don't forget to add space directly before the key).


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

This PR is part of a series related to #11008 and it superceeds https://github.com/facebook/docusaurus/pull/11011 in the goal to splitup the work into more isolated refactoring/feature parts. 

Note that this PR also includes the changes of previous steps and therefore the overall diff can be misleading. The best approach will be to review and merge every step individually and then rebase accordingly. 

Intermediately the specific changes can be checked here: https://github.com/Danielku15/docusaurus/compare/feature/codeblock-meta-4...Danielku15:docusaurus:feature/codeblock-meta-5

Step 1 (#11017): Splitup current parseLines logic (separation of concerns) 
Step 2 (#11019): Parse metastring into metaOptions and use it across components.
Step 3 (#11021): Add parsing of any options specified in the metastring.
Step 4 (#11022): Add CodeBlockToken component to customize DOM of highlighted tokens. 
Step 5 (this PR): Pass `metaOptions` to whole codeblock component tree.

The motivation of this part is to allow users to customize the rendering of the components by utilizing any special metaOption which is applied to the code blocks. 

Use cases are: 

1. Adjust the whole CodeBlock (e.g. replacing the syntax highlighter) or the Live Editor (passing on further options to react-live).
2. Adjust the individual CodeBlockLine (e.g. checking for options which could hide/show lines dynamically, rendering additional annotations,..) 
3. Adjust the individual CodeBlockToken (e.g. [render white spaces](https://prismjs.com/plugins/show-invisibles/), [link to mdn or webplatform.org](https://prismjs.com/plugins/wpd/), [inline color](https://prismjs.com/plugins/inline-color/),...)

The `metaOptions` doesn't need to be passed explicitely to the CodeBlockToken as it is accessible through `props.line.metaOptions` (See #11022). 

## Test Plan

Automatic testing relies on existing integration tests. 

Manual testing by checking `/docs/markdown-features/code-blocks` showed no impact of the change. 

If more testing is expected I'd need some guidance on how to typically such tests are written for Swizzled components.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-11023--docusaurus-2.netlify.app/
Code Blocks: https://deploy-preview-11023--docusaurus-2.netlify.app/docs/markdown-features/code-blocks/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

* https://github.com/facebook/docusaurus/pull/11011
* #11008
