### PR TITLE
fix(cli): fix CLI write-translation bug

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/globUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/globUtils.test.ts
@@ -9,7 +9,21 @@ import {
   GlobExcludeDefault,
   createMatcher,
   createAbsoluteFilePathMatcher,
+  isTranslatableSourceFile,
 } from '../globUtils';
+
+describe('isTranslatableSourceFile', () => {
+  it('works', () => {
+    expect(isTranslatableSourceFile('./xyz.ts')).toBe(true);
+    expect(isTranslatableSourceFile('./xyz.tsx')).toBe(true);
+    expect(isTranslatableSourceFile('./xyz.js')).toBe(true);
+    expect(isTranslatableSourceFile('./xyz.jsx')).toBe(true);
+
+    expect(isTranslatableSourceFile('./xyz.md')).toBe(false);
+    expect(isTranslatableSourceFile('./xyz.mdx')).toBe(false);
+    expect(isTranslatableSourceFile('./xyz.d.ts')).toBe(false);
+  });
+});
 
 describe('createMatcher', () => {
   it('match default exclude MD/MDX partials correctly', () => {

--- a/packages/docusaurus-utils/src/globUtils.ts
+++ b/packages/docusaurus-utils/src/globUtils.ts
@@ -104,11 +104,8 @@ export async function safeGlobby(
   return Globby(globPaths, options);
 }
 
-// A bit weird to put this here, but it's used by core + theme-translations
-export async function globTranslatableSourceFiles(
-  patterns: string[],
-): Promise<string[]> {
-  // We only support extracting source code translations from these kind of files
+export const isTranslatableSourceFile: (filePath: string) => boolean = (() => {
+  // We only support extracting source code translations from these extensions
   const extensionsAllowed = new Set([
     '.js',
     '.jsx',
@@ -125,9 +122,16 @@ export async function globTranslatableSourceFiles(
     return filePath.endsWith('.d.ts');
   };
 
-  const filePaths = await safeGlobby(patterns);
-  return filePaths.filter((filePath) => {
+  return (filePath): boolean => {
     const ext = path.extname(filePath);
     return extensionsAllowed.has(ext) && !isBlacklistedFilePath(filePath);
-  });
+  };
+})();
+
+// A bit weird to put this here, but it's used by core + theme-translations
+export async function globTranslatableSourceFiles(
+  patterns: string[],
+): Promise<string[]> {
+  const filePaths = await safeGlobby(patterns);
+  return filePaths.filter(isTranslatableSourceFile);
 }

--- a/packages/docusaurus-utils/src/globUtils.ts
+++ b/packages/docusaurus-utils/src/globUtils.ts
@@ -120,8 +120,14 @@ export async function globTranslatableSourceFiles(
     // '.mdx',
   ]);
 
+  const isBlacklistedFilePath = (filePath: string) => {
+    // We usually extract from ts files, unless they are .d.ts files
+    return filePath.endsWith('.d.ts');
+  };
+
   const filePaths = await safeGlobby(patterns);
-  return filePaths.filter((filePath) =>
-    extensionsAllowed.has(path.extname(filePath)),
-  );
+  return filePaths.filter((filePath) => {
+    const ext = path.extname(filePath);
+    return extensionsAllowed.has(ext) && !isBlacklistedFilePath(filePath);
+  });
 }


### PR DESCRIPTION

## Motivation

The Docusaurus CLI `docusaurus write-translations` is trying to extract translations from `.d.ts` files, leading to errors.

Reported by @tats-u here https://github.com/facebook/docusaurus/issues/3526#issuecomment-2747942435

## Test Plan

CI / unit tests

