### PR TITLE
fix(theme): Fix code block magic comments with CRLF line breaks bug

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/__snapshots__/codeBlockUtils.test.ts.snap
@@ -70,6 +70,30 @@ bbbbb",
 }
 `;
 
+exports[`parseLines handles CRLF line breaks with highlight comments correctly 1`] = `
+{
+  "code": "aaaaa
+bbbbb",
+  "lineClassNames": {
+    "1": [
+      "theme-code-block-highlighted-line",
+    ],
+  },
+}
+`;
+
+exports[`parseLines handles CRLF line breaks with highlight metastring 1`] = `
+{
+  "code": "aaaaa
+bbbbb",
+  "lineClassNames": {
+    "1": [
+      "theme-code-block-highlighted-line",
+    ],
+  },
+}
+`;
+
 exports[`parseLines handles one line with multiple class names 1`] = `
 {
   "code": "

--- a/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
@@ -360,6 +360,29 @@ line
       ),
     ).toMatchSnapshot();
   });
+
+  it('handles CRLF line breaks with highlight comments correctly', () => {
+    expect(
+      parseLines(
+        `aaaaa\r\n// highlight-start\r\nbbbbb\r\n// highlight-end\r\n`,
+        {
+          metastring: '',
+          language: 'js',
+          magicComments: defaultMagicComments,
+        },
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('handles CRLF line breaks with highlight metastring', () => {
+    expect(
+      parseLines(`aaaaa\r\nbbbbb\r\n`, {
+        metastring: '{2}',
+        language: 'js',
+        magicComments: defaultMagicComments,
+      }),
+    ).toMatchSnapshot();
+  });
 });
 
 describe('getLineNumbersStart', () => {

--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
@@ -241,7 +241,7 @@ export function parseLines(
    */
   code: string;
 } {
-  let code = content.replace(/\n$/, '');
+  let code = content.replace(/\r?\n$/, '');
   const {language, magicComments, metastring} = options;
   // Highlighted lines specified in props: don't parse the content
   if (metastring && metastringLinesRangeRegex.test(metastring)) {
@@ -266,7 +266,7 @@ export function parseLines(
     magicComments,
   );
   // Go through line by line
-  const lines = code.split('\n');
+  const lines = code.split(/\r?\n/);
   const blocks = Object.fromEntries(
     magicComments.map((d) => [d.className, {start: 0, range: ''}]),
   );


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

fix: with CRLF line breaks, an extra empty line was rendered with // highlight-end at end of code blocks

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

See: #11036
