### PR TITLE
feat(core): enable Rspack `parallelCodeSplitting`

### DIFF
--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -187,10 +187,6 @@ export async function createBaseConfig({
         // @ts-expect-error: Rspack-only, not available in Webpack typedefs
         incremental: !isProd && !process.env.DISABLE_RSPACK_INCREMENTAL,
 
-        // TODO re-enable later?
-        //  See Rspack 1.3 bug https://github.com/web-infra-dev/rspack/issues/9834
-        parallelCodeSplitting: false,
-
         ...PersistentCacheAttributes,
       };
     }
@@ -253,7 +249,8 @@ export async function createBaseConfig({
       modules: ['node_modules', path.join(siteDir, 'node_modules')],
     },
     optimization: {
-      removeAvailableModules: false,
+      // See https://github.com/web-infra-dev/rspack/issues/9834
+      removeAvailableModules: true,
       // Only minimize client bundle in production because server bundle is only
       // used for static site generation
       minimize: minimizeEnabled,


### PR DESCRIPTION
## Motivation

Re-enable Rspack `parallelCodeSplitting`, coming with v1.3 by default

It was disabled in https://github.com/facebook/docusaurus/pull/11039 due to a possible Rspack bug: https://github.com/web-infra-dev/rspack/issues/9834

But it turns out it's our fault, due to using `optimization.removeAvailableModules: false`:
- 2019 PR, I'm not sure it was really a good change: https://github.com/facebook/docusaurus/pull/1711: 
- Doc: https://webpack.js.org/configuration/optimization/#optimizationremoveavailablemodules


## Test Plan

CI + build size report

https://deploy-preview-11067--docusaurus-2.netlify.app/

