### PR TITLE
fix(blog): fix blog Atom feed item url / XSL bug

### DIFF
--- a/packages/docusaurus-plugin-content-blog/assets/atom.xsl
+++ b/packages/docusaurus-plugin-content-blog/assets/atom.xsl
@@ -71,7 +71,7 @@
           <div class="blog-posts">
             <xsl:for-each select="atom:feed/atom:entry">
               <div class="blog-post">
-                <h3><a href="{atom:link[@rel='alternate']/@href}"><xsl:value-of
+                <h3><a href="{atom:link/@href}"><xsl:value-of
                       select="atom:title"
                     /></a></h3>
                 <div class="blog-post-date">


### PR DESCRIPTION
## Motivation

Fix https://github.com/facebook/docusaurus/issues/11060

The XSL wasn't correct and wouldn't produce the right link href

## Test Plan

Preview / manual, not sure how to automate this kind of test 😅 




### Test links

https://deploy-preview-11068--docusaurus-2.netlify.app/blog/atom.xml

![CleanShot 2025-04-07 at 19 00 54](https://github.com/user-attachments/assets/74af1a14-1b12-409e-99be-fac03cee2fd7)

