### PR TITLE
perf(core): remove bundler  `optimization.removeAvailableModules`

### DIFF
--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -249,8 +249,6 @@ export async function createBaseConfig({
       modules: ['node_modules', path.join(siteDir, 'node_modules')],
     },
     optimization: {
-      // See https://github.com/web-infra-dev/rspack/issues/9834
-      removeAvailableModules: true,
       // Only minimize client bundle in production because server bundle is only
       // used for static site generation
       minimize: minimizeEnabled,


### PR DESCRIPTION


## Motivation

See https://github.com/web-infra-dev/rspack/issues/9834#issuecomment-2785339317

Doing `removeAvailableModules: true` in webpack does extra work that is already done by Webpack core itself (although it's probably not super significant)

`removeAvailableModules: true` is the default value in Rspack so no impact in removing it.
 

## Test Plan

CI bots should report no output size change for webpack/Rspack.

### Test links

https://deploy-preview-_____--docusaurus-2.netlify.app/
