### PR TITLE
feat(docusaurus-types): Add UnusedDirective: 'throw' for markdown

### DIFF
--- a/examples/classic/docusaurus.config.js
+++ b/examples/classic/docusaurus.config.js
@@ -13,6 +13,11 @@ const config = {
   title: 'My Site',
   tagline: 'Dinosaurs are cool',
   favicon: 'img/favicon.ico',
+  siteConfig: {
+      markdown: {
+        onUnusedDirective: 'throw'
+      }
+  },
 
   // Set the production url of your site here
   url: 'https://your-docusaurus-site.example.com',

--- a/packages/docusaurus-types/src/config.d.ts
+++ b/packages/docusaurus-types/src/config.d.ts
@@ -19,6 +19,10 @@ export type ReportingSeverity = 'ignore' | 'log' | 'warn' | 'throw';
 
 export type RouterType = 'browser' | 'hash';
 
+export type SiteConfig = {
+  markdown: {onUnusedDirective: 'throw'};
+};
+
 export type ThemeConfig = {
   [key: string]: unknown;
 };
@@ -316,6 +320,16 @@ export type DocusaurusConfig = {
    * @default {}
    */
   themeConfig: ThemeConfig;
+  /**
+   * The [site configuration](https://docusaurus.io/docs/api/docusaurus-config)
+   * object to customize your site configuration like markdown. For example: throw error
+   * if any unused markdown directive is found.
+   *
+   * @see https://docusaurus.io/docs/api/docusaurus-config#siteConfig
+   * @default {}
+   */
+  // TODO: Docs to be added for this
+  siteConfig: SiteConfig;
   /**
    * List of plugins.
    *

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -17,6 +17,7 @@ export {
   FasterConfig,
   StorageConfig,
   Config,
+  SiteConfig,
 } from './config';
 
 export {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [X] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

Closes: https://github.com/facebook/docusaurus/issues/10674
<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

This PR adds a directive which can be added to config to throw error if there are unused directive in the markdown. At the moment we have ability to only show warnings for it.
https://github.com/facebook/docusaurus/pull/9394


## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

I am trying to add the same config in example classic and while doing so I am getting this error.
I don't think I need to use `customFields` here

![image](https://github.com/user-attachments/assets/fd0bf76a-0d17-4838-96e4-825e24f137f6)


### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
