### PR TITLE
feat(mdx-loader): Support MDX source-map

### DIFF
--- a/packages/docusaurus-mdx-loader/package.json
+++ b/packages/docusaurus-mdx-loader/package.json
@@ -35,6 +35,7 @@
     "remark-emoji": "^4.0.0",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.0",
+    "source-map": "^0.7.4",
     "stringify-object": "^3.3.0",
     "tslib": "^2.6.0",
     "unified": "^11.0.3",

--- a/packages/docusaurus-mdx-loader/src/options.ts
+++ b/packages/docusaurus-mdx-loader/src/options.ts
@@ -9,6 +9,7 @@ import type {MDXOptions, SimpleProcessors} from './processor';
 import type {MarkdownConfig} from '@docusaurus/types';
 import type {ResolveMarkdownLink} from './remark/resolveMarkdownLinks';
 import type {PromiseWithResolvers} from './utils';
+import type {Map as SourceMap} from 'vfile';
 
 export type Options = Partial<MDXOptions> & {
   dependencies?: string[];
@@ -31,4 +32,7 @@ export type Options = Partial<MDXOptions> & {
   crossCompilerCache?: Map<string, CrossCompilerCacheEntry>; // MDX => Promise<JSX> cache
 };
 
-type CrossCompilerCacheEntry = PromiseWithResolvers<string>;
+type CrossCompilerCacheEntry = PromiseWithResolvers<{
+  content: string;
+  sourceMap: SourceMap | null | undefined;
+}>;

--- a/packages/docusaurus-mdx-loader/src/processor.ts
+++ b/packages/docusaurus-mdx-loader/src/processor.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {SourceMapGenerator} from 'source-map';
 import headings from './remark/headings';
 import contentTitle from './remark/contentTitle';
 import toc from './remark/toc';
@@ -23,6 +24,7 @@ import type {MDXFrontMatter} from './frontMatter';
 import type {Options} from './options';
 import type {AdmonitionOptions} from './remark/admonitions';
 import type {ProcessorOptions} from '@mdx-js/mdx';
+import type {Map as SourceMap} from 'vfile';
 
 // TODO as of April 2023, no way to import/re-export this ESM type easily :/
 // This might change soon, likely after TS 5.2
@@ -31,6 +33,7 @@ type Pluggable = any; // TODO fix this asap
 
 export type SimpleProcessorResult = {
   content: string;
+  map: SourceMap | null | undefined;
   data: {[key: string]: unknown};
 };
 
@@ -187,6 +190,7 @@ async function createProcessorFactory() {
       ...processorOptions,
       remarkRehypeOptions: options.markdownConfig.remarkRehypeOptions,
       format,
+      SourceMapGenerator,
     });
 
     return {
@@ -202,6 +206,7 @@ async function createProcessorFactory() {
         return mdxProcessor.process(vfile).then((result) => ({
           content: result.toString(),
           data: result.data,
+          map: result.map,
         }));
       },
     };


### PR DESCRIPTION


## Motivation

We should be able to use source map for MDX files, to know which line an MDX error comes from more easily.

Unfortunately, it's not as easy as I thought and this PR is only a WIP initial attempt.

For now we get errors such as:

> × Failed to generate code because ast or source is not set for module /Users/sebastienlorber/Desktop/projects/docusaurus/packages/docusaurus-mdx-loader/lib/index.js??ruleSet[1].rules[8].use[0]!/Users/sebastienlorber/Desktop/projects/docusaurus/website/docs/introduction.mdx

Also, we are concatenating strings in our MDX loaders so it's unlikely to work well, and we'd first need to refactor that.

Inspired by https://github.com/mdx-js/mdx/blob/main/packages/loader/lib/index.js

I will continue working on this later

## Test Plan

CI

### Test links

https://deploy-preview-_____--docusaurus-2.netlify.app/


