### PR TITLE
perf(faster): Upgrade Rspack to 1.3.6+, fix persistent cache perf issue

### DIFF
--- a/packages/docusaurus-faster/package.json
+++ b/packages/docusaurus-faster/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "@docusaurus/types": "3.7.0",
-    "@rspack/core": "^1.3.3",
+    "@rspack/core": "npm:@rspack-canary/core@1.3.6-canary-24c37390-20250417063019",
     "@swc/core": "^1.7.39",
     "@swc/html": "^1.7.39",
     "browserslist": "^4.24.2",

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -77,13 +77,6 @@ async function createMdxLoaderDependencyFile({
   options: PluginOptions;
   versionsMetadata: VersionMetadata[];
 }): Promise<string | undefined> {
-  // TODO this has been temporarily made opt-in until Rspack cache bug is fixed
-  //  See https://github.com/facebook/docusaurus/pull/10931
-  //  See https://github.com/facebook/docusaurus/pull/10934#issuecomment-2672253145
-  if (!process.env.DOCUSAURUS_ENABLE_MDX_DEPENDENCY_FILE) {
-    return undefined;
-  }
-
   const filePath = path.join(dataDir, '__mdx-loader-dependency.json');
   // the cache is invalidated whenever this file content changes
   const fileContent = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2565,48 +2565,48 @@
   dependencies:
     langium "3.3.1"
 
-"@module-federation/error-codes@0.11.2":
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/@module-federation/error-codes/-/error-codes-0.11.2.tgz#880cbaf370bacb5d27e5149a93228aebe7ed084c"
-  integrity sha512-ik1Qnn0I+WyEdprTck9WGlH41vGsVdUg8cfO+ZM02qOb2cZm5Vu3SlxGAobj6g7uAj0g8yINnd7h7Dci40BxQA==
+"@module-federation/error-codes@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@module-federation/error-codes/-/error-codes-0.12.0.tgz#cbecdbeabdc69f04f0026cdee540cde5a78c4369"
+  integrity sha512-DEXQjopcBuGzp/NA9OVtASO0uZ6grVK5TIe0PjrbDRyZDxVaYQXKrISxBLOE+3nSIELE98tYpfxptm8WC9A8zA==
 
-"@module-federation/runtime-core@0.11.2":
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/@module-federation/runtime-core/-/runtime-core-0.11.2.tgz#677aced902d56afd3e44f4033e8d78d57c8aa029"
-  integrity sha512-dia5kKybi6MFU0s5PgglJwN27k7n9Sf69Cy5xZ4BWaP0qlaXTsxHKO0PECHNt2Pt8jDdyU29sQ4DwAQfxpnXJQ==
+"@module-federation/runtime-core@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@module-federation/runtime-core/-/runtime-core-0.12.0.tgz#324338d139b137e92d2a2afdc87a42a6572bf70b"
+  integrity sha512-373zBM54196KHURs/O8lry9trCAM3PPidvsF4YdrtahNc8YaQynml0mE3zdZeBnqP6H0/4OpPqMMjACI80Ht8w==
   dependencies:
-    "@module-federation/error-codes" "0.11.2"
-    "@module-federation/sdk" "0.11.2"
+    "@module-federation/error-codes" "0.12.0"
+    "@module-federation/sdk" "0.12.0"
 
-"@module-federation/runtime-tools@0.11.2":
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/@module-federation/runtime-tools/-/runtime-tools-0.11.2.tgz#d6a5c4f61b93b647de656b08ba465590631a1316"
-  integrity sha512-4MJTGAxVq6vxQRkTtTlH7Mm9AVqgn0X9kdu+7RsL7T/qU+jeYsbrntN2CWG3GVVA8r5JddXyTI1iJ0VXQZLV1w==
+"@module-federation/runtime-tools@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@module-federation/runtime-tools/-/runtime-tools-0.12.0.tgz#43f891cb76ab02dfe9d688288572107cf40c37b7"
+  integrity sha512-hZ0R1gtHOgMDzM0QQ8WjRxo2DHzXzlTWOYMBdSivDYRTktpEtM/DXZrmJZuRYh9cvVmbIz5D/v9s6M44eLfHMA==
   dependencies:
-    "@module-federation/runtime" "0.11.2"
-    "@module-federation/webpack-bundler-runtime" "0.11.2"
+    "@module-federation/runtime" "0.12.0"
+    "@module-federation/webpack-bundler-runtime" "0.12.0"
 
-"@module-federation/runtime@0.11.2":
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/@module-federation/runtime/-/runtime-0.11.2.tgz#e623136774599ce202bb4ea1e396f18fbaeee19a"
-  integrity sha512-Ya9u/L6z2LvhgpqxuKCB7LcigIIRf1BbaxAZIH7mzbq/A7rZtTP7v+73E433jvgiAlbAfPSZkeoYGele6hfRwA==
+"@module-federation/runtime@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@module-federation/runtime/-/runtime-0.12.0.tgz#c5f8959c1e345e3e578a8d2aeb7c5583af3e966c"
+  integrity sha512-Cz9/7+gSvrdencwA8LXUMKnZdu0/flyN+yk6t3pkxfhvPJi3W65ZcalAKyOgyk2x8rEYrRSyEXu+/2DIFgrzmA==
   dependencies:
-    "@module-federation/error-codes" "0.11.2"
-    "@module-federation/runtime-core" "0.11.2"
-    "@module-federation/sdk" "0.11.2"
+    "@module-federation/error-codes" "0.12.0"
+    "@module-federation/runtime-core" "0.12.0"
+    "@module-federation/sdk" "0.12.0"
 
-"@module-federation/sdk@0.11.2":
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/@module-federation/sdk/-/sdk-0.11.2.tgz#965b0dcf8fb036dda9b1e6812d6ae0a394ea827d"
-  integrity sha512-SBFe5xOamluT900J4AGBx+2/kCH/JbfqXoUwPSAC6PRzb8Y7LB0posnOGzmqYsLZXT37vp3d6AmJDsVoajDqxw==
+"@module-federation/sdk@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@module-federation/sdk/-/sdk-0.12.0.tgz#e6e40dfb49fb8fe649568d6c7362723d273a94cf"
+  integrity sha512-vh3GcG90fxjbkMghK7iSWcMayi/y8U5DxI6mhEFuz11St3y1UgQO2TZYephL8nISFBld7DdiqAkimx+6Hb3hjQ==
 
-"@module-federation/webpack-bundler-runtime@0.11.2":
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.11.2.tgz#ef4a21e0ff8aefce9c264a57aa882ee72ecfe6aa"
-  integrity sha512-WdwIE6QF+MKs/PdVu0cKPETF743JB9PZ62/qf7Uo3gU4fjsUMc37RnbJZ/qB60EaHHfjwp1v6NnhZw1r4eVsnw==
+"@module-federation/webpack-bundler-runtime@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.12.0.tgz#b273fc6264c2414b24f9d2d24fc6d0125d3cd2dc"
+  integrity sha512-IUAz0BdCGuaKIPcMTSD/dWxGjS0K4j4bBhAupRnDMMMOvJnZivVwj0KvmTeIUfyG+lEDNWLVP2pDVQEvGcCy4Q==
   dependencies:
-    "@module-federation/runtime" "0.11.2"
-    "@module-federation/sdk" "0.11.2"
+    "@module-federation/runtime" "0.12.0"
+    "@module-federation/sdk" "0.12.0"
 
 "@netlify/functions@^1.6.0":
   version "1.6.0"
@@ -3262,75 +3262,75 @@
     fs-extra "^11.1.1"
     lodash "^4.17.21"
 
-"@rspack/binding-darwin-arm64@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.3.3.tgz#f62473fa7df23f649144d61dc40d09c44a1c26b6"
-  integrity sha512-vbzEdpRCZl5+HXWsVjzSDqB9ZVIlqldV+udHp4YDD8qiwdQznVaBZke0eMzZ7kaInqRPsZ+UHQuVk6JaH/JkMQ==
+"@rspack/binding-darwin-arm64@npm:@rspack-canary/binding-darwin-arm64@1.3.6-canary-24c37390-20250417063019":
+  version "1.3.6-canary-24c37390-20250417063019"
+  resolved "https://registry.yarnpkg.com/@rspack-canary/binding-darwin-arm64/-/binding-darwin-arm64-1.3.6-canary-24c37390-20250417063019.tgz#333feef5d75bf85c95296a7fea43f690f18132aa"
+  integrity sha512-Sf/mfx2ggwEVoEFRQXEO0twPqLDjipRIMNZVJ3lMRz0zbqFlMlNN/aA+DL3zBJD8lp4Tjl8xVEqJz1SlTE6O1A==
 
-"@rspack/binding-darwin-x64@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.3.3.tgz#472ad3b6ae6c687bff1f4bb9a6f2d2ddbe3d1c19"
-  integrity sha512-OXtY2s4nlYtUXkeJt8TQKKNIcN7PI8yDq0nqI75OfJoS4u1ZmRXJ8IMeSALLo8I+xD2RAF79tf7yhM/Y/AaiKQ==
+"@rspack/binding-darwin-x64@npm:@rspack-canary/binding-darwin-x64@1.3.6-canary-24c37390-20250417063019":
+  version "1.3.6-canary-24c37390-20250417063019"
+  resolved "https://registry.yarnpkg.com/@rspack-canary/binding-darwin-x64/-/binding-darwin-x64-1.3.6-canary-24c37390-20250417063019.tgz#e471b1f4bf2f4792d8e450a6742f69adb22b107c"
+  integrity sha512-Spds7F0ADiFyBvG/SQfLx96j5PawGqAXcfYRjNEIWSaMkBP7TWxPp0vILlTPOH6wGCZZuHiJRzNSugm5CneYuQ==
 
-"@rspack/binding-linux-arm64-gnu@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.3.3.tgz#0df2ac7ab945df162073bdcdea20171df9ee5942"
-  integrity sha512-Lluq3RLYzyCMdXr/HyALKEPGsr+196x8Ccuy5AmIRosOdWuwtSiomSRH1Ka8REUFNHfYy5y9SzfmIZo/E0QEmg==
+"@rspack/binding-linux-arm64-gnu@npm:@rspack-canary/binding-linux-arm64-gnu@1.3.6-canary-24c37390-20250417063019":
+  version "1.3.6-canary-24c37390-20250417063019"
+  resolved "https://registry.yarnpkg.com/@rspack-canary/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.3.6-canary-24c37390-20250417063019.tgz#1e0bde2a4636df0a7b2592f311830e765bbeaaf4"
+  integrity sha512-XYBGds56/q+/ANy2Yf1fVVkibjQllfTFyroaGEJnOvnqE0wiXqTFgLnIZYrLrXjPeLFwMW5DXE50nPbN9wDPIg==
 
-"@rspack/binding-linux-arm64-musl@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.3.3.tgz#082d45d2a92255656cadf4ebe801dc09726140fa"
-  integrity sha512-PIsicXWjOqzmoOutUqxpMNkCoKo+8/wxDyKxHFeu+5WIAxVFphe2d3H5qvEjc2MasWSdRmAVn9XiuIj2LIXFzA==
+"@rspack/binding-linux-arm64-musl@npm:@rspack-canary/binding-linux-arm64-musl@1.3.6-canary-24c37390-20250417063019":
+  version "1.3.6-canary-24c37390-20250417063019"
+  resolved "https://registry.yarnpkg.com/@rspack-canary/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.3.6-canary-24c37390-20250417063019.tgz#1144d70ad5dac32ed88667dfa86b7d4f69712c61"
+  integrity sha512-bFReOifJBT1HoKzAm54fwfMstS+RghnGVxi3MPfsbywfziWNJJ+gBlEoGxyo69dQNAHHXasKZXfn4MrK+/+LeQ==
 
-"@rspack/binding-linux-x64-gnu@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.3.3.tgz#2be5a5eff56c3dd2f58ff7e42abe3c9484d42b20"
-  integrity sha512-BtksK73ZFdny2T/wU1x0kxBF4ruYUUArZDyeGfpO+vd/1nNYqzzdhGvOksKmtdvsO38ETr2gZ9+XZyr1vpy9uQ==
+"@rspack/binding-linux-x64-gnu@npm:@rspack-canary/binding-linux-x64-gnu@1.3.6-canary-24c37390-20250417063019":
+  version "1.3.6-canary-24c37390-20250417063019"
+  resolved "https://registry.yarnpkg.com/@rspack-canary/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.3.6-canary-24c37390-20250417063019.tgz#747a4bd3a416ea1f8fa6d7ba977c2b3995d3bdf3"
+  integrity sha512-FB+k8u3bCpoGkVFKk11F3axbTkVZtn4aoRqegp009ltuLIPJpVq8evDGOhtB4oRsAV9DoncK2xNWjOYzIR0AfA==
 
-"@rspack/binding-linux-x64-musl@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.3.3.tgz#019d02dbcc25e0c16ca01f67bebf4b6bde3f4ae9"
-  integrity sha512-jx86CxkTmyBz/eHDqZp1mCqBwY+UTEtaPlPoWFyGkJUR5ey6nQnxS+fhG34Rqz63chW+q/afwpGNGyALYdgc8g==
+"@rspack/binding-linux-x64-musl@npm:@rspack-canary/binding-linux-x64-musl@1.3.6-canary-24c37390-20250417063019":
+  version "1.3.6-canary-24c37390-20250417063019"
+  resolved "https://registry.yarnpkg.com/@rspack-canary/binding-linux-x64-musl/-/binding-linux-x64-musl-1.3.6-canary-24c37390-20250417063019.tgz#09d2a38cfcf7cce5765e5fbe6fd3b41d09acf67f"
+  integrity sha512-vQnIPX9GPXruAUPsMrNb82SBwDy+3DVYUyVAJ65v9R7v7hADfdHKVnU09vurIbKt4sOFSA4bdHgIj363bl3mLw==
 
-"@rspack/binding-win32-arm64-msvc@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.3.3.tgz#204b33735d9b5e2c96ec0419f1e2151d1c2c4bcf"
-  integrity sha512-uXAdDzajFToVrH3fCNVDP/uKQ9i5FQjJc2aYxsnhS9Su/CZB+UQsOecbq6MnIN2s0B9GBKBG8QdQEtS3RtC6Hg==
+"@rspack/binding-win32-arm64-msvc@npm:@rspack-canary/binding-win32-arm64-msvc@1.3.6-canary-24c37390-20250417063019":
+  version "1.3.6-canary-24c37390-20250417063019"
+  resolved "https://registry.yarnpkg.com/@rspack-canary/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.3.6-canary-24c37390-20250417063019.tgz#4f1780e8f231e61eab056c85eae463ad0eb30e0d"
+  integrity sha512-vO5HVVoHIuj+0ptP2b44wkv1z8R/hGcg7ZoahPwUXVWS05rVNnruLvtYC7rQuauQfPXSHHDhR/4xCi/tBp/g3w==
 
-"@rspack/binding-win32-ia32-msvc@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.3.3.tgz#66fe0ebd3b44c34393862693d7bbb8fc68624504"
-  integrity sha512-VBE6XsJ3IiAlozAywAIxAZ1Aqc2QVnEwBo0gP9998KkwL7wxB6Bg/OJnPbH3Q0ZaNWAQViC99rPC+5hSIdeSxw==
+"@rspack/binding-win32-ia32-msvc@npm:@rspack-canary/binding-win32-ia32-msvc@1.3.6-canary-24c37390-20250417063019":
+  version "1.3.6-canary-24c37390-20250417063019"
+  resolved "https://registry.yarnpkg.com/@rspack-canary/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.3.6-canary-24c37390-20250417063019.tgz#b5b76be097a591f70392c3655d157350eeeda5cd"
+  integrity sha512-oe8zjum/0nu/IlCpK+7rXiQ0lAvCthVfgnx+AzKuKqOWVkWhCmNFIPqL8QfJI5/6UoNQj59m4MWod7VH9qUOlg==
 
-"@rspack/binding-win32-x64-msvc@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.3.3.tgz#d17a96dbb7cb5730742127c58dc3bec3f6f39333"
-  integrity sha512-rOsNz4/DFgSENjEh0t9kFn89feuXK14/9wbmmFlT8VMpYOCcj4tKcAHjWg+Nzzj4FL+NSOC/81SrUF9J+C2R7w==
+"@rspack/binding-win32-x64-msvc@npm:@rspack-canary/binding-win32-x64-msvc@1.3.6-canary-24c37390-20250417063019":
+  version "1.3.6-canary-24c37390-20250417063019"
+  resolved "https://registry.yarnpkg.com/@rspack-canary/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.3.6-canary-24c37390-20250417063019.tgz#e276b15629164491a70f9b28c510f3e011f33d3f"
+  integrity sha512-BkhxV6PuL9nwt8KdOXwUsiMzn/GN9CdIke3O6HyF9KK1K9znB4pLhytOVn1MrCdHOdFtLvBq6+ntgWDS+oX+PA==
 
-"@rspack/binding@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@rspack/binding/-/binding-1.3.3.tgz#19c104b7eed3bb01ec6089cee9f08d41acc035a4"
-  integrity sha512-zdwJ801tyC8k+Gu5RjNoc7bEtX0MgJzzVv9qpaMwcAUfUfwZgCzXPTqcGMDoNI+Z47Fw59/2fKCmgZhZn60AgA==
+"@rspack/binding@npm:@rspack-canary/binding@1.3.6-canary-24c37390-20250417063019":
+  version "1.3.6-canary-24c37390-20250417063019"
+  resolved "https://registry.yarnpkg.com/@rspack-canary/binding/-/binding-1.3.6-canary-24c37390-20250417063019.tgz#0cff7751dfc0dcac6f1c25636dfe1e12438a8cf1"
+  integrity sha512-BwIGpeXjwMY7MMvRbwnR/F+2QoJSwxJvL9XHuJfUUXC9vwnw5FDiiG9dQRhOSxY/nXJk1O7wNRvcUY/93KUAcw==
   optionalDependencies:
-    "@rspack/binding-darwin-arm64" "1.3.3"
-    "@rspack/binding-darwin-x64" "1.3.3"
-    "@rspack/binding-linux-arm64-gnu" "1.3.3"
-    "@rspack/binding-linux-arm64-musl" "1.3.3"
-    "@rspack/binding-linux-x64-gnu" "1.3.3"
-    "@rspack/binding-linux-x64-musl" "1.3.3"
-    "@rspack/binding-win32-arm64-msvc" "1.3.3"
-    "@rspack/binding-win32-ia32-msvc" "1.3.3"
-    "@rspack/binding-win32-x64-msvc" "1.3.3"
+    "@rspack/binding-darwin-arm64" "npm:@rspack-canary/binding-darwin-arm64@1.3.6-canary-24c37390-20250417063019"
+    "@rspack/binding-darwin-x64" "npm:@rspack-canary/binding-darwin-x64@1.3.6-canary-24c37390-20250417063019"
+    "@rspack/binding-linux-arm64-gnu" "npm:@rspack-canary/binding-linux-arm64-gnu@1.3.6-canary-24c37390-20250417063019"
+    "@rspack/binding-linux-arm64-musl" "npm:@rspack-canary/binding-linux-arm64-musl@1.3.6-canary-24c37390-20250417063019"
+    "@rspack/binding-linux-x64-gnu" "npm:@rspack-canary/binding-linux-x64-gnu@1.3.6-canary-24c37390-20250417063019"
+    "@rspack/binding-linux-x64-musl" "npm:@rspack-canary/binding-linux-x64-musl@1.3.6-canary-24c37390-20250417063019"
+    "@rspack/binding-win32-arm64-msvc" "npm:@rspack-canary/binding-win32-arm64-msvc@1.3.6-canary-24c37390-20250417063019"
+    "@rspack/binding-win32-ia32-msvc" "npm:@rspack-canary/binding-win32-ia32-msvc@1.3.6-canary-24c37390-20250417063019"
+    "@rspack/binding-win32-x64-msvc" "npm:@rspack-canary/binding-win32-x64-msvc@1.3.6-canary-24c37390-20250417063019"
 
-"@rspack/core@^1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@rspack/core/-/core-1.3.3.tgz#1eba8c52878ab898e2c06cfbffd3ee32881e8054"
-  integrity sha512-+mXVlFcYr0tWezZfJ/gR0fj8njRc7pzEMtTFa2NO5cfsNAKPF/SXm4rb55kfa63r0b3U3N7f2nKrJG9wyG7zMQ==
+"@rspack/core@npm:@rspack-canary/core@1.3.6-canary-24c37390-20250417063019":
+  version "1.3.6-canary-24c37390-20250417063019"
+  resolved "https://registry.yarnpkg.com/@rspack-canary/core/-/core-1.3.6-canary-24c37390-20250417063019.tgz#b012945d16d4c104098feb3fd4cda0b39afb1f51"
+  integrity sha512-AF4Mo6i3m6dByA7lftY3rW4Mel/fRWeb+er3hZXxa/MKpzvadoVwKEq1V2pb+Wykls1bEhnUUPTn7aFmbCPxRA==
   dependencies:
-    "@module-federation/runtime-tools" "0.11.2"
-    "@rspack/binding" "1.3.3"
+    "@module-federation/runtime-tools" "0.12.0"
+    "@rspack/binding" "npm:@rspack-canary/binding@1.3.6-canary-24c37390-20250417063019"
     "@rspack/lite-tapable" "1.0.1"
-    caniuse-lite "^1.0.30001707"
+    caniuse-lite "^1.0.30001713"
 
 "@rspack/lite-tapable@1.0.1":
   version "1.0.1"
@@ -5911,10 +5911,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001669, caniuse-lite@^1.0.30001707:
-  version "1.0.30001712"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001712.tgz#41ee150f12de11b5f57c5889d4f30deb451deedf"
-  integrity sha512-MBqPpGYYdQ7/hfKiet9SCI+nmN5/hp4ZzveOJubl5DTAMa5oggjAuoi0Z4onBpKPFI2ePGnQuQIzF3VxDjDJig==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001669, caniuse-lite@^1.0.30001713:
+  version "1.0.30001714"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001714.tgz#cfd27ff07e6fa20a0f45c7a10d28a0ffeaba2122"
+  integrity sha512-mtgapdwDLSSBnCI3JokHM7oEQBLxiJKVRtg10AxM1AyeiKcM96f0Mkbqeq+1AbiCtvMcHRulAAEMu693JrSWqg==
 
 ccount@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
## Motivation

The Rspack persistent cache was enabled in Docusaurus with https://github.com/facebook/docusaurus/pull/10931

Unfortunately, the performance improvement wasn't significant because code-generated files would always recompile/reload, even if their content/hash didn't change. 

After our feedback in https://github.com/web-infra-dev/rspack/issues/9413, with v1.3.6, Rspack is changing its default strategy for the persistent cache, using a file content hash instead of the filesystem lastModified time.

This PR significantly improves the efficiency of the Rspack persistent cache, so that warm rebuilds will bundle the app faster, by avoiding recompiling all the code-generated files.

Many code-generated files are generated by Docusaurus core in `website/.docusaurus`, but they can also be generated by plugins that generate MDX files (often the case of docsgen plugin like OpenAPI).

This upgrade affects the speed of both the dev server and the production build.

On our own website, we use a custom [changelog plugin](https://docusaurus.io/changelog/) which is a fork of the blog plugin that does MDX codegen. We can see that it's now faster on prod builds, and the persistent cache also significantly improve the startup time of the dev server (on 2nd startups).


## Benchmarks

Impact of the persistent cache on total build times:
- Small site: 15.8s -> 9.3s (previously 10.4s)
- Medium site: 37.4s -> 24.9s (previously 29.7s)

Note: 
- Those numbers represent the impact on the average build time, and not just the bundling phase
- The bundling phase is likely to be at least x2-x3 faster with the Rspack persistent cache enabled
- Other Docusaurus phases (such as the SSG phase, which happens just after bundling) are also expensive to run.
- The persistent cache of Rspack is still in active development and will keep improving in the future (see https://rspack.dev/blog/announcing-1-2#persistent-cache)

### Cold build

Small site

```bash
yarn clear:website
hyperfine --runs 5 'DOCUSAURUS_NO_PERSISTENT_CACHE=true yarn build:website:fast'

Benchmark 1: DOCUSAURUS_NO_PERSISTENT_CACHE=true yarn build:website:fast
  Time (mean ± σ):     15.878 s ±  1.077 s    [User: 49.951 s, System: 8.975 s]
  Range (min … max):   14.507 s … 17.140 s    5 runs
```

Medium site

```bash
yarn clear:website
hyperfine --runs 5 'DOCUSAURUS_NO_PERSISTENT_CACHE=true yarn build:website --locale en'

Benchmark 1: DOCUSAURUS_NO_PERSISTENT_CACHE=true yarn build:website --locale en
  Time (mean ± σ):     37.432 s ±  1.609 s    [User: 130.666 s, System: 20.958 s]
  Range (min … max):   34.742 s … 38.823 s    5 runs
```

### Warm build - before upgrading

Small site

```bash
yarn clear:website
yarn build:website:fast
hyperfine --runs 5 'yarn build:website:fast'

Benchmark 1: yarn build:website:fast
  Time (mean ± σ):     10.442 s ±  0.878 s    [User: 33.773 s, System: 7.245 s]
  Range (min … max):    9.524 s … 11.599 s    5 runs
```

Medium site

```bash
yarn clear:website
yarn build:website --locale en
hyperfine --runs 5 'yarn build:website --locale en'

Benchmark 1: yarn build:website --locale en
  Time (mean ± σ):     29.721 s ±  2.407 s    [User: 103.784 s, System: 19.332 s]
  Range (min … max):   27.340 s … 33.297 s    5 runs
```


### Warm build - after upgrading

Small site

```bash
yarn clear:website
yarn build:website:fast
hyperfine --runs 5 'yarn build:website:fast'

Benchmark 1: yarn build:website:fast
  Time (mean ± σ):      9.309 s ±  1.063 s    [User: 30.241 s, System: 7.210 s]
  Range (min … max):    7.975 s … 10.314 s    5 runs
```

Medium site


```bash
yarn clear:website
yarn build:website --locale en
hyperfine --runs 5 'yarn build:website --locale en'

Benchmark 1: yarn build:website --locale en
  Time (mean ± σ):     24.992 s ±  3.595 s    [User: 96.350 s, System: 19.542 s]
  Range (min … max):   22.522 s … 31.272 s    5 runs
```

## Test Plan

Local benchmarks on my M3 computer:


It should also speed up CI rebuilds

### Test links

https://deploy-preview-11114--docusaurus-2.netlify.app/
