### PR TITLE
fix Improper code sanitization on ChunkAssetPlugin() could lead to Cross-site Scripting 

### DIFF
--- a/packages/docusaurus/src/webpack/plugins/ChunkAssetPlugin.ts
+++ b/packages/docusaurus/src/webpack/plugins/ChunkAssetPlugin.ts
@@ -18,6 +18,24 @@ const DocusaurusGetChunkAssetFn = '__webpack_require__.gca';
 
 const PluginName = 'Docusaurus-ChunkAssetPlugin';
 
+function escapeUnsafeChars(str: string): string {
+  const charMap: Record<string, string> = {
+    '<': '\\u003C',
+    '>': '\\u003E',
+    '/': '\\u002F',
+    '\\': '\\\\',
+    '\b': '\\b',
+    '\f': '\\f',
+    '\n': '\\n',
+    '\r': '\\r',
+    '\t': '\\t',
+    '\0': '\\0',
+    '\u2028': '\\u2028',
+    '\u2029': '\\u2029',
+  };
+  return str.replace(/[<>\b\f\n\r\t\0\u2028\u2029]/g, (x) => charMap[x]);
+}
+
 function generateGetChunkAssetRuntimeCode(chunk: webpack.Chunk): string {
   const chunkIdToName = chunk.getChunkMaps(false).name;
   const chunkNameToId = Object.fromEntries(
@@ -40,8 +58,8 @@ function generateGetChunkAssetRuntimeCode(chunk: webpack.Chunk): string {
   } = webpack.RuntimeGlobals;
 
   const code = `// Docusaurus function to get chunk asset
-${DocusaurusGetChunkAssetFn} = function(chunkId) { chunkId = ${JSON.stringify(
-    chunkNameToId,
+${DocusaurusGetChunkAssetFn} = function(chunkId) { chunkId = ${escapeUnsafeChars(
+    JSON.stringify(chunkNameToId),
   )}[chunkId]||chunkId; return ${publicPath} + ${getChunkScriptFilename}(chunkId); };`;
 
   return webpack.Template.asString(code);


### PR DESCRIPTION
https://github.com/facebook/docusaurus/blob/67924ca9795c4cd0399c752b4345f515bcedcaf6/packages/docusaurus/src/webpack/plugins/ChunkAssetPlugin.ts#L43-L45


fix the issue sanitize the output of `JSON.stringify(chunkNameToId)` to ensure that any potentially unsafe characters are escaped. This can be achieved by implementing a utility function, `escapeUnsafeChars`, which replaces unsafe characters with their Unicode escape sequences. We will then apply this function to the serialized string before embedding it into the dynamically constructed code.

---


Using string concatenation to construct JavaScript code can be error-prone, or in the worst case, enable code injection if an input is constructed by an attacker. below constructs a function that assigns the number 42 to the property `key` on an object `obj`. However, if `key` contains `</script>`, then the generated code will break out of a `</script>` if inserted into a `</script>` tag.

```ts
function createObjectWrite() {
    const assignment = `obj[${JSON.stringify(key)}]=42`;
    return `(function(){${assignment}})` // NOT OK
}
```
The issue has been fixed by escaping potentially dangerous characters, as shown below.
```ts
const charMap = {
    '<': '\\u003C',
    '>' : '\\u003E',
    '/': '\\u002F',
    '\\': '\\\\',
    '\b': '\\b',
    '\f': '\\f',
    '\n': '\\n',
    '\r': '\\r',
    '\t': '\\t',
    '\0': '\\0',
    '\u2028': '\\u2028',
    '\u2029': '\\u2029'
};

function escapeUnsafeChars(str) {
    return str.replace(/[<>\b\f\n\r\t\0\u2028\u2029]/g, x => charMap[x])
}

function createObjectWrite() {
    const assignment = `obj[${escapeUnsafeChars(JSON.stringify(key))}]=42`;
    return `(function(){${assignment}})` // OK
}
```

## References
[Code Injection](https://www.owasp.org/index.php/Code_Injection)
[CWE-94](https://cwe.mitre.org/data/definitions/94.html)
[CWE-79](https://cwe.mitre.org/data/definitions/79.html)
[CWE-116](https://cwe.mitre.org/data/definitions/116.html)

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.
