### PR TITLE
fix: Improve accessibility of live code block header (improves lighthouse a11y score)

### DIFF
--- a/packages/docusaurus-theme-live-codeblock/src/theme/Playground/Header/styles.module.css
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/Playground/Header/styles.module.css
@@ -16,6 +16,6 @@
 }
 
 .playgroundHeader:first-of-type {
-  background: var(--ifm-color-emphasis-600);
+  background: var(--ifm-color-emphasis-700);
   color: var(--ifm-color-content-inverse);
 }


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan. -> issue submitted; wasn't sure if it was minor enough for a proposal https://github.com/facebook/docusaurus/issues/11119

## Motivation

It's a bug that the title of the live code block does not have a WCAG 2.0 contrast level. 

## Test Plan

1. Go to a page with a live code block in light mode
2. Hover over the title Live Editor with inspector
3. See now-passing contrast check 
4. Go to dark mode
5. See the still-passing contrast check

### Before 

- Content and background do not pass 4.5 contrast check at 3.06 https://docusaurus.io/docs/markdown-features/code-blocks#interactive-code-editor

![Screenshot 2025-04-21 at 4 51 32 PM](https://github.com/user-attachments/assets/9373a3fb-84fe-4e8f-ab74-d67eefb8e8db)
![Screenshot 2025-04-21 at 4 51 49 PM](https://github.com/user-attachments/assets/f3cb594e-1e61-46e4-a1bc-1443c1751b84)

### After 

- Content and background pass 4.5 contrast check in light mode now as well as dark mode
- https://deploy-preview-11120--docusaurus-2.netlify.app/docs/markdown-features/code-blocks/#interactive-code-editor
![Screenshot 2025-04-21 at 4 49 03 PM](https://github.com/user-attachments/assets/18ee1497-a5a3-45ed-8d15-e9279c7ce9c3)
![Screenshot 2025-04-21 at 4 50 34 PM](https://github.com/user-attachments/assets/9a3e278d-9155-42d8-81a0-f777be8d3ad5)

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

[Deploy preview: https://deploy-preview-11120--docusaurus-2.netlify.app/](https://deploy-preview-11120--docusaurus-2.netlify.app/)

## Related issues/PRs

- My issue created https://github.com/facebook/docusaurus/issues/11119
- Dark mode support in pr https://github.com/facebook/docusaurus/pull/2767
