### PR TITLE
fix(theme): restore former code block theme-common internal APIs

### DIFF
--- a/packages/docusaurus-theme-common/src/internal.ts
+++ b/packages/docusaurus-theme-common/src/internal.ts
@@ -41,6 +41,7 @@ export {
   useCodeBlockContext,
 
   // TODO Docusaurus v4: remove, only kept for internal retro-compatibility
+  //  See https://github.com/facebook/docusaurus/pull/11153
   parseCodeBlockTitle,
   parseClassNameLanguage as parseLanguage,
   parseLines,

--- a/packages/docusaurus-theme-common/src/internal.ts
+++ b/packages/docusaurus-theme-common/src/internal.ts
@@ -39,6 +39,13 @@ export {
   getPrismCssVariables,
   CodeBlockContextProvider,
   useCodeBlockContext,
+
+  // TODO Docusaurus v4: remove, only kept for internal retro-compatibility
+  parseCodeBlockTitle,
+  parseClassNameLanguage as parseLanguage,
+  parseLines,
+  getLineNumbersStart,
+  containsLineNumbers,
 } from './utils/codeBlockUtils';
 
 export {DEFAULT_SEARCH_TAG} from './utils/searchUtils';

--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.tsx
@@ -188,6 +188,11 @@ export function getLineNumbersStart({
   return getMetaLineNumbersStart(metastring);
 }
 
+// TODO Docusaurus v4: remove, only kept for internal retro-compatibility
+export function containsLineNumbers(metastring?: string): boolean {
+  return Boolean(metastring?.includes('showLineNumbers'));
+}
+
 type ParseCodeLinesParam = {
   /**
    * The full metastring, as received from MDX. Line ranges declared here

--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.tsx
@@ -189,6 +189,7 @@ export function getLineNumbersStart({
 }
 
 // TODO Docusaurus v4: remove, only kept for internal retro-compatibility
+//  See https://github.com/facebook/docusaurus/pull/11153
 export function containsLineNumbers(metastring?: string): boolean {
   return Boolean(metastring?.includes('showLineNumbers'));
 }

--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -374,12 +374,96 @@ Add these two workflow files:
 
 :::warning Tweak the parameters for your setup
 
-These files assume you are using Yarn. If you use npm, change `cache: yarn`, `yarn install --frozen-lockfile`, `yarn build` to `cache: npm`, `npm ci`, `npm run build` accordingly.
-
 If your Docusaurus project is not at the root of your repo, you may need to configure a [default working directory](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-set-the-default-shell-and-working-directory), and adjust the paths accordingly.
 
 :::
 
+<Tabs>
+  <TabItem value="npm" label="npm">
+```yml title=".github/workflows/deploy.yml"
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    # Review gh actions docs if you want to further define triggers, paths, etc
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
+
+jobs:
+  build:
+    name: Build Docusaurus
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+      - name: Build website
+        run: npm build
+
+      - name: Upload Build Artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+```
+
+```yml title=".github/workflows/test-deploy.yml"
+name: Test deployment
+
+on:
+  pull_request:
+    branches:
+      - main
+    # Review gh actions docs if you want to further define triggers, paths, etc
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
+
+jobs:
+  test-deploy:
+    name: Test deployment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+      - name: Test build website
+        run: npm build
+```
+  </TabItem>
+  <TabItem value="yarn" label="Yarn">
 ```yml title=".github/workflows/deploy.yml"
 name: Deploy to GitHub Pages
 
@@ -462,6 +546,8 @@ jobs:
       - name: Test build website
         run: yarn build
 ```
+  </TabItem>
+</Tabs>
 
 </details>
 


### PR DESCRIPTION


## Motivation

It's preferable to keep retro-compatibility on these APIs even if they are not officially public API surface.

Various sites swizzled the code block components and would have to upgrade.

We also have third-party plugins using these APIs, for example:

https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/blob/main/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ApiCodeBlock/Content/String.tsx

```ts
import {
  parseCodeBlockTitle,
  parseLanguage,
  parseLines,
  containsLineNumbers,
  useCodeWordWrap,
} from "@docusaurus/theme-common/internal";
```

## Test Plan

Will test on third-party sites / canary
