### PR TITLE
fix: fix docs lint issue

### DIFF
--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -380,6 +380,7 @@ If your Docusaurus project is not at the root of your repo, you may need to conf
 
 <Tabs>
   <TabItem value="npm" label="npm">
+
 ```yml title=".github/workflows/deploy.yml"
 name: Deploy to GitHub Pages
 
@@ -462,8 +463,10 @@ jobs:
       - name: Test build website
         run: npm build
 ```
+
   </TabItem>
   <TabItem value="yarn" label="Yarn">
+
 ```yml title=".github/workflows/deploy.yml"
 name: Deploy to GitHub Pages
 
@@ -546,6 +549,7 @@ jobs:
       - name: Test build website
         run: yarn build
 ```
+
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
Linter is unhappy about https://github.com/facebook/docusaurus/pull/11145 and tries to reformat yaml code blocks