### PR TITLE
feat(core): add internal flag to skip bundling

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -324,7 +324,7 @@ export default async function createConfigAsync() {
           showLastUpdateTime: true,
         } satisfies DocsOptions,
       ],
-      [
+      !process.env.DOCUSAURUS_SKIP_BUNDLING && [
         'client-redirects',
         {
           fromExtensions: ['html'],


### PR DESCRIPTION

## Motivation

To benchmark SSG or troubleshoot memory problems, it can be time consuming depending on the size of a test site.

For example, this one takes 20min to bundle locally: https://github.com/facebook/docusaurus/discussions/11140

This env variable permits me to "focus" on the SSG part of Docusaurus so that I can optimize it in isolation.

It is mostly for internal usage. It is not considered a public API surface, and we may remove/refactor it at any time in minor versions.

## Test Plan

```bash
yarn install

# bundles, and does not cleanup the server bundle used for SSG
DOCUSAURUS_KEEP_SERVER_BUNDLE=true yarn build:website:fast

# skip bundling, and reuse the former server bundle for SSG
DOCUSAURUS_KEEP_SERVER_BUNDLE=true DOCUSAURUS_SKIP_BUNDLING=true yarn build:website:fast
```
