### PR TITLE
perf(core): optimize SSG collected data memory and worker thread communication

### DIFF
--- a/packages/docusaurus-logger/src/perfLogger.ts
+++ b/packages/docusaurus-logger/src/perfLogger.ts
@@ -73,12 +73,12 @@ function createPerfLogger(): PerfLoggerAPI {
   };
 
   const formatMemory = (memory: Memory): string => {
-    const fmtHead = (bytes: number) =>
+    const fmtHeap = (bytes: number) =>
       logger.cyan(`${(bytes / 1000000).toFixed(0)}mb`);
     return logger.dim(
-      `(${fmtHead(memory.before.heapUsed)} -> ${fmtHead(
+      `(Heap ${fmtHeap(memory.before.heapUsed)} -> ${fmtHeap(
         memory.after.heapUsed,
-      )})`,
+      )} / Total ${fmtHeap(memory.after.heapTotal)})`,
     );
   };
 

--- a/packages/docusaurus-logger/src/perfLogger.ts
+++ b/packages/docusaurus-logger/src/perfLogger.ts
@@ -72,13 +72,23 @@ function createPerfLogger(): PerfLoggerAPI {
     }
   };
 
-  const formatMemory = (memory: Memory): string => {
-    const fmtHeap = (bytes: number) =>
-      logger.cyan(`${(bytes / 1000000).toFixed(0)}mb`);
+  const formatBytesToMb = (bytes: number) =>
+    logger.cyan(`${(bytes / 1024 / 1024).toFixed(0)}mb`);
+
+  const formatMemoryDelta = (memory: Memory): string => {
     return logger.dim(
-      `(Heap ${fmtHeap(memory.before.heapUsed)} -> ${fmtHeap(
+      `(Heap ${formatBytesToMb(memory.before.heapUsed)} -> ${formatBytesToMb(
         memory.after.heapUsed,
-      )} / Total ${fmtHeap(memory.after.heapTotal)})`,
+      )} / Total ${formatBytesToMb(memory.after.heapTotal)})`,
+    );
+  };
+
+  const formatMemoryCurrent = (): string => {
+    const memory = getMemory();
+    return logger.dim(
+      `(Heap ${formatBytesToMb(memory.heapUsed)} / Total ${formatBytesToMb(
+        memory.heapTotal,
+      )})`,
     );
   };
 
@@ -103,7 +113,7 @@ function createPerfLogger(): PerfLoggerAPI {
     console.log(
       `${PerfPrefix}${formatStatus(error)} ${label} - ${formatDuration(
         duration,
-      )} - ${formatMemory(memory)}`,
+      )} - ${formatMemoryDelta(memory)}`,
     );
   };
 
@@ -144,7 +154,9 @@ function createPerfLogger(): PerfLoggerAPI {
   };
 
   const log: PerfLoggerAPI['log'] = (label: string) =>
-    console.log(`${PerfPrefix} ${applyParentPrefix(label)}`);
+    console.log(
+      `${PerfPrefix} ${applyParentPrefix(label)} - ${formatMemoryCurrent()}`,
+    );
 
   const async: PerfLoggerAPI['async'] = async (label, asyncFn) => {
     const finalLabel = applyParentPrefix(label);

--- a/packages/docusaurus/src/client/serverEntry.tsx
+++ b/packages/docusaurus/src/client/serverEntry.tsx
@@ -16,7 +16,7 @@ import {
   createStatefulBrokenLinks,
   BrokenLinksProvider,
 } from './BrokenLinksContext';
-import {toPageCollectedMetadata} from './serverHelmetUtils';
+import {toPageCollectedMetadataInternal} from './serverHelmetUtils';
 import type {AppRenderer, PageCollectedDataInternal} from '../common';
 
 const render: AppRenderer['render'] = async ({
@@ -47,7 +47,7 @@ const render: AppRenderer['render'] = async ({
 
   const {helmet} = helmetContext as FilledContext;
 
-  const metadata = toPageCollectedMetadata({helmet});
+  const metadata = toPageCollectedMetadataInternal({helmet});
 
   // TODO Docusaurus v4 remove with deprecated postBuild({head}) API
   //  the returned collectedData must be serializable to run in workers

--- a/packages/docusaurus/src/client/serverEntry.tsx
+++ b/packages/docusaurus/src/client/serverEntry.tsx
@@ -17,7 +17,7 @@ import {
   BrokenLinksProvider,
 } from './BrokenLinksContext';
 import {toPageCollectedMetadata} from './serverHelmetUtils';
-import type {PageCollectedData, AppRenderer} from '../common';
+import type {AppRenderer, PageCollectedDataInternal} from '../common';
 
 const render: AppRenderer['render'] = async ({
   pathname,
@@ -55,7 +55,7 @@ const render: AppRenderer['render'] = async ({
     metadata.helmet = null;
   }
 
-  const collectedData: PageCollectedData = {
+  const collectedData: PageCollectedDataInternal = {
     metadata,
     anchors: statefulBrokenLinks.getCollectedAnchors(),
     links: statefulBrokenLinks.getCollectedLinks(),

--- a/packages/docusaurus/src/client/serverHelmetUtils.tsx
+++ b/packages/docusaurus/src/client/serverHelmetUtils.tsx
@@ -6,7 +6,7 @@
  */
 
 import type {ReactElement} from 'react';
-import type {PageCollectedMetadata} from '../common';
+import type {PageCollectedMetadataInternal} from '../common';
 import type {HelmetServerState} from 'react-helmet-async';
 
 type BuildMetaTag = {name?: string; content?: string};
@@ -34,7 +34,7 @@ export function toPageCollectedMetadata({
   helmet,
 }: {
   helmet: HelmetServerState;
-}): PageCollectedMetadata {
+}): PageCollectedMetadataInternal {
   const tags = getBuildMetaTags(helmet);
   const noIndex = tags.some(isNoIndexTag);
 

--- a/packages/docusaurus/src/client/serverHelmetUtils.tsx
+++ b/packages/docusaurus/src/client/serverHelmetUtils.tsx
@@ -30,7 +30,7 @@ function isNoIndexTag(tag: BuildMetaTag): boolean {
   );
 }
 
-export function toPageCollectedMetadata({
+export function toPageCollectedMetadataInternal({
   helmet,
 }: {
   helmet: HelmetServerState;

--- a/packages/docusaurus/src/common.d.ts
+++ b/packages/docusaurus/src/common.d.ts
@@ -42,7 +42,9 @@ export type RouteBuildMetadataInternal = {
 
 export type PageCollectedMetadata = {
   public: RouteBuildMetadata;
-  helmet: HelmetServerState | null; // TODO Docusaurus v4 remove
+  // TODO Docusaurus v4 remove legacy unserializable helmet data structure
+  // See https://github.com/facebook/docusaurus/pull/10850
+  helmet: HelmetServerState | null;
 };
 
 // This data structure must remain serializable!

--- a/packages/docusaurus/src/common.d.ts
+++ b/packages/docusaurus/src/common.d.ts
@@ -13,7 +13,7 @@ import type {RouteBuildMetadata} from '@docusaurus/types';
 
 export type AppRenderResult = {
   html: string;
-  collectedData: PageCollectedData;
+  collectedData: PageCollectedDataInternal;
 };
 
 export type AppRenderer = {
@@ -40,21 +40,28 @@ export type RouteBuildMetadataInternal = {
   script: string;
 };
 
-// This data structure must remain serializable!
-// See why: https://github.com/facebook/docusaurus/pull/10826
 export type PageCollectedMetadata = {
   public: RouteBuildMetadata;
-  internal: RouteBuildMetadataInternal;
-  // TODO Docusaurus v4 remove legacy unserializable helmet data structure
-  // See https://github.com/facebook/docusaurus/pull/10850
   helmet: HelmetServerState | null;
+};
+
+// This data structure must remain serializable!
+// See why: https://github.com/facebook/docusaurus/pull/10826
+export type PageCollectedMetadataInternal = PageCollectedMetadata & {
+  internal: RouteBuildMetadataInternal;
+};
+
+export type PageCollectedDataInternal = {
+  metadata: PageCollectedMetadataInternal;
+  modules: string[];
+  links: string[];
+  anchors: string[];
 };
 
 export type PageCollectedData = {
   metadata: PageCollectedMetadata;
-  links: string[];
-  anchors: string[];
-  modules: string[];
+  links: PageCollectedDataInternal['links'];
+  anchors: PageCollectedDataInternal['anchors'];
 };
 
 export type SiteCollectedData = {

--- a/packages/docusaurus/src/common.d.ts
+++ b/packages/docusaurus/src/common.d.ts
@@ -42,13 +42,20 @@ export type RouteBuildMetadataInternal = {
 
 export type PageCollectedMetadata = {
   public: RouteBuildMetadata;
-  helmet: HelmetServerState | null;
+  helmet: HelmetServerState | null; // TODO Docusaurus v4 remove
 };
 
 // This data structure must remain serializable!
 // See why: https://github.com/facebook/docusaurus/pull/10826
 export type PageCollectedMetadataInternal = PageCollectedMetadata & {
-  internal: RouteBuildMetadataInternal;
+  internal: {
+    htmlAttributes: string;
+    bodyAttributes: string;
+    title: string;
+    meta: string;
+    link: string;
+    script: string;
+  };
 };
 
 export type PageCollectedDataInternal = {
@@ -58,12 +65,16 @@ export type PageCollectedDataInternal = {
   anchors: string[];
 };
 
+// Keep this data structure as small as possible
+// See https://github.com/facebook/docusaurus/pull/11162
 export type PageCollectedData = {
   metadata: PageCollectedMetadata;
-  links: PageCollectedDataInternal['links'];
-  anchors: PageCollectedDataInternal['anchors'];
+  links: string[];
+  anchors: string[];
 };
 
+// Keep this data structure as small as possible
+// See https://github.com/facebook/docusaurus/pull/11162
 export type SiteCollectedData = {
   [pathname: string]: PageCollectedData;
 };

--- a/packages/docusaurus/src/ssg/ssgRenderer.ts
+++ b/packages/docusaurus/src/ssg/ssgRenderer.ts
@@ -22,14 +22,18 @@ import {SSGConcurrency} from './ssgEnv';
 import {writeStaticFile} from './ssgUtils';
 import {createSSGRequire} from './ssgNodeRequire';
 import type {SSGParams} from './ssgParams';
-import type {AppRenderer, AppRenderResult} from '../common';
+import type {
+  AppRenderer,
+  PageCollectedData,
+  PageCollectedDataInternal,
+} from '../common';
 import type {HtmlMinifier} from '@docusaurus/bundler';
 
 export type SSGSuccess = {
   success: true;
   pathname: string;
   result: {
-    collectedData: AppRenderResult['collectedData'];
+    collectedData: PageCollectedData;
     warnings: string[];
     // html: we don't include it on purpose!
     // we don't need to aggregate all html contents in memory!
@@ -144,6 +148,24 @@ export async function loadSSGRenderer({
   };
 }
 
+// We reduce the page collected data structure after the HTML file is written
+// Some data (modules, metadata.internal) is only useful to create the HTML file
+// It's not useful to aggregate that collected data in memory
+function reduceCollectedData(
+  pageCollectedData: PageCollectedDataInternal,
+): PageCollectedData {
+  // We re-create the object from scratch
+  // We absolutely want to avoid TS duck typing
+  return {
+    anchors: pageCollectedData.anchors,
+    metadata: {
+      public: pageCollectedData.metadata.public,
+      helmet: pageCollectedData.metadata.helmet,
+    },
+    links: pageCollectedData.links,
+  };
+}
+
 async function generateStaticFile({
   pathname,
   appRenderer,
@@ -177,15 +199,13 @@ async function generateStaticFile({
       params,
     });
 
-    appRenderResult.collectedData.modules = [];
-    // @ts-expect-error: test
-    appRenderResult.collectedData.metadata.internal = null;
+    const collectedData = reduceCollectedData(appRenderResult.collectedData);
 
     return {
       success: true,
       pathname,
       result: {
-        collectedData: appRenderResult.collectedData,
+        collectedData,
         // As of today, only the html minifier can emit SSG warnings
         warnings: minifierResult.warnings,
       },

--- a/packages/docusaurus/src/ssg/ssgRenderer.ts
+++ b/packages/docusaurus/src/ssg/ssgRenderer.ts
@@ -176,6 +176,11 @@ async function generateStaticFile({
       content: minifierResult.code,
       params,
     });
+
+    appRenderResult.collectedData.modules = [];
+    // @ts-expect-error: test
+    appRenderResult.collectedData.metadata.internal = null;
+
     return {
       success: true,
       pathname,

--- a/packages/docusaurus/src/ssg/ssgRenderer.ts
+++ b/packages/docusaurus/src/ssg/ssgRenderer.ts
@@ -151,6 +151,8 @@ export async function loadSSGRenderer({
 // We reduce the page collected data structure after the HTML file is written
 // Some data (modules, metadata.internal) is only useful to create the HTML file
 // It's not useful to aggregate that collected data in memory
+// Keep this data structure as small as possible
+// See https://github.com/facebook/docusaurus/pull/11162
 function reduceCollectedData(
   pageCollectedData: PageCollectedDataInternal,
 ): PageCollectedData {


### PR DESCRIPTION


## Motivation

This is a fix for my https://github.com/facebook/docusaurus/issues/11161 about heavy collected data memory usage.

Some data is collected and is only useful during the SSG phase.

Once the HTML file is written, we'd like to release that now useless data asap on the worker thread before sending the result to the parent thread. This reduces aggregated site data in memory, and also reduces the size of the worker thread payloads.







## Benchmark

```bash
yarn clear:website && NODE_OPTIONS="--max-old-space-size=400 --expose-gc" yarn build:website --locale en
```

I didn't do a proper benchmark, but from simple logs we can see it improves both memory and time to execute.

Before:

```bash
[PERF] Build > en > SSG > Thread pool - 13.55 seconds! - (Heap 151mb -> 161mb / Total 209mb)
```

After:

```bash
[PERF] Build > en > SSG > Thread pool - 12.03 seconds! - (Heap 151mb -> 155mb / Total 200mb)
```



---

On a [large Docusaurus site with 11k docs](https://github.com/facebook/docusaurus/discussions/11140), I found out the difference can be quite significative (~500mb saved heap memory + reduced serialization cost)


