### PR TITLE
perf(utils): implement git command queue

### DIFF
--- a/packages/docusaurus-utils/package.json
+++ b/packages/docusaurus-utils/package.json
@@ -33,6 +33,7 @@
     "lodash": "^4.17.21",
     "micromatch": "^4.0.5",
     "prompts": "^2.4.2",
+    "p-queue": "^6.6.2",
     "resolve-pathname": "^3.0.0",
     "tslib": "^2.6.0",
     "url-loader": "^4.1.1",

--- a/packages/docusaurus-utils/src/gitUtils.ts
+++ b/packages/docusaurus-utils/src/gitUtils.ts
@@ -7,9 +7,14 @@
 
 import path from 'path';
 import fs from 'fs-extra';
+import os from 'os';
 import _ from 'lodash';
 import execa from 'execa';
 import PQueue from 'p-queue';
+
+// Quite high/conservative concurrency value (it was previously "Infinity")
+// See https://github.com/facebook/docusaurus/pull/10915
+const DefaultGitCommandConcurrency = os.availableParallelism() * 4;
 
 const GitCommandConcurrencyEnv = process.env.DOCUSAURUS_GIT_COMMAND_CONCURRENCY
   ? parseInt(process.env.DOCUSAURUS_GIT_COMMAND_CONCURRENCY, 10)
@@ -18,9 +23,7 @@ const GitCommandConcurrencyEnv = process.env.DOCUSAURUS_GIT_COMMAND_CONCURRENCY
 const GitCommandConcurrency =
   GitCommandConcurrencyEnv && GitCommandConcurrencyEnv > 0
     ? GitCommandConcurrencyEnv
-    : Infinity;
-
-console.log('GitCommandConcurrency', GitCommandConcurrency);
+    : DefaultGitCommandConcurrency;
 
 // We use a queue to avoid running too many concurrent Git commands at once
 // See https://github.com/facebook/docusaurus/issues/10348

--- a/packages/docusaurus-utils/src/gitUtils.ts
+++ b/packages/docusaurus-utils/src/gitUtils.ts
@@ -14,7 +14,11 @@ import PQueue from 'p-queue';
 
 // Quite high/conservative concurrency value (it was previously "Infinity")
 // See https://github.com/facebook/docusaurus/pull/10915
-const DefaultGitCommandConcurrency = os.availableParallelism() * 4;
+const DefaultGitCommandConcurrency =
+  // TODO Docusaurus v4: bump node, availableParallelism() now always exists
+  (typeof os.availableParallelism === 'function'
+    ? os.availableParallelism()
+    : os.cpus().length) * 4;
 
 const GitCommandConcurrencyEnv = process.env.DOCUSAURUS_GIT_COMMAND_CONCURRENCY
   ? parseInt(process.env.DOCUSAURUS_GIT_COMMAND_CONCURRENCY, 10)

--- a/packages/docusaurus/src/commands/build/buildLocale.ts
+++ b/packages/docusaurus/src/commands/build/buildLocale.ts
@@ -58,6 +58,10 @@ export async function buildLocale({
     }),
   );
 
+  if (process && site) {
+    process.exit(0);
+  }
+
   const {props} = site;
   const {outDir, plugins, siteConfig} = props;
 

--- a/packages/docusaurus/src/commands/build/buildLocale.ts
+++ b/packages/docusaurus/src/commands/build/buildLocale.ts
@@ -58,10 +58,6 @@ export async function buildLocale({
     }),
   );
 
-  if (process && site) {
-    process.exit(0);
-  }
-
   const {props} = site;
   const {outDir, plugins, siteConfig} = props;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8582,6 +8582,11 @@ eventemitter3@^4.0.0, eventemitter3@^4.0.4:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
+eventemitter3@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
+  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
+
 events@^3.2.0, events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
@@ -13917,6 +13922,14 @@ p-queue@6.6.2:
     eventemitter3 "^4.0.4"
     p-timeout "^3.2.0"
 
+p-queue@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-8.1.0.tgz#d71929249868b10b16f885d8a82beeaf35d32279"
+  integrity sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==
+  dependencies:
+    eventemitter3 "^5.0.1"
+    p-timeout "^6.1.2"
+
 p-reduce@2.1.0, p-reduce@^2.0.0, p-reduce@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-2.1.0.tgz#09408da49507c6c274faa31f28df334bc712b64a"
@@ -13936,6 +13949,11 @@ p-timeout@^3.2.0:
   integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
   dependencies:
     p-finally "^1.0.0"
+
+p-timeout@^6.1.2:
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-6.1.4.tgz#418e1f4dd833fa96a2e3f532547dd2abdb08dbc2"
+  integrity sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==
 
 p-try@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Motivation


Fix https://github.com/facebook/docusaurus/issues/10348

Avoids Node.js EBADF error on large Docusaurus sites due to running too many concurrent Git commands.

I choose `os.availableParallelism() * 4;` as an arbitrary default concurrency value. It's high on purpose to be conservative with the former behavior, which was Infinity. As my local benchmark shows, between 4 and Infinity, the performance impact is quite low anyway.

## Benchmark

It's hard to provide the perfect default value, but we can see on my Mac M3 Pro that:
- Concurrency 1 is the slowest
- Concurrency 0 (= Infinity) is slower than any concurrency > 4
- On my computer (12 cores), the sweet spot seems to be in between concurrency 10 -> 100

```bash
hyperfine --runs 4 \
'DOCUSAURUS_GIT_COMMAND_CONCURRENCY=0 yarn build:website --locale en' \
'DOCUSAURUS_GIT_COMMAND_CONCURRENCY=1 yarn build:website --locale en' \
'DOCUSAURUS_GIT_COMMAND_CONCURRENCY=2 yarn build:website --locale en' \
'DOCUSAURUS_GIT_COMMAND_CONCURRENCY=4 yarn build:website --locale en' \
'DOCUSAURUS_GIT_COMMAND_CONCURRENCY=8 yarn build:website --locale en' \
'DOCUSAURUS_GIT_COMMAND_CONCURRENCY=12 yarn build:website --locale en' \
'DOCUSAURUS_GIT_COMMAND_CONCURRENCY=16 yarn build:website --locale en' \
'DOCUSAURUS_GIT_COMMAND_CONCURRENCY=20 yarn build:website --locale en' \
'DOCUSAURUS_GIT_COMMAND_CONCURRENCY=24 yarn build:website --locale en' \
'DOCUSAURUS_GIT_COMMAND_CONCURRENCY=30 yarn build:website --locale en' \
'DOCUSAURUS_GIT_COMMAND_CONCURRENCY=40 yarn build:website --locale en' \
'DOCUSAURUS_GIT_COMMAND_CONCURRENCY=60 yarn build:website --locale en' \
'DOCUSAURUS_GIT_COMMAND_CONCURRENCY=100 yarn build:website --locale en'

Benchmark 1: DOCUSAURUS_GIT_COMMAND_CONCURRENCY=0 yarn build:website --locale en
  Time (mean ± σ):      4.255 s ±  1.074 s    [User: 12.487 s, System: 6.392 s]
  Range (min … max):    3.703 s …  5.866 s    4 runs
 
Benchmark 2: DOCUSAURUS_GIT_COMMAND_CONCURRENCY=1 yarn build:website --locale en
  Time (mean ± σ):     13.151 s ±  0.083 s    [User: 9.875 s, System: 3.586 s]
  Range (min … max):   13.061 s … 13.246 s    4 runs
 
Benchmark 3: DOCUSAURUS_GIT_COMMAND_CONCURRENCY=2 yarn build:website --locale en
  Time (mean ± σ):      7.614 s ±  0.023 s    [User: 9.894 s, System: 3.567 s]
  Range (min … max):    7.581 s …  7.633 s    4 runs
 
Benchmark 4: DOCUSAURUS_GIT_COMMAND_CONCURRENCY=4 yarn build:website --locale en
  Time (mean ± σ):      4.823 s ±  0.008 s    [User: 10.097 s, System: 3.688 s]
  Range (min … max):    4.817 s …  4.832 s    4 runs
 
Benchmark 5: DOCUSAURUS_GIT_COMMAND_CONCURRENCY=8 yarn build:website --locale en
  Time (mean ± σ):      3.698 s ±  0.016 s    [User: 11.257 s, System: 4.917 s]
  Range (min … max):    3.677 s …  3.716 s    4 runs
 
Benchmark 6: DOCUSAURUS_GIT_COMMAND_CONCURRENCY=12 yarn build:website --locale en
  Time (mean ± σ):      3.617 s ±  0.015 s    [User: 11.828 s, System: 5.437 s]
  Range (min … max):    3.601 s …  3.635 s    4 runs
 
Benchmark 7: DOCUSAURUS_GIT_COMMAND_CONCURRENCY=16 yarn build:website --locale en
  Time (mean ± σ):      3.615 s ±  0.024 s    [User: 11.915 s, System: 5.495 s]
  Range (min … max):    3.588 s …  3.647 s    4 runs
 
Benchmark 8: DOCUSAURUS_GIT_COMMAND_CONCURRENCY=20 yarn build:website --locale en
  Time (mean ± σ):      3.617 s ±  0.042 s    [User: 11.822 s, System: 5.472 s]
  Range (min … max):    3.579 s …  3.671 s    4 runs
 
Benchmark 9: DOCUSAURUS_GIT_COMMAND_CONCURRENCY=24 yarn build:website --locale en
  Time (mean ± σ):      3.600 s ±  0.007 s    [User: 11.873 s, System: 5.512 s]
  Range (min … max):    3.589 s …  3.604 s    4 runs
 
Benchmark 10: DOCUSAURUS_GIT_COMMAND_CONCURRENCY=30 yarn build:website --locale en
  Time (mean ± σ):      3.613 s ±  0.027 s    [User: 11.841 s, System: 5.496 s]
  Range (min … max):    3.589 s …  3.649 s    4 runs
 
Benchmark 11: DOCUSAURUS_GIT_COMMAND_CONCURRENCY=40 yarn build:website --locale en
  Time (mean ± σ):      3.623 s ±  0.012 s    [User: 11.872 s, System: 5.503 s]
  Range (min … max):    3.613 s …  3.639 s    4 runs
 
Benchmark 12: DOCUSAURUS_GIT_COMMAND_CONCURRENCY=60 yarn build:website --locale en
  Time (mean ± σ):      3.644 s ±  0.039 s    [User: 11.948 s, System: 5.574 s]
  Range (min … max):    3.616 s …  3.700 s    4 runs
 
Benchmark 13: DOCUSAURUS_GIT_COMMAND_CONCURRENCY=100 yarn build:website --locale en
  Time (mean ± σ):      3.650 s ±  0.027 s    [User: 11.985 s, System: 5.563 s]
  Range (min … max):    3.610 s …  3.669 s    4 runs
 
Summary
  DOCUSAURUS_GIT_COMMAND_CONCURRENCY=24 yarn build:website --locale en ran
    1.00 ± 0.01 times faster than DOCUSAURUS_GIT_COMMAND_CONCURRENCY=30 yarn build:website --locale en
    1.00 ± 0.01 times faster than DOCUSAURUS_GIT_COMMAND_CONCURRENCY=16 yarn build:website --locale en
    1.00 ± 0.00 times faster than DOCUSAURUS_GIT_COMMAND_CONCURRENCY=12 yarn build:website --locale en
    1.00 ± 0.01 times faster than DOCUSAURUS_GIT_COMMAND_CONCURRENCY=20 yarn build:website --locale en
    1.01 ± 0.00 times faster than DOCUSAURUS_GIT_COMMAND_CONCURRENCY=40 yarn build:website --locale en
    1.01 ± 0.01 times faster than DOCUSAURUS_GIT_COMMAND_CONCURRENCY=60 yarn build:website --locale en
    1.01 ± 0.01 times faster than DOCUSAURUS_GIT_COMMAND_CONCURRENCY=100 yarn build:website --locale en
    1.03 ± 0.00 times faster than DOCUSAURUS_GIT_COMMAND_CONCURRENCY=8 yarn build:website --locale en
    1.18 ± 0.30 times faster than DOCUSAURUS_GIT_COMMAND_CONCURRENCY=0 yarn build:website --locale en
    1.34 ± 0.00 times faster than DOCUSAURUS_GIT_COMMAND_CONCURRENCY=4 yarn build:website --locale en
    2.12 ± 0.01 times faster than DOCUSAURUS_GIT_COMMAND_CONCURRENCY=2 yarn build:website --locale en
    3.65 ± 0.02 times faster than DOCUSAURUS_GIT_COMMAND_CONCURRENCY=1 yarn build:website --locale en
```
