### PR TITLE
feat(core): expose opt-in env variable for SSG thread recycling

### DIFF
--- a/packages/docusaurus/src/ssg/ssgEnv.ts
+++ b/packages/docusaurus/src/ssg/ssgEnv.ts
@@ -29,6 +29,7 @@ export const SSGWorkerThreadTaskSize: number = process.env
   : 10; // TODO need fine-tuning
 
 // Controls worker thread recycling behavior (maxMemoryLimitBeforeRecycle)
+// See https://github.com/facebook/docusaurus/pull/11166
 // See https://github.com/facebook/docusaurus/issues/11161
 export const SSGWorkerThreadRecyclerMaxMemory: number | undefined = process.env
   .DOCUSAURUS_SSG_WORKER_THREAD_RECYCLER_MAX_MEMORY

--- a/packages/docusaurus/src/ssg/ssgEnv.ts
+++ b/packages/docusaurus/src/ssg/ssgEnv.ts
@@ -27,3 +27,13 @@ export const SSGWorkerThreadTaskSize: number = process.env
   .DOCUSAURUS_SSG_WORKER_THREAD_TASK_SIZE
   ? parseInt(process.env.DOCUSAURUS_SSG_WORKER_THREAD_TASK_SIZE, 10)
   : 10; // TODO need fine-tuning
+
+// Controls worker thread recycling behavior (maxMemoryLimitBeforeRecycle)
+// See https://github.com/facebook/docusaurus/issues/11161
+export const SSGWorkerThreadRecyclerMaxMemory: number | undefined = process.env
+  .DOCUSAURUS_SSG_WORKER_THREAD_RECYCLER_MAX_MEMORY
+  ? parseInt(process.env.DOCUSAURUS_SSG_WORKER_THREAD_RECYCLER_MAX_MEMORY, 10)
+  : // TODO we should probably provide a default value here
+    //  2gb is a quite reasonable max that should work well even for large sites
+    //  we'd rather ask community feedback first
+    undefined;

--- a/packages/docusaurus/src/ssg/ssgExecutor.ts
+++ b/packages/docusaurus/src/ssg/ssgExecutor.ts
@@ -12,7 +12,11 @@ import _ from 'lodash';
 import logger, {PerfLogger} from '@docusaurus/logger';
 import {createSSGParams} from './ssgParams';
 import {renderHashRouterTemplate} from './ssgTemplate';
-import {SSGWorkerThreadCount, SSGWorkerThreadTaskSize} from './ssgEnv';
+import {
+  SSGWorkerThreadCount,
+  SSGWorkerThreadRecyclerMaxMemory,
+  SSGWorkerThreadTaskSize,
+} from './ssgEnv';
 import {generateHashRouterEntrypoint} from './ssgUtils';
 import {createGlobalSSGResult} from './ssgGlobalResult';
 import {executeSSGInlineTask} from './ssgWorkerInline';
@@ -124,6 +128,15 @@ const createPooledSSGExecutor: CreateSSGExecutor = async ({
         runtime: 'worker_threads',
         isolateWorkers: false,
         workerData: {params},
+
+        // WORKER MEMORY MANAGEMENT
+        // Allows containing SSG memory leaks with a thread recycling workaround
+        // See also https://github.com/facebook/docusaurus/issues/11161
+        maxMemoryLimitBeforeRecycle: SSGWorkerThreadRecyclerMaxMemory,
+        resourceLimits: {
+          // For some reason I can't figure out how to limit memory on a worker
+          // See https://x.com/sebastienlorber/status/1920781195618513143
+        },
       });
     },
   );

--- a/packages/docusaurus/src/ssg/ssgExecutor.ts
+++ b/packages/docusaurus/src/ssg/ssgExecutor.ts
@@ -131,7 +131,8 @@ const createPooledSSGExecutor: CreateSSGExecutor = async ({
 
         // WORKER MEMORY MANAGEMENT
         // Allows containing SSG memory leaks with a thread recycling workaround
-        // See also https://github.com/facebook/docusaurus/issues/11161
+        // See https://github.com/facebook/docusaurus/pull/11166
+        // See https://github.com/facebook/docusaurus/issues/11161
         maxMemoryLimitBeforeRecycle: SSGWorkerThreadRecyclerMaxMemory,
         resourceLimits: {
           // For some reason I can't figure out how to limit memory on a worker


### PR DESCRIPTION
## Motivation

See issue https://github.com/facebook/docusaurus/issues/11161

During SSG, for large sites, the memory keeps growing.

Note:
- There's a separate heap for the parent thread, and each worker thread
- Each worker inherits the heap size from its parent (for example using `NODE_OPTIONS="--max-old-space-size=5000"`), and for some reason I couldn't figure out how to allocate a different heap size for a specific worker (see https://x.com/sebastienlorber/status/1920781195618513143)

If the main process is given 5gb and we have 5 workers each using up to 5gb too, that means potentially 30gb of memory, and the app is likely to swap, in particular if memory in workers keep growing and can't be collected. When this happens, SSG times increase significantly. Also, the user doesn't expect that Docusaurus would take more than 5gb, while in practice it can take much more.

For this reason, I'm adding an opt-in env variable to recycle SSG worker threads when they reach a certain amount of memory. To be conservative, we can keep it undefined, but in my experience on [this 11k docs site](https://github.com/facebook/docusaurus/discussions/11140), using a max value of 1-2 GB works fine.

In the future I think we should both:
- fix the SSG leaks: it's not always possible because the code of the users can leak too
- provide a sensible default value: I'd like to test this env var on a few large sites first, because if the site is super large and the value is too low, it would constantly recycle the threads, or always OOM. I think with 1.5 GB, it's already good enough for quite large sites, but we'll see. We can eventually try to set a lower value, and emit a good DX error message when recycling happens.


Note: Vitest/Jest also have thread recycling and uses a default strategy of `maxMemory = total memory / number of cpus`, see:
- https://vitest.dev/config/#pooloptions-vmthreads-memorylimit
- https://github.com/vitest-dev/vitest/blob/v3.1.3/packages/vitest/src/node/pools/vmThreads.ts#L207
- https://jestjs.io/docs/configuration#workeridlememorylimit-numberstring


## Test Plan

local + third-party sites


