### PR TITLE
chore: add Node 24 to CI + fix deprecation warnings

### DIFF
--- a/.github/workflows/argos.yml
+++ b/.github/workflows/argos.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: lts/*
+          cache: yarn
 
       - name: Install dependencies
         run: yarn || yarn || yarn

--- a/.github/workflows/lighthouse-report.yml
+++ b/.github/workflows/lighthouse-report.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: lts/*
+          cache: yarn
 
       - name: Install dependencies
         run: yarn || yarn || yarn

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['18.0', '20', '22']
+        node: ['18.0', '20', '22', '24']
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        node: ['18.0', '20', '22']
+        node: ['18.0', '20', '22', '24']
     steps:
       - name: Support longpaths
         run: git config --system core.longpaths true

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}
+          cache: yarn
       - name: Installation
         run: yarn || yarn || yarn
       - name: Docusaurus Jest Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['18.0', '20', '22']
+        node: ['18.0', '20', '22', '24']
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/packages/docusaurus-mdx-loader/src/remark/transformImage/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/transformImage/index.ts
@@ -14,6 +14,7 @@ import {
   escapePath,
   findAsyncSequential,
   getFileLoaderUtils,
+  parseURLOrPath,
 } from '@docusaurus/utils';
 import escapeHtml from 'escape-html';
 import {imageSizeFromFile} from 'image-size/fromFile';
@@ -50,7 +51,7 @@ async function toImageRequireNode(
   );
   relativeImagePath = `./${relativeImagePath}`;
 
-  const parsedUrl = url.parse(node.url);
+  const parsedUrl = parseURLOrPath(node.url, 'https://example.com');
   const hash = parsedUrl.hash ?? '';
   const search = parsedUrl.search ?? '';
   const requireString = `${context.inlineMarkdownImageFileLoader}${

--- a/packages/docusaurus-mdx-loader/src/remark/transformLinks/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/transformLinks/index.ts
@@ -14,6 +14,7 @@ import {
   escapePath,
   findAsyncSequential,
   getFileLoaderUtils,
+  parseURLOrPath,
 } from '@docusaurus/utils';
 import escapeHtml from 'escape-html';
 import {assetRequireAttributeValue, transformNode} from '../utils';
@@ -51,7 +52,7 @@ async function toAssetRequireNode(
     path.relative(path.dirname(context.filePath), assetPath),
   )}`;
 
-  const parsedUrl = url.parse(node.url);
+  const parsedUrl = parseURLOrPath(node.url);
   const hash = parsedUrl.hash ?? '';
   const search = parsedUrl.search ?? '';
 

--- a/packages/docusaurus-utils/src/urlUtils.ts
+++ b/packages/docusaurus-utils/src/urlUtils.ts
@@ -166,7 +166,8 @@ export function isValidPathname(str: string): boolean {
 
 export function parseURLOrPath(url: string, base?: string | URL): URL {
   try {
-    // TODO when Node supports it, use URL.parse could be faster?
+    // TODO Docusaurus v4: use URL.parse()
+    //  Node 24 supports it, use URL.parse could be faster?
     //  see https://kilianvalkhof.com/2024/javascript/the-problem-with-new-url-and-how-url-parse-fixes-that/
     return new URL(url, base ?? 'https://example.com');
   } catch (e) {


### PR DESCRIPTION

## Motivation

We'll upgrade to Node >= 24 for Docusaurus v4 so now is a good time to see if we are compatible

Also fix a `url.parse` deprecation warning, see also https://github.com/nodejs/node/pull/55017#issuecomment-2867085793

## Test Plan

CI

### Test links

https://deploy-preview-11168--docusaurus-2.netlify.app/


