### PR TITLE
perf(core): add default for DOCUSAURUS_SSG_WORKER_THREAD_RECYCLER_MAX_MEMORY

### DIFF
--- a/packages/docusaurus/src/ssg/ssgEnv.ts
+++ b/packages/docusaurus/src/ssg/ssgEnv.ts
@@ -34,7 +34,6 @@ export const SSGWorkerThreadTaskSize: number = process.env
 export const SSGWorkerThreadRecyclerMaxMemory: number | undefined = process.env
   .DOCUSAURUS_SSG_WORKER_THREAD_RECYCLER_MAX_MEMORY
   ? parseInt(process.env.DOCUSAURUS_SSG_WORKER_THREAD_RECYCLER_MAX_MEMORY, 10)
-  : // TODO we should probably provide a default value here
-    //  2gb is a quite reasonable max that should work well even for large sites
-    //  we'd rather ask community feedback first
-    undefined;
+  : // 1.5 GB is a quite reasonable max value
+    // It should work well even for large sites
+    1_500_000;


### PR DESCRIPTION

## Motivation

See https://github.com/facebook/docusaurus/pull/11166

After thinking about it, since the SSG thread pool is Docusaurus Faster (opt-in), I think we have the opportunity to be quite aggressive with this setting, and use a low 1 GB value.

This will only affect Docusaurus Faster websites. Small sites shouldn't see a lot of recycling, and even quite large sites like [this 11k docs one](https://github.com/facebook/docusaurus/discussions/11140) are not recycling threads that often.

Unfortunately, there's nothing to tell the user that thread recycling is happening. For very large sites, there's a possibility this limit is too low, in which case recycling will happen on every task, but at least we can use the env variable to increase the limit (https://github.com/facebook/docusaurus/pull/11166). The only problem is that large sites can't easily discover the setting with good DX.
