### PR TITLE
fix(mdx-loader): remove opt-in for mdx dependency file

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -77,13 +77,6 @@ async function createMdxLoaderDependencyFile({
   options: PluginOptions;
   versionsMetadata: VersionMetadata[];
 }): Promise<string | undefined> {
-  // TODO this has been temporarily made opt-in until Rspack cache bug is fixed
-  //  See https://github.com/facebook/docusaurus/pull/10931
-  //  See https://github.com/facebook/docusaurus/pull/10934#issuecomment-2672253145
-  if (!process.env.DOCUSAURUS_ENABLE_MDX_DEPENDENCY_FILE) {
-    return undefined;
-  }
-
   const filePath = path.join(dataDir, '__mdx-loader-dependency.json');
   // the cache is invalidated whenever this file content changes
   const fileContent = {


### PR DESCRIPTION


## Motivation

Supersede https://github.com/facebook/docusaurus/pull/11114 after Rspack fixed the cache issue in Rspack 1.3.6

This MDX dependency file permits to invalidate the mdx loader cache entries when anything inside that file changes.

It probably doesn't cover all the possible edge cases, but already better than what we have before: stale cache issues leading to unexpected bundling output.


## Test Plan

CI + local
