### PR TITLE
fix(theme-classic): restore right padding on sidebar (DocSidebar) in Firefox

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/Content/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/Content/styles.module.css
@@ -10,10 +10,17 @@
     flex-grow: 1;
     padding: 0.5rem;
   }
+
   @supports (scrollbar-gutter: stable) {
     .menu {
       padding: 0.5rem 0 0.5rem 0.5rem;
       scrollbar-gutter: stable;
+    }
+  }
+
+  @supports (-moz-appearance: none) and (scrollbar-gutter: stable) {
+    .menu {
+      padding-right: 0.5rem;
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #11130) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

Added `@supports (-moz-appearance: none) and (scrollbar-gutter: stable)` to set `padding-right: 0.5rem` for Firefox-based browsers, fixing missing right padding on sidebar while preserving behavior in other browsers. The issue occurs because the existing `@supports (scrollbar-gutter: stable)` block sets `padding: 0.5rem 0 0.5rem 0.5rem`, which removes right padding in Firefox-based browsers (e.g., Firefox 137, Librewolf 137, Zen). This fix uses `-moz-appearance: none` to target Firefox specifically.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

1. **Run locally**:
   - Clone the repository and run `yarn install`.
   - Start the development server: `yarn workspace website start`.
   - Open `http://localhost:3000` in Firefox 137, Librewolf 137, Zen, Chromium, and Epiphany.
   - Inspect the sidebar buttons (`.menu`) using Developer Tools to confirm `padding-right: 0.5rem` in Firefox-based browsers.
   - Verify that Chromium, Edge, and Epiphany retain correct padding (no regressions).
2. **Run tests**:
   - Execute `yarn test` to run unit tests and confirm no failures.
3. **Screenshots**:
   - **Before**: Sidebar buttons in Firefox 137 lack right padding.  

![Captura de Ecrã (2)](https://github.com/user-attachments/assets/1f0e26fd-8570-4fb2-a44c-b208ccdf1ca0)

   - **After**: Sidebar buttons in Firefox 137 have `padding-right: 0.5rem` ([attach screenshot]).

![Captura de Ecrã (3)](https://github.com/user-attachments/assets/bcce4fd3-aedd-4ffb-89b5-ba04f6f49143)

4. **Browsers Tested**:
   - Firefox 137, Librewolf 137, Zen (fixed).
   - Chromium, Edge.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

- **Issue**: #11130 