### PR TITLE
docs: fix highlighted lines in github link to commonly used languages

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
@@ -80,7 +80,7 @@ Because a Prism theme is just a JS object, you can also write your own theme if 
 
 ### Supported Languages {#supported-languages}
 
-By default, Docusaurus comes with a subset of [commonly used languages](https://github.com/FormidableLabs/prism-react-renderer/blob/master/packages/generate-prism-languages/index.ts#L9-L23).
+By default, Docusaurus comes with a subset of [commonly used languages](https://github.com/FormidableLabs/prism-react-renderer/blob/master/packages/generate-prism-languages/index.ts#L10-L25).
 
 :::warning
 


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

In the documentation about the [markdown code blocks feature](https://docusaurus.io/docs/next/markdown-features/code-blocks#supported-languages) is a GitHub link to the **commonly used languages**. That link redirects to a code file on GitHub were the supported languages are highlighted. However, the highlight does not encompass all supported languages.

My change extends the highlighted area to the "newly" added languages.

## Test Plan

Check rendered markdown.

### Test links

Current version: https://docusaurus.io/docs/next/markdown-features/code-blocks#supported-languages
(see link: **commonly used languages**)
Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

No issue created since it is a very small PR.
