### PR TITLE
fix(core): fix `docusaurus start` error for macOS users with no Chromium-based browser

### DIFF
--- a/packages/docusaurus/src/commands/utils/openBrowser/openBrowser.ts
+++ b/packages/docusaurus/src/commands/utils/openBrowser/openBrowser.ts
@@ -70,7 +70,14 @@ async function tryOpenWithAppleScript({
       const command = `ps cax -o command | grep -E "^(${supportedChromiumBrowsers.join(
         '|',
       )})$"`;
-      const result = await execPromise(command);
+
+      const result = await execPromise(command).catch(() => {
+        // Ignore grep errors when macOS user has no Chromium-based browser
+        // See https://github.com/facebook/docusaurus/issues/11204
+      });
+      if (!result) {
+        return [];
+      }
 
       const activeBrowsers = result.stdout.toString().trim().split('\n');
 


### PR DESCRIPTION


## Motivation

Fix https://github.com/facebook/docusaurus/issues/11204

grep returns exit code 1 by default when the no match found, leading to an error for macOS users that have no Chromium-based browser installed

## Test Plan

Local only 😅 

This reverts to what CRA used to do before my change: swallow errors

See also PR introducing the bug: https://github.com/facebook/docusaurus/pull/11007
