### PR TITLE
perf(website): optimize website i18n build time by removing useless git log calls

### DIFF
--- a/website/_dogfooding/dogfooding.config.ts
+++ b/website/_dogfooding/dogfooding.config.ts
@@ -12,6 +12,12 @@ import type {Options as DocsOptions} from '@docusaurus/plugin-content-docs';
 import type {Options as BlogOptions} from '@docusaurus/plugin-content-blog';
 import type {Options as PageOptions} from '@docusaurus/plugin-content-pages';
 
+// By default, we don't want to run "git log" commands on i18n sites
+// This makes localized sites build much slower on Netlify
+// See also https://github.com/facebook/docusaurus/issues/11208
+// TODO duplicated :/
+export const showLastUpdate = process.env.DOCUSAURUS_CURRENT_LOCALE === 'en';
+
 export const isArgosBuild = process.env.DOCUSAURUS_ARGOS_BUILD === 'true';
 
 if (isArgosBuild) {
@@ -62,8 +68,8 @@ export const dogfoodingPluginInstances: PluginConfig[] = [
 
       // Using a _ prefix to test against an edge case regarding MDX partials: https://github.com/facebook/docusaurus/discussions/5181#discussioncomment-1018079
       path: '_dogfooding/_docs tests',
-      showLastUpdateTime: true,
-      showLastUpdateAuthor: true,
+      showLastUpdateTime: showLastUpdate,
+      showLastUpdateAuthor: showLastUpdate,
       sidebarItemsGenerator(args) {
         return args.defaultSidebarItemsGenerator({
           ...args,
@@ -122,8 +128,8 @@ export const dogfoodingPluginInstances: PluginConfig[] = [
       id: 'pages-tests',
       path: '_dogfooding/_pages tests',
       routeBasePath: '/tests/pages',
-      showLastUpdateTime: true,
-      showLastUpdateAuthor: true,
+      showLastUpdateTime: showLastUpdate,
+      showLastUpdateAuthor: showLastUpdate,
       editUrl: ({pagesPath}) =>
         `https://github.com/facebook/docusaurus/edit/main/website/_dogfooding/_pages tests/${pagesPath}`,
     } satisfies PageOptions,

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -157,6 +157,11 @@ function getLocalizedConfigValue(key: keyof typeof ConfigLocalized) {
   return value;
 }
 
+// By default, we don't want to run "git log" commands on i18n sites
+// This makes localized sites build much slower on Netlify
+// See also https://github.com/facebook/docusaurus/issues/11208
+const showLastUpdate = process.env.DOCUSAURUS_CURRENT_LOCALE === defaultLocale;
+
 export default async function createConfigAsync() {
   return {
     title: 'Docusaurus',
@@ -318,8 +323,8 @@ export default async function createConfigAsync() {
           blogTitle: 'Docusaurus changelog',
           // Not useful, but permits to run git commands earlier
           // Otherwise the sitemap plugin will run them in postBuild()
-          showLastUpdateAuthor: true,
-          showLastUpdateTime: true,
+          showLastUpdateAuthor: showLastUpdate,
+          showLastUpdateTime: showLastUpdate,
           blogDescription:
             'Keep yourself up-to-date about new features in every release',
           blogSidebarCount: 'ALL',
@@ -355,8 +360,8 @@ export default async function createConfigAsync() {
           remarkPlugins: [npm2yarn],
           editCurrentVersion: true,
           sidebarPath: './sidebarsCommunity.js',
-          showLastUpdateAuthor: true,
-          showLastUpdateTime: true,
+          showLastUpdateAuthor: showLastUpdate,
+          showLastUpdateTime: showLastUpdate,
         } satisfies DocsOptions,
       ],
       !process.env.DOCUSAURUS_SKIP_BUNDLING && [
@@ -490,8 +495,8 @@ export default async function createConfigAsync() {
             admonitions: {
               keywords: ['my-custom-admonition'],
             },
-            showLastUpdateAuthor: true,
-            showLastUpdateTime: true,
+            showLastUpdateAuthor: showLastUpdate,
+            showLastUpdateTime: showLastUpdate,
             remarkPlugins: [[npm2yarn, {sync: true}], remarkMath, configTabs],
             rehypePlugins: [rehypeKatex],
             disableVersioning: isVersioningDisabled,
@@ -524,8 +529,8 @@ export default async function createConfigAsync() {
           blog: {
             // routeBasePath: '/',
             path: 'blog',
-            showLastUpdateAuthor: true,
-            showLastUpdateTime: true,
+            showLastUpdateAuthor: showLastUpdate,
+            showLastUpdateTime: showLastUpdate,
             editUrl: ({locale, blogDirPath, blogPath}) => {
               if (locale !== defaultLocale) {
                 return `https://crowdin.com/project/docusaurus-v2/${locale}`;
@@ -562,8 +567,8 @@ export default async function createConfigAsync() {
               }
               return `https://github.com/facebook/docusaurus/edit/main/website/src/pages/${pagesPath}`;
             },
-            showLastUpdateAuthor: true,
-            showLastUpdateTime: true,
+            showLastUpdateAuthor: showLastUpdate,
+            showLastUpdateTime: showLastUpdate,
           } satisfies PageOptions,
           theme: {
             customCss: [
@@ -582,7 +587,7 @@ export default async function createConfigAsync() {
               ? undefined
               : // Note: /tests/docs already has noIndex: true
                 ['/tests/{blog,pages}/**'],
-            lastmod: 'date',
+            lastmod: showLastUpdate ? 'date' : null,
             priority: null,
             changefreq: null,
           },

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -207,7 +207,7 @@ export default async function createConfigAsync() {
       locales:
         isDeployPreview || isBranchDeploy
           ? // Deploy preview and branch deploys: keep them fast!
-            [defaultLocale, 'fr']
+            [defaultLocale]
           : isI18nStaging
           ? // Staging locales: https://docusaurus-i18n-staging.netlify.app/
             [defaultLocale, 'ja']

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -207,7 +207,7 @@ export default async function createConfigAsync() {
       locales:
         isDeployPreview || isBranchDeploy
           ? // Deploy preview and branch deploys: keep them fast!
-            [defaultLocale]
+            [defaultLocale, 'fr']
           : isI18nStaging
           ? // Staging locales: https://docusaurus-i18n-staging.netlify.app/
             [defaultLocale, 'ja']


### PR DESCRIPTION

## Motivation

Related to:
- https://github.com/facebook/docusaurus/issues/11208
- https://github.com/facebook/docusaurus/pull/11211

Running useless `git log` commands for our localized sites significantly slows them down.

Until we find a general way to solve this problem for all sites, this temporary trick permits us to optimize our own website deployment.

## Local Benchmark


Before:

```bash
[PERF] Build > fr > Load site - 7.92 seconds!
```

After:

```bash
[PERF] Build > fr > Load site - 1.15 seconds!
```


## Test Plan

Local + our CI

### Test links

https://deploy-preview-11214--docusaurus-2.netlify.app/

