### PR TITLE
fix(bundler): fix `docusaurus start` using `concatenateModules: true`

### DIFF
--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -253,13 +253,6 @@ export async function createBaseConfig({
       modules: ['node_modules', path.join(siteDir, 'node_modules')],
     },
     optimization: {
-      // The optimization.concatenateModules is expensive
-      // - On the server, it's not useful to run it at all
-      // - On the client, it leads to a ~3% JS assets total size decrease
-      //   Let's keep it by default, but large sites may prefer faster builds
-      // See also https://github.com/facebook/docusaurus/pull/11176
-      concatenateModules: !isServer,
-
       // The optimization.mergeDuplicateChunks is expensive
       // - On the server, it's not useful to run it at all
       // - On the client, we compared assets/js before/after and see 0 change

--- a/packages/docusaurus/src/webpack/server.ts
+++ b/packages/docusaurus/src/webpack/server.ts
@@ -52,6 +52,16 @@ export default async function createServerConfig({
         color: 'yellow',
       }),
     ],
+    optimization: {
+      // The optimization.concatenateModules is expensive
+      // - On the server, it's not useful to run it at all
+      // - On the client, it leads to a ~3% JS assets total size decrease
+      //   Let's keep it by default, but large sites may prefer faster builds
+      // See also https://github.com/facebook/docusaurus/pull/11176
+      // Note: we don't want to enable it on the client for "docusaurus start"
+      // See also
+      concatenateModules: false,
+    },
   });
 
   return {config, serverBundlePath};


### PR DESCRIPTION


## Motivation

Using `concatenateModules: !isServer` on the base bundler config is not ideal because it will turn it on for `docusaurus start` too, while we only want the optimization to be enabled for the build client config.

Reminder: by default the flag is enabled in production mode.

Before:
- ❌ `docusaurus start`: on (should be off)
- ✅ `docusaurus build` - client: on
- ✅ `docusaurus build` - server: off
- ❌ `docusaurus build --dev` - server: on (should be off)

After
- ✅ `docusaurus start`: off
- ✅ `docusaurus build` - client: on
- ✅ `docusaurus build` - server: off
- ✅ `docusaurus build --dev` - server: off


## Test Plan

We don't have good coverage for that 😅 hard to default default values of bundlers by observing their dev server behavior.


### Test links

https://deploy-preview-_____--docusaurus-2.netlify.app/


