### PR TITLE
fix(website): ensure feedback widget renders with correct theme

### DIFF
--- a/website/src/plugins/featureRequests/FeatureRequestsPage.tsx
+++ b/website/src/plugins/featureRequests/FeatureRequestsPage.tsx
@@ -8,6 +8,7 @@
 import React, {type ReactNode, useEffect} from 'react';
 import clsx from 'clsx';
 import {useColorMode} from '@docusaurus/theme-common';
+import BrowserOnly from '@docusaurus/BrowserOnly';
 import Layout from '@theme/Layout';
 
 import cannyScript from './cannyScript';
@@ -15,6 +16,8 @@ import styles from './styles.module.css';
 
 const BOARD_TOKEN = '054e0e53-d951-b14c-7e74-9eb8f9ed2f91';
 
+// TODO find a way to remove this unreliable useColorMode() hook
+// See also https://github.com/facebook/docusaurus/pull/11224
 function useCannyTheme() {
   const {colorMode} = useColorMode();
   return colorMode === 'light' ? 'light' : 'dark';
@@ -27,18 +30,15 @@ function CannyWidget({basePath}: {basePath: string}) {
 
   const theme = useCannyTheme();
   useEffect(() => {
-    const timer = setTimeout(() => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const {Canny} = window as any;
-      Canny('render', {
-        boardToken: BOARD_TOKEN,
-        basePath,
-        theme,
-      });
-    }, 50);
-
-    return () => clearTimeout(timer);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const {Canny} = window as any;
+    Canny('render', {
+      boardToken: BOARD_TOKEN,
+      basePath,
+      theme,
+    });
   }, [basePath, theme]);
+
   return (
     <main
       key={theme} // widget needs a full reset: unable to update the theme
@@ -55,7 +55,7 @@ export default function FeatureRequests({
 }): ReactNode {
   return (
     <Layout title="Feedback" description="Docusaurus 2 Feature Requests page">
-      <CannyWidget basePath={basePath} />
+      <BrowserOnly>{() => <CannyWidget basePath={basePath} />}</BrowserOnly>
     </Layout>
   );
 }

--- a/website/src/plugins/featureRequests/FeatureRequestsPage.tsx
+++ b/website/src/plugins/featureRequests/FeatureRequestsPage.tsx
@@ -5,10 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {type ReactNode, useEffect} from 'react';
+import React, {type ReactNode, useEffect, useState} from 'react';
 import clsx from 'clsx';
 import {useColorMode} from '@docusaurus/theme-common';
-import BrowserOnly from '@docusaurus/BrowserOnly';
 import Layout from '@theme/Layout';
 
 import cannyScript from './cannyScript';
@@ -16,10 +15,25 @@ import styles from './styles.module.css';
 
 const BOARD_TOKEN = '054e0e53-d951-b14c-7e74-9eb8f9ed2f91';
 
-// TODO find a way to remove this unreliable useColorMode() hook
-// See also https://github.com/facebook/docusaurus/pull/11224
+// TODO useColorMode() hook is not reliable on first call
+//  To ensure we always init Canny with the correct theme, we prefer to delay
+//  initialization until we know the theme is correct
+//  See also https://github.com/facebook/docusaurus/issues/7986
+//  See also https://github.com/facebook/docusaurus/pull/11224
+function useIsColorModeReliable() {
+  const [isColorModeReliable, setIsColorModeReliable] = useState(false);
+  useEffect(() => {
+    setIsColorModeReliable(true);
+  }, []);
+  return isColorModeReliable;
+}
+
 function useCannyTheme() {
   const {colorMode} = useColorMode();
+  const isColorModeReliable = useIsColorModeReliable();
+  if (!isColorModeReliable) {
+    return null;
+  }
   return colorMode === 'light' ? 'light' : 'dark';
 }
 
@@ -30,6 +44,9 @@ function CannyWidget({basePath}: {basePath: string}) {
 
   const theme = useCannyTheme();
   useEffect(() => {
+    if (!theme) {
+      return;
+    }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const {Canny} = window as any;
     Canny('render', {
@@ -55,7 +72,7 @@ export default function FeatureRequests({
 }): ReactNode {
   return (
     <Layout title="Feedback" description="Docusaurus 2 Feature Requests page">
-      <BrowserOnly>{() => <CannyWidget basePath={basePath} />}</BrowserOnly>
+      <CannyWidget basePath={basePath} />
     </Layout>
   );
 }

--- a/website/src/plugins/featureRequests/FeatureRequestsPage.tsx
+++ b/website/src/plugins/featureRequests/FeatureRequestsPage.tsx
@@ -27,13 +27,17 @@ function CannyWidget({basePath}: {basePath: string}) {
 
   const theme = useCannyTheme();
   useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const {Canny} = window as any;
-    Canny('render', {
-      boardToken: BOARD_TOKEN,
-      basePath,
-      theme,
-    });
+    const timer = setTimeout(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const {Canny} = window as any;
+      Canny('render', {
+        boardToken: BOARD_TOKEN,
+        basePath,
+        theme,
+      });
+    }, 50);
+
+    return () => clearTimeout(timer);
   }, [basePath, theme]);
   return (
     <main


### PR DESCRIPTION
If a user lands on the feature request community page with the theme set to dark the canny widget is rendered twice, first light and then dark. The first call with the light theme takes effect as the widget has not yet loaded and the widget shows in light theme. Adding a small delay prevents the first render with the wrong theme.

![CleanShot 2025-06-01 at 07 40 20@2x](https://github.com/user-attachments/assets/8999cebd-ac64-4741-8256-de6fd76e24dd)


## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-11224--docusaurus-2.netlify.app/
