### PR TITLE
fix(css-cascade-layers): fix windows css cascade layers bug

### DIFF
--- a/packages/docusaurus-plugin-css-cascade-layers/package.json
+++ b/packages/docusaurus-plugin-css-cascade-layers/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@docusaurus/core": "3.8.0",
     "@docusaurus/types": "3.8.0",
+    "@docusaurus/utils": "3.8.0",
     "@docusaurus/utils-validation": "3.8.0",
     "tslib": "^2.6.0"
   },

--- a/packages/docusaurus-plugin-css-cascade-layers/src/options.ts
+++ b/packages/docusaurus-plugin-css-cascade-layers/src/options.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import {Joi} from '@docusaurus/utils-validation';
+import {posixPath} from '@docusaurus/utils';
 import {isValidLayerName} from './layers';
 import type {OptionValidationContext} from '@docusaurus/types';
 
@@ -20,7 +21,10 @@ export type Options = {
 // Not ideal to compute layers using "filePath.includes()"
 // But this is mostly temporary until we add first-class layers everywhere
 function layerFor(...params: string[]) {
-  return (filePath: string) => params.some((p) => filePath.includes(p));
+  return (filePath: string) => {
+    const posixFilePath = posixPath(filePath);
+    return params.some((p) => posixFilePath.includes(p));
+  };
 }
 
 // Object order matters, it defines the layer order


### PR DESCRIPTION

## Motivation

Fix bug initially reported in https://github.com/facebook/docusaurus/issues/2853#issuecomment-2925283734 

CSS cascade layers were not dynamically applied on Windows due to windows/posix file path differences.

This leads to another bug: CSS cascade layer directives are ignored by `clean-css`: https://github.com/clean-css/clean-css/issues/1272
(replaced by LightningCSS with Docusaurus Faster)

By chance, fixing the Windows bug also fixes the clean-css bug because the top-level directive declaration: `@layer d1, d2;` gets converted to ordered block-level directives like `@layer d1 {}`

## Test Plan

CI : The newly added windows e2e build artifact (https://github.com/facebook/docusaurus/pull/11231) should render correctly. Unfortunately it's not easy to automate this test.

