### PR TITLE
fix(theme-common): remove superfluous aria region from skip-to-conten…

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/skipToContentUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/skipToContentUtils.tsx
@@ -52,14 +52,14 @@ function useSkipToContent(): {
    * so that keyboard navigators can instantly interact with the link and jump
    * to content.
    */
-  containerRef: React.RefObject<HTMLDivElement>;
+  containerRef: React.RefObject<HTMLAnchorElement>;
   /**
    * Callback fired when the skip to content link has been clicked.
    * It will programmatically focus the main content.
    */
   onClick: (e: React.MouseEvent<HTMLAnchorElement>) => void;
 } {
-  const containerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLAnchorElement>(null);
   const {action} = useHistory();
 
   const onClick = useCallback((e: React.MouseEvent<HTMLAnchorElement>) => {
@@ -94,19 +94,15 @@ export function SkipToContentLink(props: SkipToContentLinkProps): ReactNode {
   const linkLabel = props.children ?? DefaultSkipToContentLabel;
   const {containerRef, onClick} = useSkipToContent();
   return (
-    <div
+    // eslint-disable-next-line @docusaurus/no-html-links
+    <a
+      {...props}
       ref={containerRef}
-      role="region"
-      aria-label={DefaultSkipToContentLabel}>
-      {/* eslint-disable-next-line @docusaurus/no-html-links */}
-      <a
-        {...props}
-        // Note this is a fallback href in case JS is disabled
-        // It has limitations, see https://github.com/facebook/docusaurus/issues/6411#issuecomment-1284136069
-        href={`#${SkipToContentFallbackId}`}
-        onClick={onClick}>
-        {linkLabel}
-      </a>
-    </div>
+      // Note this is a fallback href in case JS is disabled
+      // It has limitations, see https://github.com/facebook/docusaurus/issues/6411#issuecomment-1284136069
+      href={`#${SkipToContentFallbackId}`}
+      onClick={onClick}>
+      {linkLabel}
+    </a>
   );
 }


### PR DESCRIPTION
…t link

This commit addresses issue #9800 by removing the unnecessary ARIA region (div with role='region') that was wrapping the skip-to-content link.

This change aligns with accessibility best practices, which recommend that skip links should be direct children of the body or a main landmark, rather than being wrapped in their own landmark region.

Tested by running all tests in the docusaurus-theme-common package.

## Pre-flight checklist

- [X] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [X] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [X] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

This PR fixes an accessibility issue (#9800) where a superfluous ARIA region was present around the skip-to-content link, causing redundant announcements for screen reader users. This change removes the unnecessary region, aligning with accessibility best practices. Closes #9800

## Test Plan

Verified the change by running all unit tests within the docusaurus-theme-common package using the command npm test -- --testPathPattern=docusaurus-theme-common. All 92 tests in 12 suites passed. The change involves removing a div element and updating a type definition, which is covered by the existing test structure. Manual inspection of the rendered output can confirm the absence of the div[role='region'] around the skip link

### Test links

<!--
A deploy preview will be added by the Netlify bot. The primary verification for this change is inspecting the DOM to ensure the skip link is no longer wrapped in a div with role='region'-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- Closes #9800-->
