### PR TITLE
fix: dev server HTML lang attribute

### DIFF
--- a/packages/docusaurus/src/webpack/client.ts
+++ b/packages/docusaurus/src/webpack/client.ts
@@ -117,6 +117,7 @@ export async function createStartClientConfig({
           headTags,
           preBodyTags,
           postBodyTags,
+          lang: props.i18n.currentLocale,
         }),
       ],
     },

--- a/packages/docusaurus/src/webpack/templates/dev.html.template.ejs
+++ b/packages/docusaurus/src/webpack/templates/dev.html.template.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="<%= htmlWebpackPlugin.options.lang %>">
   <head>
     <meta charset="utf-8">
     <meta name="generator" content="Docusaurus">


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation
This fixes a bug where the development server always uses `lang="en"` in HTML regardless of the configured `i18n.defaultLocale`. 

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

1. Created a new Docusaurus site with `i18n.defaultLocale: 'ja'`
2. Started development server with `npm start`
3. **Before fix**: HTML showed `<html lang="en">` - causing browser translation popups
4. **After fix**: HTML correctly shows `<html lang="ja">` - no inappropriate popups

Before
![image](https://github.com/user-attachments/assets/75310fee-6bd8-4947-96df-2564a31e5277)


After
![image](https://github.com/user-attachments/assets/507aa816-e02b-4aee-883d-28d0ec48a519)


<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs
fix #11253 
<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
