### PR TITLE
fix(theme-common): Export FooterColumnItem type

### DIFF
--- a/packages/docusaurus-theme-common/src/index.ts
+++ b/packages/docusaurus-theme-common/src/index.ts
@@ -53,6 +53,7 @@ export {
   type MultiColumnFooter,
   type SimpleFooter,
   type Footer,
+  type FooterColumnItem,
   type FooterLogo,
   type FooterLinkItem,
   type ColorModeConfig,


### PR DESCRIPTION
Export FooterColumnItem type from utils/useThemeConfig.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

I'm trying to create presets for footer section where i have multiple docusaurus.config.ts files for each deployment environment. I wanted to add `FooterColumnItem` type to each footer column preset for type safety and noticed that `FooterLinkItem` is exported but column item was not. 

## Test Plan

I've not written any tests for this, advice welcome if it's needed.

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

I don't believe this is related to any issues or pre/existing PR's.
