### PR TITLE
fea(core): Add `siteConfig.markdown.hooks`, deprecate `siteConfig.onBrokenMarkdownLinks`

### DIFF
--- a/packages/create-docusaurus/templates/classic-typescript/docusaurus.config.ts
+++ b/packages/create-docusaurus/templates/classic-typescript/docusaurus.config.ts
@@ -26,7 +26,6 @@ const config: Config = {
   projectName: 'docusaurus', // Usually your repo name.
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you

--- a/packages/create-docusaurus/templates/classic/docusaurus.config.js
+++ b/packages/create-docusaurus/templates/classic/docusaurus.config.js
@@ -31,7 +31,6 @@ const config = {
   projectName: 'docusaurus', // Usually your repo name.
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you

--- a/packages/docusaurus-mdx-loader/src/processor.ts
+++ b/packages/docusaurus-mdx-loader/src/processor.ts
@@ -22,6 +22,7 @@ import type {WebpackCompilerName} from '@docusaurus/utils';
 import type {MDXFrontMatter} from './frontMatter';
 import type {Options} from './options';
 import type {AdmonitionOptions} from './remark/admonitions';
+import type {PluginOptions as ResolveMarkdownLinksOptions} from './remark/resolveMarkdownLinks';
 import type {ProcessorOptions} from '@mdx-js/mdx';
 
 // TODO as of April 2023, no way to import/re-export this ESM type easily :/
@@ -127,7 +128,12 @@ async function createProcessorFactory() {
       options.resolveMarkdownLink
         ? [
             resolveMarkdownLinks,
-            {resolveMarkdownLink: options.resolveMarkdownLink},
+            {
+              siteDir: options.siteDir,
+              resolveMarkdownLink: options.resolveMarkdownLink,
+              onBrokenMarkdownLinks:
+                options.markdownConfig.hooks.onBrokenMarkdownLinks,
+            } satisfies ResolveMarkdownLinksOptions,
           ]
         : undefined,
       [

--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -71,7 +71,7 @@ export default async function pluginContentBlog(
     );
   }
 
-  const {onBrokenMarkdownLinks, baseUrl} = siteConfig;
+  const {baseUrl} = siteConfig;
 
   const contentPaths: BlogContentPaths = {
     contentPath: path.resolve(siteDir, options.path),
@@ -154,18 +154,12 @@ export default async function pluginContentBlog(
       },
       markdownConfig: siteConfig.markdown,
       resolveMarkdownLink: ({linkPathname, sourceFilePath}) => {
-        const permalink = resolveMarkdownLinkPathname(linkPathname, {
+        return resolveMarkdownLinkPathname(linkPathname, {
           sourceFilePath,
           sourceToPermalink: contentHelpers.sourceToPermalink,
           siteDir,
           contentPaths,
         });
-        if (permalink === null) {
-          logger.report(
-            onBrokenMarkdownLinks,
-          )`Blog markdown link couldn't be resolved: (url=${linkPathname}) in source file path=${sourceFilePath}`;
-        }
-        return permalink;
       },
     });
 

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -7,7 +7,6 @@
 
 import path from 'path';
 import fs from 'fs-extra';
-import logger from '@docusaurus/logger';
 import {
   normalizeUrl,
   docuHash,
@@ -158,18 +157,12 @@ export default async function pluginContentDocs(
             sourceFilePath,
             versionsMetadata,
           );
-          const permalink = resolveMarkdownLinkPathname(linkPathname, {
+          return resolveMarkdownLinkPathname(linkPathname, {
             sourceFilePath,
             sourceToPermalink: contentHelpers.sourceToPermalink,
             siteDir,
             contentPaths: version,
           });
-          if (permalink === null) {
-            logger.report(
-              siteConfig.onBrokenMarkdownLinks,
-            )`Docs markdown link couldn't be resolved: (url=${linkPathname}) in source file path=${sourceFilePath} for version number=${version.versionName}`;
-          }
-          return permalink;
         },
       },
     });

--- a/packages/docusaurus-types/src/config.d.ts
+++ b/packages/docusaurus-types/src/config.d.ts
@@ -10,7 +10,7 @@ import type {RuleSetRule} from 'webpack';
 import type {DeepPartial, Overwrite} from 'utility-types';
 import type {I18nConfig} from './i18n';
 import type {PluginConfig, PresetConfig, HtmlTagObject} from './plugin';
-import type {ReportingSeverity} from './hooks';
+import type {ReportingSeverity} from './reporting';
 import type {MarkdownConfig} from './markdown';
 
 export type RouterType = 'browser' | 'hash';

--- a/packages/docusaurus-types/src/config.d.ts
+++ b/packages/docusaurus-types/src/config.d.ts
@@ -11,10 +11,6 @@ import type {DeepPartial, Overwrite} from 'utility-types';
 import type {I18nConfig} from './i18n';
 import type {PluginConfig, PresetConfig, HtmlTagObject} from './plugin';
 
-import type {ProcessorOptions} from '@mdx-js/mdx';
-
-export type RemarkRehypeOptions = ProcessorOptions['remarkRehypeOptions'];
-
 export type ReportingSeverity = 'ignore' | 'log' | 'warn' | 'throw';
 
 export type RouterType = 'browser' | 'hash';
@@ -23,100 +19,18 @@ export type ThemeConfig = {
   [key: string]: unknown;
 };
 
-export type MarkdownPreprocessor = (args: {
-  filePath: string;
-  fileContent: string;
-}) => string;
-
-export type MDX1CompatOptions = {
-  comments: boolean;
-  admonitions: boolean;
-  headingIds: boolean;
-};
-
-export type ParseFrontMatterParams = {filePath: string; fileContent: string};
-export type ParseFrontMatterResult = {
-  frontMatter: {[key: string]: unknown};
-  content: string;
-};
-export type DefaultParseFrontMatter = (
-  params: ParseFrontMatterParams,
-) => Promise<ParseFrontMatterResult>;
-export type ParseFrontMatter = (
-  params: ParseFrontMatterParams & {
-    defaultParseFrontMatter: DefaultParseFrontMatter;
-  },
-) => Promise<ParseFrontMatterResult>;
-
-export type MarkdownAnchorsConfig = {
-  /**
-   * Preserves the case of the heading text when generating anchor ids.
-   */
-  maintainCase: boolean;
-};
-
-export type MarkdownConfig = {
-  /**
-   * The Markdown format to use by default.
-   *
-   * This is the format passed down to the MDX compiler, impacting the way the
-   * content is parsed.
-   *
-   * Possible values:
-   * - `'mdx'`: use the MDX format (JSX support)
-   * - `'md'`: use the CommonMark format (no JSX support)
-   * - `'detect'`: select the format based on file extension (.md / .mdx)
-   *
-   * @see https://mdxjs.com/packages/mdx/#optionsformat
-   * @default 'mdx'
-   */
-  format: 'mdx' | 'md' | 'detect';
-
-  /**
-   * A function callback that lets users parse the front matter themselves.
-   * Gives the opportunity to read it from a different source, or process it.
-   *
-   * @see https://github.com/facebook/docusaurus/issues/5568
-   */
-  parseFrontMatter: ParseFrontMatter;
-
-  /**
-   * Allow mermaid language code blocks to be rendered into Mermaid diagrams:
-   *
-   * - `true`: code blocks with language mermaid will be rendered.
-   * - `false` | `undefined` (default): code blocks with language mermaid
-   * will be left as code blocks.
-   *
-   * @see https://docusaurus.io/docs/markdown-features/diagrams/
-   * @default false
-   */
-  mermaid: boolean;
-
-  /**
-   * Gives opportunity to preprocess the MDX string content before compiling.
-   * A good escape hatch that can be used to handle edge cases.
-   *
-   * @param args
-   */
-  preprocessor?: MarkdownPreprocessor;
-
-  /**
-   * Set of flags make it easier to upgrade from MDX 1 to MDX 2
-   * See also https://github.com/facebook/docusaurus/issues/4029
-   */
-  mdx1Compat: MDX1CompatOptions;
-
-  /**
-   * Ability to provide custom remark-rehype options
-   * See also https://github.com/remarkjs/remark-rehype#options
-   */
-  remarkRehypeOptions: RemarkRehypeOptions;
-
-  /**
-   * Options to control the behavior of anchors generated from Markdown headings
-   */
-  anchors: MarkdownAnchorsConfig;
-};
+// We probably expose too many types here, I kept exports for v3.x retro compat
+export type {
+  RemarkRehypeOptions,
+  MarkdownPreprocessor,
+  MDX1CompatOptions,
+  ParseFrontMatterParams,
+  ParseFrontMatterResult,
+  DefaultParseFrontMatter,
+  ParseFrontMatter,
+  MarkdownAnchorsConfig,
+  MarkdownConfig,
+} from './markdown';
 
 export type StorageConfig = {
   type: SiteStorage['type'];

--- a/packages/docusaurus-types/src/config.d.ts
+++ b/packages/docusaurus-types/src/config.d.ts
@@ -10,27 +10,14 @@ import type {RuleSetRule} from 'webpack';
 import type {DeepPartial, Overwrite} from 'utility-types';
 import type {I18nConfig} from './i18n';
 import type {PluginConfig, PresetConfig, HtmlTagObject} from './plugin';
-
-export type ReportingSeverity = 'ignore' | 'log' | 'warn' | 'throw';
+import type {ReportingSeverity} from './hooks';
+import type {MarkdownConfig} from './markdown';
 
 export type RouterType = 'browser' | 'hash';
 
 export type ThemeConfig = {
   [key: string]: unknown;
 };
-
-// We probably expose too many types here, I kept exports for v3.x retro compat
-export type {
-  RemarkRehypeOptions,
-  MarkdownPreprocessor,
-  MDX1CompatOptions,
-  ParseFrontMatterParams,
-  ParseFrontMatterResult,
-  DefaultParseFrontMatter,
-  ParseFrontMatter,
-  MarkdownAnchorsConfig,
-  MarkdownConfig,
-} from './markdown';
 
 export type StorageConfig = {
   type: SiteStorage['type'];

--- a/packages/docusaurus-types/src/config.d.ts
+++ b/packages/docusaurus-types/src/config.d.ts
@@ -159,7 +159,8 @@ export type DocusaurusConfig = {
    * @see https://docusaurus.io/docs/api/docusaurus-config#onBrokenMarkdownLinks
    * @default "warn"
    */
-  onBrokenMarkdownLinks: ReportingSeverity;
+  // TODO Docusaurus v4 remove
+  onBrokenMarkdownLinks: ReportingSeverity | undefined;
   /**
    * The behavior of Docusaurus when it detects any [duplicate
    * routes](https://docusaurus.io/docs/creating-pages#duplicate-routes).

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -6,18 +6,22 @@
  */
 
 export {
-  ReportingSeverity,
   RouterType,
   ThemeConfig,
-  MarkdownConfig,
-  DefaultParseFrontMatter,
-  ParseFrontMatter,
   DocusaurusConfig,
   FutureConfig,
   FasterConfig,
   StorageConfig,
   Config,
 } from './config';
+
+export {
+  MarkdownConfig,
+  DefaultParseFrontMatter,
+  ParseFrontMatter,
+} from './markdown';
+
+export {ReportingSeverity} from './reporting';
 
 export {
   SiteMetadata,

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -19,6 +19,7 @@ export {
   MarkdownConfig,
   DefaultParseFrontMatter,
   ParseFrontMatter,
+  OnBrokenMarkdownLinksFunction,
 } from './markdown';
 
 export {ReportingSeverity} from './reporting';

--- a/packages/docusaurus-types/src/markdown.d.ts
+++ b/packages/docusaurus-types/src/markdown.d.ts
@@ -42,15 +42,32 @@ export type MarkdownAnchorsConfig = {
   maintainCase: boolean;
 };
 
-// TODO refactor doc links!
+export type OnBrokenMarkdownLinksFunction = (params: {
+  /**
+   * Path of the source file on which the broken link was found
+   * Relative to the site dir.
+   * Example: "docs/category/myDoc.mdx"
+   */
+  sourceFilePath: string;
+
+  /**
+   * The Markdown link url that couldn't be resolved.
+   * Technically, in this context, it's more a "relative file path", but let's
+   * name it url for consistency with usual Markdown names and the MDX AST
+   * Example: "relative/dir/myTargetDoc.mdx?query#hash"
+   */
+  url: string;
+}) => void | string;
+
 export type MarkdownHooks = {
   /**
    * The behavior of Docusaurus when it detects any broken Markdown link.
    *
+   * // TODO refactor doc links!
    * @see https://docusaurus.io/docs/api/docusaurus-config#onBrokenMarkdownLinks
    * @default "warn"
    */
-  onBrokenMarkdownLinks: ReportingSeverity;
+  onBrokenMarkdownLinks: ReportingSeverity | OnBrokenMarkdownLinksFunction;
 };
 
 export type MarkdownConfig = {

--- a/packages/docusaurus-types/src/markdown.d.ts
+++ b/packages/docusaurus-types/src/markdown.d.ts
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type {ProcessorOptions} from '@mdx-js/mdx';
+import type {ReportingSeverity} from './config';
+
+export type RemarkRehypeOptions = ProcessorOptions['remarkRehypeOptions'];
+
+export type MarkdownPreprocessor = (args: {
+  filePath: string;
+  fileContent: string;
+}) => string;
+
+export type MDX1CompatOptions = {
+  comments: boolean;
+  admonitions: boolean;
+  headingIds: boolean;
+};
+
+export type ParseFrontMatterParams = {filePath: string; fileContent: string};
+export type ParseFrontMatterResult = {
+  frontMatter: {[key: string]: unknown};
+  content: string;
+};
+export type DefaultParseFrontMatter = (
+  params: ParseFrontMatterParams,
+) => Promise<ParseFrontMatterResult>;
+export type ParseFrontMatter = (
+  params: ParseFrontMatterParams & {
+    defaultParseFrontMatter: DefaultParseFrontMatter;
+  },
+) => Promise<ParseFrontMatterResult>;
+
+export type MarkdownAnchorsConfig = {
+  /**
+   * Preserves the case of the heading text when generating anchor ids.
+   */
+  maintainCase: boolean;
+};
+
+// TODO refactor doc links!
+export type MarkdownHooks = {
+  /**
+   * The behavior of Docusaurus when it detects any broken Markdown link.
+   *
+   * @see https://docusaurus.io/docs/api/docusaurus-config#onBrokenMarkdownLinks
+   * @default "warn"
+   */
+  onBrokenLinks: ReportingSeverity;
+};
+
+export type MarkdownConfig = {
+  /**
+   * The Markdown format to use by default.
+   *
+   * This is the format passed down to the MDX compiler, impacting the way the
+   * content is parsed.
+   *
+   * Possible values:
+   * - `'mdx'`: use the MDX format (JSX support)
+   * - `'md'`: use the CommonMark format (no JSX support)
+   * - `'detect'`: select the format based on file extension (.md / .mdx)
+   *
+   * @see https://mdxjs.com/packages/mdx/#optionsformat
+   * @default 'mdx'
+   */
+  format: 'mdx' | 'md' | 'detect';
+
+  /**
+   * A function callback that lets users parse the front matter themselves.
+   * Gives the opportunity to read it from a different source, or process it.
+   *
+   * @see https://github.com/facebook/docusaurus/issues/5568
+   */
+  parseFrontMatter: ParseFrontMatter;
+
+  /**
+   * Allow mermaid language code blocks to be rendered into Mermaid diagrams:
+   *
+   * - `true`: code blocks with language mermaid will be rendered.
+   * - `false` | `undefined` (default): code blocks with language mermaid
+   * will be left as code blocks.
+   *
+   * @see https://docusaurus.io/docs/markdown-features/diagrams/
+   * @default false
+   */
+  mermaid: boolean;
+
+  /**
+   * Gives opportunity to preprocess the MDX string content before compiling.
+   * A good escape hatch that can be used to handle edge cases.
+   *
+   * @param args
+   */
+  preprocessor?: MarkdownPreprocessor;
+
+  /**
+   * Set of flags make it easier to upgrade from MDX 1 to MDX 2
+   * See also https://github.com/facebook/docusaurus/issues/4029
+   */
+  mdx1Compat: MDX1CompatOptions;
+
+  /**
+   * Ability to provide custom remark-rehype options
+   * See also https://github.com/remarkjs/remark-rehype#options
+   */
+  remarkRehypeOptions: RemarkRehypeOptions;
+
+  /**
+   * Options to control the behavior of anchors generated from Markdown headings
+   */
+  anchors: MarkdownAnchorsConfig;
+
+  hooks: MarkdownHooks;
+};

--- a/packages/docusaurus-types/src/markdown.d.ts
+++ b/packages/docusaurus-types/src/markdown.d.ts
@@ -50,7 +50,7 @@ export type MarkdownHooks = {
    * @see https://docusaurus.io/docs/api/docusaurus-config#onBrokenMarkdownLinks
    * @default "warn"
    */
-  onBrokenLinks: ReportingSeverity;
+  onBrokenMarkdownLinks: ReportingSeverity;
 };
 
 export type MarkdownConfig = {

--- a/packages/docusaurus-types/src/markdown.d.ts
+++ b/packages/docusaurus-types/src/markdown.d.ts
@@ -6,7 +6,7 @@
  */
 
 import type {ProcessorOptions} from '@mdx-js/mdx';
-import type {ReportingSeverity} from './config';
+import type {ReportingSeverity} from './reporting';
 
 export type RemarkRehypeOptions = ProcessorOptions['remarkRehypeOptions'];
 

--- a/packages/docusaurus-types/src/reporting.d.ts
+++ b/packages/docusaurus-types/src/reporting.d.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export type ReportingSeverity = 'ignore' | 'log' | 'warn' | 'throw';

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/config.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/config.test.ts.snap
@@ -42,6 +42,9 @@ exports[`loadSiteConfig website with .cjs siteConfig 1`] = `
         "maintainCase": false,
       },
       "format": "mdx",
+      "hooks": {
+        "onBrokenMarkdownLinks": "warn",
+      },
       "mdx1Compat": {
         "admonitions": true,
         "comments": true,
@@ -55,7 +58,6 @@ exports[`loadSiteConfig website with .cjs siteConfig 1`] = `
     "noIndex": false,
     "onBrokenAnchors": "warn",
     "onBrokenLinks": "throw",
-    "onBrokenMarkdownLinks": "warn",
     "onDuplicateRoutes": "warn",
     "plugins": [],
     "presets": [],
@@ -117,6 +119,9 @@ exports[`loadSiteConfig website with ts + js config 1`] = `
         "maintainCase": false,
       },
       "format": "mdx",
+      "hooks": {
+        "onBrokenMarkdownLinks": "warn",
+      },
       "mdx1Compat": {
         "admonitions": true,
         "comments": true,
@@ -130,7 +135,6 @@ exports[`loadSiteConfig website with ts + js config 1`] = `
     "noIndex": false,
     "onBrokenAnchors": "warn",
     "onBrokenLinks": "throw",
-    "onBrokenMarkdownLinks": "warn",
     "onDuplicateRoutes": "warn",
     "plugins": [],
     "presets": [],
@@ -192,6 +196,9 @@ exports[`loadSiteConfig website with valid JS CJS config 1`] = `
         "maintainCase": false,
       },
       "format": "mdx",
+      "hooks": {
+        "onBrokenMarkdownLinks": "warn",
+      },
       "mdx1Compat": {
         "admonitions": true,
         "comments": true,
@@ -205,7 +212,6 @@ exports[`loadSiteConfig website with valid JS CJS config 1`] = `
     "noIndex": false,
     "onBrokenAnchors": "warn",
     "onBrokenLinks": "throw",
-    "onBrokenMarkdownLinks": "warn",
     "onDuplicateRoutes": "warn",
     "plugins": [],
     "presets": [],
@@ -267,6 +273,9 @@ exports[`loadSiteConfig website with valid JS ESM config 1`] = `
         "maintainCase": false,
       },
       "format": "mdx",
+      "hooks": {
+        "onBrokenMarkdownLinks": "warn",
+      },
       "mdx1Compat": {
         "admonitions": true,
         "comments": true,
@@ -280,7 +289,6 @@ exports[`loadSiteConfig website with valid JS ESM config 1`] = `
     "noIndex": false,
     "onBrokenAnchors": "warn",
     "onBrokenLinks": "throw",
-    "onBrokenMarkdownLinks": "warn",
     "onDuplicateRoutes": "warn",
     "plugins": [],
     "presets": [],
@@ -342,6 +350,9 @@ exports[`loadSiteConfig website with valid TypeScript CJS config 1`] = `
         "maintainCase": false,
       },
       "format": "mdx",
+      "hooks": {
+        "onBrokenMarkdownLinks": "warn",
+      },
       "mdx1Compat": {
         "admonitions": true,
         "comments": true,
@@ -355,7 +366,6 @@ exports[`loadSiteConfig website with valid TypeScript CJS config 1`] = `
     "noIndex": false,
     "onBrokenAnchors": "warn",
     "onBrokenLinks": "throw",
-    "onBrokenMarkdownLinks": "warn",
     "onDuplicateRoutes": "warn",
     "plugins": [],
     "presets": [],
@@ -417,6 +427,9 @@ exports[`loadSiteConfig website with valid TypeScript ESM config 1`] = `
         "maintainCase": false,
       },
       "format": "mdx",
+      "hooks": {
+        "onBrokenMarkdownLinks": "warn",
+      },
       "mdx1Compat": {
         "admonitions": true,
         "comments": true,
@@ -430,7 +443,6 @@ exports[`loadSiteConfig website with valid TypeScript ESM config 1`] = `
     "noIndex": false,
     "onBrokenAnchors": "warn",
     "onBrokenLinks": "throw",
-    "onBrokenMarkdownLinks": "warn",
     "onDuplicateRoutes": "warn",
     "plugins": [],
     "presets": [],
@@ -492,6 +504,9 @@ exports[`loadSiteConfig website with valid async config 1`] = `
         "maintainCase": false,
       },
       "format": "mdx",
+      "hooks": {
+        "onBrokenMarkdownLinks": "warn",
+      },
       "mdx1Compat": {
         "admonitions": true,
         "comments": true,
@@ -505,7 +520,6 @@ exports[`loadSiteConfig website with valid async config 1`] = `
     "noIndex": false,
     "onBrokenAnchors": "warn",
     "onBrokenLinks": "throw",
-    "onBrokenMarkdownLinks": "warn",
     "onDuplicateRoutes": "warn",
     "organizationName": "endiliey",
     "plugins": [],
@@ -569,6 +583,9 @@ exports[`loadSiteConfig website with valid async config creator function 1`] = `
         "maintainCase": false,
       },
       "format": "mdx",
+      "hooks": {
+        "onBrokenMarkdownLinks": "warn",
+      },
       "mdx1Compat": {
         "admonitions": true,
         "comments": true,
@@ -582,7 +599,6 @@ exports[`loadSiteConfig website with valid async config creator function 1`] = `
     "noIndex": false,
     "onBrokenAnchors": "warn",
     "onBrokenLinks": "throw",
-    "onBrokenMarkdownLinks": "warn",
     "onDuplicateRoutes": "warn",
     "organizationName": "endiliey",
     "plugins": [],
@@ -646,6 +662,9 @@ exports[`loadSiteConfig website with valid config creator function 1`] = `
         "maintainCase": false,
       },
       "format": "mdx",
+      "hooks": {
+        "onBrokenMarkdownLinks": "warn",
+      },
       "mdx1Compat": {
         "admonitions": true,
         "comments": true,
@@ -659,7 +678,6 @@ exports[`loadSiteConfig website with valid config creator function 1`] = `
     "noIndex": false,
     "onBrokenAnchors": "warn",
     "onBrokenLinks": "throw",
-    "onBrokenMarkdownLinks": "warn",
     "onDuplicateRoutes": "warn",
     "organizationName": "endiliey",
     "plugins": [],
@@ -726,6 +744,9 @@ exports[`loadSiteConfig website with valid siteConfig 1`] = `
         "maintainCase": false,
       },
       "format": "mdx",
+      "hooks": {
+        "onBrokenMarkdownLinks": "warn",
+      },
       "mdx1Compat": {
         "admonitions": true,
         "comments": true,
@@ -739,7 +760,6 @@ exports[`loadSiteConfig website with valid siteConfig 1`] = `
     "noIndex": false,
     "onBrokenAnchors": "warn",
     "onBrokenLinks": "throw",
-    "onBrokenMarkdownLinks": "warn",
     "onDuplicateRoutes": "warn",
     "organizationName": "endiliey",
     "plugins": [

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/site.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/site.test.ts.snap
@@ -126,6 +126,9 @@ exports[`load loads props for site with custom i18n path 1`] = `
         "maintainCase": false,
       },
       "format": "mdx",
+      "hooks": {
+        "onBrokenMarkdownLinks": "warn",
+      },
       "mdx1Compat": {
         "admonitions": true,
         "comments": true,
@@ -139,7 +142,6 @@ exports[`load loads props for site with custom i18n path 1`] = `
     "noIndex": false,
     "onBrokenAnchors": "warn",
     "onBrokenLinks": "throw",
-    "onBrokenMarkdownLinks": "warn",
     "onDuplicateRoutes": "warn",
     "plugins": [],
     "presets": [],

--- a/packages/docusaurus/src/server/__tests__/configValidation.test.ts
+++ b/packages/docusaurus/src/server/__tests__/configValidation.test.ts
@@ -592,7 +592,8 @@ describe('markdown', () => {
           expect(warnMock).toHaveBeenCalledTimes(1);
           expect(warnMock.mock.calls[0]).toMatchInlineSnapshot(`
             [
-              "[WARNING] The \`siteConfig.onBrokenMarkdownLinks\` config option is deprecated and will be removed in Docusaurus v4. Please migrate and move this option to \`siteConfig.markdown.hooks.onBrokenMarkdownLinks\` instead.",
+              "[WARNING] The \`siteConfig.onBrokenMarkdownLinks\` config option is deprecated and will be removed in Docusaurus v4.
+            Please migrate and move this option to \`siteConfig.markdown.hooks.onBrokenMarkdownLinks\` instead.",
             ]
           `);
         });

--- a/packages/docusaurus/src/server/__tests__/configValidation.test.ts
+++ b/packages/docusaurus/src/server/__tests__/configValidation.test.ts
@@ -16,7 +16,10 @@ import {
   DEFAULT_STORAGE_CONFIG,
   validateConfig,
 } from '../configValidation';
-import type {MarkdownConfig, MarkdownHooks} from '@docusaurus/types/src/markdown';
+import type {
+  MarkdownConfig,
+  MarkdownHooks,
+} from '@docusaurus/types/src/markdown';
 import type {
   FasterConfig,
   FutureConfig,
@@ -108,6 +111,9 @@ describe('normalizeConfig', () => {
         },
         remarkRehypeOptions: {
           footnoteLabel: 'Pied de page',
+        },
+        hooks: {
+          onBrokenMarkdownLinks: 'log',
         },
       },
     };

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -17,6 +17,7 @@ import {
   removeTrailingSlash,
 } from '@docusaurus/utils-common';
 import logger from '@docusaurus/logger';
+import type {MarkdownHooks} from '@docusaurus/types/src/markdown';
 import type {
   FasterConfig,
   FutureConfig,
@@ -84,6 +85,10 @@ export const DEFAULT_FUTURE_CONFIG: FutureConfig = {
   experimental_router: 'browser',
 };
 
+export const DEFAULT_MARKDOWN_HOOKS: MarkdownHooks = {
+  onBrokenMarkdownLinks: 'warn',
+};
+
 export const DEFAULT_MARKDOWN_CONFIG: MarkdownConfig = {
   format: 'mdx', // TODO change this to "detect" in Docusaurus v4?
   mermaid: false,
@@ -98,6 +103,7 @@ export const DEFAULT_MARKDOWN_CONFIG: MarkdownConfig = {
     maintainCase: false,
   },
   remarkRehypeOptions: undefined,
+  hooks: DEFAULT_MARKDOWN_HOOKS,
 };
 
 export const DEFAULT_CONFIG: Pick<
@@ -455,6 +461,11 @@ export const ConfigSchema = Joi.object<DocusaurusConfig>({
         DEFAULT_CONFIG.markdown.anchors.maintainCase,
       ),
     }).default(DEFAULT_CONFIG.markdown.anchors),
+    hooks: Joi.object<MarkdownHooks>({
+      onBrokenMarkdownLinks: Joi.string()
+        .equal('ignore', 'log', 'warn', 'throw')
+        .default(DEFAULT_CONFIG.markdown.hooks.onBrokenMarkdownLinks),
+    }).default(DEFAULT_CONFIG.markdown.hooks),
   }).default(DEFAULT_CONFIG.markdown),
 }).messages({
   'docusaurus.configValidationWarning':

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -476,7 +476,8 @@ export const ConfigSchema = Joi.object<DocusaurusConfig>({
 // We also want to decouple logic from Joi: easier to remove it later!
 function postProcessDocusaurusConfig(config: DocusaurusConfig) {
   if (config.onBrokenMarkdownLinks) {
-    logger.warn`The code=${'siteConfig.onBrokenMarkdownLinks'} config option is deprecated and will be removed in Docusaurus v4. Please migrate and move this option to code=${'siteConfig.markdown.hooks.onBrokenMarkdownLinks'} instead.`;
+    logger.warn`The code=${'siteConfig.onBrokenMarkdownLinks'} config option is deprecated and will be removed in Docusaurus v4.
+Please migrate and move this option to code=${'siteConfig.markdown.hooks.onBrokenMarkdownLinks'} instead.`;
     // For v3 retro compatibility we use the old attribute over the new one
     config.markdown.hooks.onBrokenMarkdownLinks = config.onBrokenMarkdownLinks;
     // We erase the former one to ensure we don't use it anywhere

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -217,6 +217,9 @@ export default async function createConfigAsync() {
     markdown: {
       format: 'detect',
       mermaid: true,
+      hooks: {
+        onBrokenMarkdownLinks: 'warn',
+      },
       mdx1Compat: {
         // comments: false,
       },
@@ -265,7 +268,6 @@ export default async function createConfigAsync() {
       process.env.DOCUSAURUS_CURRENT_LOCALE !== defaultLocale
         ? 'warn'
         : 'throw',
-    onBrokenMarkdownLinks: 'warn',
     favicon: 'img/docusaurus.ico',
     customFields: {
       crashTest,


### PR DESCRIPTION

## Motivation

We want to have hooks to eventually report and recover from broken markdown links and images.

Fix https://github.com/facebook/docusaurus/issues/11219

This PR deprecates `siteConfig.onBrokenMarkdownLinks` in favor of `siteConfig.markdown.hooks.onBrokenMarkdownLinks`. It now also has the ability to recover from broken markdown file paths by returning a fallback value.

TODO: implement `siteConfig.markdown.hooks.onBrokenMarkdownImages`

## Test Plan

Unit tests

### Test links

https://deploy-preview-_____--docusaurus-2.netlify.app/

