### PR TITLE
feat(create-docusaurus): use respectPrefersColorScheme in init template

### DIFF
--- a/packages/create-docusaurus/templates/classic-typescript/docusaurus.config.ts
+++ b/packages/create-docusaurus/templates/classic-typescript/docusaurus.config.ts
@@ -71,6 +71,9 @@ const config: Config = {
   themeConfig: {
     // Replace with your project's social card
     image: 'img/docusaurus-social-card.jpg',
+    colorMode: {
+      respectPrefersColorScheme: true,
+    },
     navbar: {
       title: 'My Site',
       logo: {

--- a/packages/create-docusaurus/templates/classic/docusaurus.config.js
+++ b/packages/create-docusaurus/templates/classic/docusaurus.config.js
@@ -79,6 +79,9 @@ const config = {
     ({
       // Replace with your project's social card
       image: 'img/docusaurus-social-card.jpg',
+      colorMode: {
+        respectPrefersColorScheme: true,
+      },
       navbar: {
         title: 'My Site',
         logo: {


### PR DESCRIPTION

## Motivation

Use `themeConfig.colorMode.respectPrefersColorScheme` in our init templates to make it easier to discover the "system color mode" feature.

In Docusaurus v4 I think we'll change the default config value to `true`

## Test Plan

local init template tests + CI (windows e2e artifact)

### Test links

https://deploy-preview-_____--docusaurus-2.netlify.app/

