### PR TITLE
test(docs): fix docs tests issues

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -62,6 +62,12 @@ async function createMdxLoaderDependencyFile({
   options: PluginOptions;
   versionsMetadata: VersionMetadata[];
 }): Promise<string | undefined> {
+  // Disabled for unit tests, the side effect produces infinite watch loops
+  // TODO find a better way :/
+  if (process.env.NODE_ENV === 'test') {
+    return undefined;
+  }
+
   const filePath = path.join(dataDir, '__mdx-loader-dependency.json');
   // the cache is invalidated whenever this file content changes
   const fileContent = {

--- a/packages/docusaurus-plugin-content-docs/src/versions/loadVersion.ts
+++ b/packages/docusaurus-plugin-content-docs/src/versions/loadVersion.ts
@@ -38,6 +38,12 @@ type LoadVersionParams = {
 
 function ensureNoDuplicateDocId(docs: DocMetadataBase[]): void {
   const duplicatesById = _.chain(docs)
+    .sort((d1, d2) => {
+      // Need to sort because Globby order is non-deterministic
+      // TODO maybe we should create a deterministic glob utils?
+      //  see https://github.com/sindresorhus/globby/issues/131
+      return d1.source.localeCompare(d2.source);
+    })
     .groupBy((d) => d.id)
     .pickBy((group) => group.length > 1)
     .value();


### PR DESCRIPTION


## Motivation

Solving 2 cases annoying me:
- Infinite test watch loop due to creating an MDX dependency file
- Non-deterministic snapshot due to non-deterministic docs order returned by Globby (https://github.com/sindresorhus/globby/issues/131)

This shouldn't have any significant impact on anything apart from making my life easier


## Test Plan

CI + local

