### PR TITLE
docs(website): fix duplicate anchor id typo

### DIFF
--- a/website/docs/guides/docs/sidebar/index.mdx
+++ b/website/docs/guides/docs/sidebar/index.mdx
@@ -191,7 +191,7 @@ To pass in custom props to a sidebar item, add the optional `customProps` object
 };
 ```
 
-## Passing a unique key {#passing-custom-props}
+## Passing a unique key {#passing-unique-key}
 
 Passing a unique `key` attribute can help uniquely identify a sidebar item. Sometimes other attributes (such as `label`) are not enough to distinguish two sidebar items from each other.
 


### PR DESCRIPTION


## Motivation

We have 2 headings with the same id


When running `yarn build:website:fast --dev && yarn serve:website` we get a React hydration due to 2 TOC items having the same React key. 

Error caught by our CI: https://github.com/facebook/docusaurus/actions/runs/16076678264/job/45373437084?pr=11304

