### PR TITLE
fix(theme-classic): fix that category doesn't expand upon navigating to some menu under already active category.

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Category/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Category/index.tsx
@@ -37,18 +37,30 @@ function useAutoExpandActiveCategory({
   isActive,
   collapsed,
   updateCollapsed,
+  activePath,
 }: {
   isActive: boolean;
   collapsed: boolean;
   updateCollapsed: (b: boolean) => void;
+  activePath: string;
 }) {
   const wasActive = usePrevious(isActive);
+  const previousActivePath = usePrevious(activePath);
   useEffect(() => {
     const justBecameActive = isActive && !wasActive;
-    if (justBecameActive && collapsed) {
+    const stillActiveButPathChanged =
+      isActive && wasActive && activePath !== previousActivePath;
+    if ((justBecameActive || stillActiveButPathChanged) && collapsed) {
       updateCollapsed(false);
     }
-  }, [isActive, wasActive, collapsed, updateCollapsed]);
+  }, [
+    isActive,
+    wasActive,
+    collapsed,
+    updateCollapsed,
+    activePath,
+    previousActivePath,
+  ]);
 }
 
 /**
@@ -150,7 +162,12 @@ export default function DocSidebarItemCategory({
     setExpandedItem(toCollapsed ? null : index);
     setCollapsed(toCollapsed);
   };
-  useAutoExpandActiveCategory({isActive, collapsed, updateCollapsed});
+  useAutoExpandActiveCategory({
+    isActive,
+    collapsed,
+    updateCollapsed,
+    activePath,
+  });
   useEffect(() => {
     if (
       collapsible &&

--- a/website/_dogfooding/_docs tests/tests/test-expansion/menu-under-same-category.mdx
+++ b/website/_dogfooding/_docs tests/tests/test-expansion/menu-under-same-category.mdx
@@ -1,0 +1,5 @@
+---
+sidebar_position: 2
+---
+
+# Another Menu

--- a/website/_dogfooding/_docs tests/tests/test-expansion/test-category-expansion.mdx
+++ b/website/_dogfooding/_docs tests/tests/test-expansion/test-category-expansion.mdx
@@ -1,0 +1,8 @@
+---
+sidebar_position: 1
+---
+
+# Test Expansion
+
+- [go to menu on different category](../sidebar-frontmatter/doc-with-sidebar-className)
+- [go to menu under same category](./menu-under-same-category)


### PR DESCRIPTION
…

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation
- As i have mentioned in the issue #11122, currently docsidebarItem/Category doesn't expand when the user navigates to the menu under the same category(when it's in collapsed state). It only expands when the user navigates to the menu in not active category. 
- This behavior is due to the [useAutoExpandActiveCategory](https://github.com/facebook/docusaurus/blob/67924ca9795c4cd0399c752b4345f515bcedcaf6/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Category/index.tsx#L36) function in DocsidebarItem/Category in theme-classic. Currently DocSidebarItemCategory only expand itself when it changes from inactive to active, not when it is already active but the url path changes.
- This not only affects when the user navigates to the menu under the active category by clicking markdown link, but also when the user searches menu through algolia and clicks on the result to navigate to that page(as stressed in the issue).

## Test Plan
1. So I included the dogfooding page in the dogfooding test section for test. 
2. yarn build and go to the dogfooding page. (http://localhost:3000/tests/docs/tests/test-expansion/test-category-expansion)
3. collapse the `test-expansion` category and on the page click `go to menu under same category` menu to see the changed behavior.

#### Before 
https://github.com/user-attachments/assets/e90c4947-c8b6-45f9-8882-b28027540229

#### After
https://github.com/user-attachments/assets/71dbe66f-6be9-4f87-abeb-6e48d6ea4cb6

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs
#11122 

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
