### PR TITLE
fix(core): Fix docusaurus start on macOS when exec throws a synchronous error

### DIFF
--- a/packages/docusaurus/src/commands/utils/openBrowser/openBrowser.ts
+++ b/packages/docusaurus/src/commands/utils/openBrowser/openBrowser.ts
@@ -72,10 +72,16 @@ async function tryOpenWithAppleScript({
         '|',
       )})$"`;
 
-      const result = await execPromise(command).catch(() => {
-        // Ignore grep errors when macOS user has no Chromium-based browser open
-        // See https://github.com/facebook/docusaurus/issues/11204
-      });
+      const result = await Promise
+        // TODO Docusaurus v4: use Promise.try()
+        // See why here https://github.com/facebook/docusaurus/issues/11204#issuecomment-3073480330
+        .resolve()
+        .then(() => execPromise(command))
+        .catch(() => {
+          // Ignore all errors
+          // In particular grep errors when macOS user has no Chromium-based browser open
+          // See https://github.com/facebook/docusaurus/issues/11204
+        });
       if (!result) {
         return [];
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9652,7 +9652,7 @@ has-yarn@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-yarn/-/has-yarn-3.0.0.tgz#c3c21e559730d1d3b57e28af1f30d06fac38147d"
   integrity sha512-IrsVwUHhEULx3R8f/aA8AHuEzAorplsab/v8HBzEiIukwq5i/EC+xmOW+HfP1OaDP+2JkgT1yILHN2O3UFIbcA==
 
-hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
+hasown@^2.0.0, hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==


### PR DESCRIPTION


## Motivation

Fix little docusaurus start issue reported here by also catching synchronous errors that execPromise might throw

https://github.com/facebook/docusaurus/issues/11204#issuecomment-3073480330

## Test Plan

hard to reproduce and test even locally 😓 
