### PR TITLE
fix(theme): Add translate no to heading anchors and blog authors

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Blog/Components/Author/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Blog/Components/Author/index.tsx
@@ -30,10 +30,14 @@ function AuthorTitle({title}: {title: string}) {
 
 function AuthorName({name, as}: {name: string; as: Props['as']}) {
   if (!as) {
-    return <span className={styles.authorName}>{name}</span>;
+    return (
+      <span className={styles.authorName} translate="no">
+        {name}
+      </span>
+    );
   } else {
     return (
-      <Heading as={as} className={styles.authorName}>
+      <Heading as={as} className={styles.authorName} translate="no">
         {name}
       </Heading>
     );

--- a/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
@@ -54,7 +54,8 @@ export default function Heading({as: As, id, ...props}: Props): ReactNode {
         className="hash-link"
         to={`#${id}`}
         aria-label={anchorTitle}
-        title={anchorTitle}>
+        title={anchorTitle}
+        translate="no">
         &#8203;
       </Link>
     </As>


### PR DESCRIPTION
## Motivation

Try to fix google auto-translate

Fix https://github.com/facebook/docusaurus/issues/11358

See also https://www.stefanjudis.com/today-i-learned/non-translatable-html-elements/

## Test Plan

preview

### Test links

https://deploy-preview-11360--docusaurus-2.netlify.app/

