### PR TITLE
fix(theme-classic): reverse color mode toggle icons to show target state

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/ColorModeToggle/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/ColorModeToggle/styles.module.css
@@ -30,8 +30,8 @@
 }
 
 [data-theme-choice='system'] .systemToggleIcon,
-[data-theme-choice='light'] .lightToggleIcon,
-[data-theme-choice='dark'] .darkToggleIcon {
+[data-theme-choice='light'] .darkToggleIcon,
+[data-theme-choice='dark'] .lightToggleIcon {
   display: initial;
 }
 


### PR DESCRIPTION
This PR corrects the light/dark mode toggle icon behavior in the Classic theme.  
The toggle now shows the **target state** (the mode it will switch to), instead of the current state.  
This matches common UX conventions and makes the toggle more intuitive.  
**Closes:** #11370

---

### Changes

- **CSS** (`packages/docusaurus-theme-classic/src/theme/ColorModeToggle/styles.module.css`):
  - Updated logic for `.lightToggleIcon` and `.darkToggleIcon` under `[data-theme-choice]`.
    - **Light mode** → shows the **moon** (indicates toggle to dark).  
    - **Dark mode** → shows the **sun** (indicates toggle to light).  
  - **System mode** is unchanged (still shows the system icon).

---
### BEFORE
![Screenshot_2025-08-19_06:18pm-1](https://github.com/user-attachments/assets/c003cc33-4187-410c-af95-3d34d2ad8a18)
![Screenshot_2025-08-19_06:18pm](https://github.com/user-attachments/assets/0ce293c9-312e-4205-8fdc-31516dc807a0)


### AFTER
![Screenshot_2025-08-19_06:16pm-1](https://github.com/user-attachments/assets/67d898c7-489c-45e0-b7b1-3cf0ce304d8b)
![Screenshot_2025-08-19_06:16pm](https://github.com/user-attachments/assets/3f99ff71-aa3d-447a-b6db-5d68b6d4906f)

| Mode    | Before Icon | After Icon  |
| ------- | ----------- | ----------- |
| Light   | ☀️ (sun)    | 🌙 (moon)   |
| Dark    | 🌙 (moon)   | ☀️ (sun)    |
| System  | ⚙️ (system) | ⚙️ (system) |

---

### Test Plan

```
yarn clear && yarn workspace website start && hard-refresh browser
```
1. Verify:  
   - Light mode → moon icon  
   - Dark mode → sun icon  
   - System mode → system icon  
2. Click toggle in each mode to confirm functionality remains unchanged.

---

### Checklist

- [x] Small change (~3 lines CSS)  
- [x] Semantic PR title  
- [x] Closes linked issue (#11370)  
- [x] Clear test plan provided  
- [x] No breaking changes (visual-only)  
- [x] CLA ready  

---

### Breaking Changes

None - purely a visual/UX fix.

---

Thanks for reviewing! :)