### PR TITLE
fix(theme-classic): reverse color mode toggle icon logic and update

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/ColorModeToggle/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/ColorModeToggle/index.tsx
@@ -44,21 +44,21 @@ function getColorModeLabel(colorMode: ColorMode | null): string {
   switch (colorMode) {
     case null:
       return translate({
-        message: 'system mode',
-        id: 'theme.colorToggle.ariaLabel.mode.system',
-        description: 'The name for the system color mode',
+        message: 'Switch to system mode',
+        id: 'theme.colorToggle.title.system',
+        description: 'The title for switching to system color mode',
       });
     case 'light':
       return translate({
-        message: 'light mode',
-        id: 'theme.colorToggle.ariaLabel.mode.light',
-        description: 'The name for the light color mode',
+        message: 'Switch to dark mode',
+        id: 'theme.colorToggle.title.light',
+        description: 'The title for switching to dark color mode',
       });
     case 'dark':
       return translate({
-        message: 'dark mode',
-        id: 'theme.colorToggle.ariaLabel.mode.dark',
-        description: 'The name for the dark color mode',
+        message: 'Switch to light mode',
+        id: 'theme.colorToggle.title.dark',
+        description: 'The title for switching to light color mode',
       });
     default:
       throw new Error(`unexpected color mode ${colorMode}`);
@@ -68,12 +68,12 @@ function getColorModeLabel(colorMode: ColorMode | null): string {
 function getColorModeAriaLabel(colorMode: ColorMode | null) {
   return translate(
     {
-      message: 'Switch between dark and light mode (currently {mode})',
+      message: 'Switch to {mode}',
       id: 'theme.colorToggle.ariaLabel',
       description: 'The ARIA label for the color mode toggle',
     },
     {
-      mode: getColorModeLabel(colorMode),
+      mode: getColorModeLabel(colorMode).replace('Switch to ', ''),
     },
   );
 }

--- a/packages/docusaurus-theme-classic/src/theme/ColorModeToggle/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/ColorModeToggle/styles.module.css
@@ -30,8 +30,8 @@
 }
 
 [data-theme-choice='system'] .systemToggleIcon,
-[data-theme-choice='light'] .lightToggleIcon,
-[data-theme-choice='dark'] .darkToggleIcon {
+[data-theme-choice='light'] .darkToggleIcon,
+[data-theme-choice='dark'] .lightToggleIcon {
   display: initial;
 }
 


### PR DESCRIPTION
   ## Description
   Fixes the light/dark mode toggle icon logic and updates titles to follow standard UX conventions.
   
   **Changes:**
   - Reversed icon display: light mode shows moon icon, dark mode shows sun icon
   - Updated titles to describe action ("Switch to X mode") instead of current state
   - Updated aria-labels for consistency
   
   **Fixes:** [Issue #11370](https://github.com/facebook/docusaurus/issues/11370)
   
   ## Test Plan
   - [x] No TypeScript compilation errors
   - [x] Built packages successfully
   - [x] Lint-staged passed
   - [x] Test in browser (icon shows correctly, titles are descriptive)