### PR TITLE
docs(website): just some animated testimonials marquee, hover lift-to-center, and view‑all overlay

### DIFF
--- a/argos/tests/screenshot.css
+++ b/argos/tests/screenshot.css
@@ -48,6 +48,11 @@ Mermaid diagrams are rendered client-side and produce layout shifts
   visibility: hidden;
 }
 
+/* Testimonials marquee moves: hide to avoid visual flakiness */
+.tweetsMarquee {
+  visibility: hidden;
+}
+
 /* YouTube player lite can load video lazily */
 article.yt-lite {
   visibility: hidden;

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -223,23 +223,268 @@ html[data-theme='dark'] .topBannerTitleText {
   }
 }
 
+.tweetsMarquee {
+  position: relative;
+  overflow: hidden;
+  padding: 8px 0;
+}
+
+.tweetsMarquee::before,
+.tweetsMarquee::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 64px;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.tweetsMarquee::before {
+  left: 0;
+  background: linear-gradient(
+    to right,
+    var(--ifm-color-emphasis-100) 0%,
+    rgb(255 255 255 / 0%) 70%
+  );
+}
+
+.tweetsMarquee::after {
+  right: 0;
+  background: linear-gradient(
+    to left,
+    var(--ifm-color-emphasis-100) 0%,
+    rgb(255 255 255 / 0%) 70%
+  );
+}
+
+html[data-theme='dark'] .tweetsMarquee::before {
+  background: linear-gradient(
+    to right,
+    var(--ifm-background-surface-color) 0%,
+    rgb(0 0 0 / 0%) 70%
+  );
+}
+html[data-theme='dark'] .tweetsMarquee::after {
+  background: linear-gradient(
+    to left,
+    var(--ifm-background-surface-color) 0%,
+    rgb(0 0 0 / 0%) 70%
+  );
+}
+
+.tweetsHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.2rem;
+}
+.tweetsTitle {
+  margin: 0;
+}
+
+.tweetsViewAll {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+.tweetsViewAllIcon {
+  margin-right: 0.1rem;
+}
+
+.tweetsTrack {
+  display: flex;
+  gap: 16px;
+  will-change: transform;
+  align-items: flex-start;
+}
+
+.tweetsSet {
+  display: flex;
+  gap: 16px;
+}
+
+.tweetItem {
+  position: relative;
+  flex: 0 0 auto;
+  --ty: 0;
+  transform: translateY(var(--ty));
+  transition: transform 0.35s ease, filter 0.35s ease;
+  z-index: 0;
+}
+.tweetItem > * {
+  height: 100%;
+}
+
+.tweetItem > :global(.card) {
+  width: clamp(280px, 30vw, 420px);
+  max-width: 420px;
+}
+
+.tweetItem:hover {
+  transform: translateY(calc(var(--ty) - 2px)) scale(1.06);
+  z-index: 5;
+  filter: drop-shadow(0 14px 34px rgb(0 0 0 / 25%));
+}
+
+.tweetItem::after {
+  content: '';
+  position: absolute;
+  left: 10%;
+  right: 10%;
+  bottom: -10px;
+  height: 18px;
+  background: radial-gradient(closest-side, rgb(0 0 0 / 22%), rgb(0 0 0 / 0%));
+  filter: blur(10px);
+  opacity: 0;
+  transition: opacity 0.35s ease;
+  z-index: -1;
+}
+.tweetItem:hover::after {
+  opacity: 1;
+}
+
+.tweetsSet .tweetItem:nth-child(1) {
+  --ty: -10px;
+}
+.tweetsSet .tweetItem:nth-child(2) {
+  --ty: 14px;
+}
+.tweetsSet .tweetItem:nth-child(3) {
+  --ty: -6px;
+}
+.tweetsSet .tweetItem:nth-child(4) {
+  --ty: 10px;
+}
+.tweetsSet .tweetItem:nth-child(5) {
+  --ty: -12px;
+}
+.tweetsSet .tweetItem:nth-child(6) {
+  --ty: 8px;
+}
+.tweetsSet .tweetItem:nth-child(7) {
+  --ty: -4px;
+}
+.tweetsSet .tweetItem:nth-child(8) {
+  --ty: 12px;
+}
+.tweetsSet .tweetItem:nth-child(9) {
+  --ty: -8px;
+}
+
+.tweetsOverlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+  z-index: 50;
+  background: rgb(0 0 0 / 12%);
+  backdrop-filter: blur(8px) saturate(120%);
+}
+.tweetsOverlayVisible {
+  opacity: 1;
+}
+
+.tweetsOverlayCard {
+  pointer-events: auto;
+  transform: translate(var(--from-x, 0), var(--from-y, 0))
+    scale(var(--from-s, 1));
+  transition: transform 0.5s cubic-bezier(0.22, 0.61, 0.36, 1), filter 0.3s ease;
+  filter: drop-shadow(0 30px 60px rgb(0 0 0 / 35%));
+}
+
+.tweetsOverlayCard > :global(.card) {
+  width: min(90vw, 760px);
+  max-width: 760px;
+}
+.tweetsOverlayAnim .tweetsOverlayCard {
+  transform: translate(0, 0) scale(1.15);
+}
+
+.tweetsAllOverlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(0 0 0 / 18%);
+  backdrop-filter: blur(6px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+  z-index: 60;
+}
+
+.tweetsAllVisible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.tweetsAllPanel {
+  background: var(--ifm-background-surface-color);
+  border-radius: 14px;
+  box-shadow: 0 24px 80px rgb(0 0 0 / 35%);
+  width: min(1200px, 94vw);
+  max-height: 88vh;
+  overflow: auto;
+  transform: scale(0.96) translateY(8px);
+  transition: transform 0.28s cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+.tweetsAllVisible .tweetsAllPanel {
+  transform: scale(1) translateY(0);
+}
+
+.tweetsAllHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+.tweetsAllTitle {
+  margin: 0;
+}
+
+.tweetsAllClose {
+  display: inline-flex;
+  align-items: center;
+}
+
+.tweetsAllGrid {
+  padding: 16px 18px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+.tweetsAllItem > :global(.card) {
+  height: 100%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tweetsMarquee::before,
+  .tweetsMarquee::after {
+    display: none;
+  }
+}
+
 .tweetsSection > :global(.col) > * {
   margin-bottom: 2rem;
 }
-
 @media (max-width: 996px) {
   .tweetsSection > :global(.col:last-child) > *:last-child {
     margin-bottom: 0;
   }
 }
-
 @media (min-width: 997px) {
   .tweetsSection > :global(.col) > *:last-child {
     margin-bottom: 0;
   }
 }
 
-/* Used to test CSS insertion order */
 .test-marker-site-index-page {
   content: 'site-index-page';
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation
See I am in good-amount fond of improvements in ui/frontend of the pages, so for the section where testimonial cards are there, applied marquee effect of the cards, then there is also the view all overlay button which would help to see all the cards at once. These are take on bit of design stuffs added to the frontend homepage dyamics of the docusaurus. I HAVE TAKEN INSPIRATION FROM WEBSITES LIKE REACT BITS, VUE BITS.  Later if the reviewer is also okay with these minute ui changes, i also may add some more card details and designs when they are in the hover state with high z -index
## Test Plan

•  yarn workspace website start
•  Hover cards to verify pause/lift/center animation and resume on leave
•  Click View all to open overlay--verify grid layout and close button
•  Toggle OS reduced motion to verify animation disables
•  CI: Argos hides marquee via .tweetsMarquee to avoid flakiness
website/src/pages/index.tsx
website/src/pages/styles.module.css
argos/tests/screenshot.css

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.
- 


After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->
<img width="1760" height="520" alt="image" src="https://github.com/user-attachments/assets/81db11e9-0d3f-45dd-a233-7af80fcf15bc" />
<img width="1756" height="722" alt="image" src="https://github.com/user-attachments/assets/532e8b73-c3f6-4bdb-8bf3-e985155d50d9" />
<img width="1489" height="833" alt="image" src="https://github.com/user-attachments/assets/fffb8dd6-5e3b-4854-9974-902efaeb430c" />



Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
