### PR TITLE
chore(ci): Change Lighthouse trigger from pull_request_target to pull_request

### DIFF
--- a/.github/workflows/lighthouse-report.yml
+++ b/.github/workflows/lighthouse-report.yml
@@ -1,7 +1,7 @@
 name: Lighthouse Report
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - docusaurus-v**


### PR DESCRIPTION


## Motivation

The recent Nx critical supply chain attack (https://socket.dev/blog/nx-packages-compromised) is due to the usage of `pull_request_target`: https://x.com/adnanthekhan/status/1958722939534417989

We also use `pull_request_target` on this action, but:
- this is very risky, and the code below can introduce critical vulnerabilities
- it doesn't even work because we run Lighthouse on our main branch (see https://github.com/facebook/docusaurus/issues/9449#issuecomment-1779360339), and checkout out the base branch would introduce the vulnerability


So, I'm moving the event to the much safer `pull_request`. This: 
- fixes the security risk
- fixes the Lighthouse job for internal PRs
- unfortunately, external PRs won't be able to post the GitHub lighthouse comment.

Posting a comment to an external PR should be fixable. If someone wants to improve our workflow, please submit a PR, but I'll only accept the usage of `pull_request_target` on tiny workflows that doesn't execute any code outside of the Yaml workflow itself.


See also https://github.blog/security/application-security/how-to-secure-your-github-actions-workflows-with-codeql/


## Test Plan

CI


