### PR TITLE
fix(theme): fix `useColorMode()` visual glitches due to provider unmounts/remounts

### DIFF
--- a/packages/docusaurus-theme-common/src/contexts/colorMode.tsx
+++ b/packages/docusaurus-theme-common/src/contexts/colorMode.tsx
@@ -13,6 +13,7 @@ import React, {
   useMemo,
   type ReactNode,
 } from 'react';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 import {ReactContextError} from '../utils/reactUtils';
 import {createStorageSlot} from '../utils/storageUtils';
 import {useThemeConfig} from '../utils/useThemeConfig';
@@ -124,10 +125,17 @@ function useColorModeState() {
   const {
     colorMode: {defaultMode},
   } = useThemeConfig();
+  const isBrowser = useIsBrowser();
 
-  const [colorMode, setColorModeState] = useState<ColorMode>(defaultMode);
-  const [colorModeChoice, setColorModeChoiceState] =
-    useState<ColorModeChoice>(null);
+  // Since the provider may unmount/remount on client navigation, we need to
+  // reinitialize the state with the correct values to avoid visual glitches.
+  // See also https://github.com/facebook/docusaurus/issues/11399#issuecomment-3279181314
+  const [colorMode, setColorModeState] = useState<ColorMode>(
+    isBrowser ? ColorModeAttribute.get() : defaultMode,
+  );
+  const [colorModeChoice, setColorModeChoiceState] = useState<ColorModeChoice>(
+    isBrowser ? ColorModeChoiceAttribute.get() : null,
+  );
 
   useEffect(() => {
     setColorModeState(ColorModeAttribute.get());


### PR DESCRIPTION

## Motivation

Fix visual glitch reported in https://github.com/facebook/docusaurus/issues/11399

See why we apply this solution here: https://github.com/facebook/docusaurus/issues/11399#issuecomment-3279181314

## Test Plan

deploy preview

### Test links

https://deploy-preview-11405--docusaurus-2.netlify.app/


