### PR TITLE
feat(eslint): add prefer-ideal-image rule

### DIFF
--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -17,7 +17,6 @@ export = {
         '@docusaurus/string-literal-i18n-messages': 'error',
         '@docusaurus/no-html-links': 'warn',
         '@docusaurus/prefer-docusaurus-heading': 'warn',
-        '@docusaurus/prefer-ideal-image': 'warn',
       },
     },
     all: {

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -17,6 +17,7 @@ export = {
         '@docusaurus/string-literal-i18n-messages': 'error',
         '@docusaurus/no-html-links': 'warn',
         '@docusaurus/prefer-docusaurus-heading': 'warn',
+        '@docusaurus/prefer-ideal-image': 'warn',
       },
     },
     all: {
@@ -26,6 +27,7 @@ export = {
         '@docusaurus/no-untranslated-text': 'warn',
         '@docusaurus/no-html-links': 'warn',
         '@docusaurus/prefer-docusaurus-heading': 'warn',
+        '@docusaurus/prefer-ideal-image': 'warn',
       },
     },
   },

--- a/packages/eslint-plugin/src/rules/__tests__/prefer-ideal-image.test.ts
+++ b/packages/eslint-plugin/src/rules/__tests__/prefer-ideal-image.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import rule from '../prefer-ideal-image';
+import {RuleTester} from './testUtils';
+
+const errorsJSX = [{messageId: 'idealImage'}] as const;
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+ruleTester.run('prefer-ideal-image', rule, {
+  valid: [
+    {
+      code: '<Image src={thumbnail}/>',
+    },
+    {
+      code: "<Image src='path/to/image'/>",
+    },
+  ],
+  invalid: [
+    {
+      code: '<img sec={thumbnail} />',
+      errors: errorsJSX,
+    },
+    {
+      code: "<img sec='path/to/image' />",
+      errors: errorsJSX,
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -9,10 +9,12 @@ import noHtmlLinks from './no-html-links';
 import preferDocusaurusHeading from './prefer-docusaurus-heading';
 import noUntranslatedText from './no-untranslated-text';
 import stringLiteralI18nMessages from './string-literal-i18n-messages';
+import preferIdealImage from './prefer-ideal-image';
 
 export default {
   'no-untranslated-text': noUntranslatedText,
   'string-literal-i18n-messages': stringLiteralI18nMessages,
   'no-html-links': noHtmlLinks,
   'prefer-docusaurus-heading': preferDocusaurusHeading,
+  'prefer-ideal-image': preferIdealImage,
 };

--- a/packages/eslint-plugin/src/rules/prefer-ideal-image.ts
+++ b/packages/eslint-plugin/src/rules/prefer-ideal-image.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {createRule} from '../util';
+import type {TSESTree} from '@typescript-eslint/types/dist/ts-estree';
+
+type Options = [];
+type MessageIds = 'idealImage';
+
+export default createRule<Options, MessageIds>({
+  name: 'prefer-ideal-image',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'enforce using Docusaurus theme idealImage component instead of <img> tag',
+      recommended: false,
+    },
+    schema: [],
+    messages: {
+      idealImage:
+        'Do not use the `<img>` tag for images. Use the `<Image />` component from `@theme/IdealImage` instead.',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      JSXOpeningElement(node) {
+        const elementName = (node.name as TSESTree.JSXIdentifier).name;
+
+        if (elementName !== 'img') {
+          return;
+        }
+
+        context.report({node, messageId: 'idealImage'});
+      },
+    };
+  },
+});

--- a/website/docs/api/misc/eslint-plugin/README.mdx
+++ b/website/docs/api/misc/eslint-plugin/README.mdx
@@ -54,6 +54,7 @@ For more fine-grained control, you can also enable the plugin manually and confi
 | [`@docusaurus/string-literal-i18n-messages`](./string-literal-i18n-messages.mdx) | Enforce translate APIs to be called on plain text labels | ✅ |
 | [`@docusaurus/no-html-links`](./no-html-links.mdx) | Ensures @docusaurus/Link is used instead of `<a>` tags | ✅ |
 | [`@docusaurus/prefer-docusaurus-heading`](./prefer-docusaurus-heading.mdx) | Ensures @theme/Heading is used instead of `<hn>` tags for headings | ✅ |
+| [`@docusaurus/prefer-ideal-image`](./prefer-ideal-image.mdx) | Ensures @theme/IdealImage is used instead of `<img>` tag for images | ✅ |
 
 ✅ = recommended
 

--- a/website/docs/api/misc/eslint-plugin/prefer-ideal-image.mdx
+++ b/website/docs/api/misc/eslint-plugin/prefer-ideal-image.mdx
@@ -1,0 +1,27 @@
+---
+slug: /api/misc/@docusaurus/eslint-plugin/prefer-ideal-image
+---
+
+# prefer-ideal-image
+
+Ensures that `@theme/IdealImage` theme component provided by Docusaurus [`theme-classic`](../../themes/theme-classic.mdx) is used instead of `<img>` tag for images.
+
+## Rule Details {#details}
+
+Examples of **incorrect** code for this rule:
+
+```html
+<img src="{thumbnail}" />
+
+<img src="path/to/image" />
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+import Image from '@theme/IdealImage'
+
+<Image src='path/to/image' />
+
+<Image src='path/to/image' />
+```


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [X] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

proposal mentioned in #6472, This newly added `prefer-ideal-image` enforces the use of `@theme/IdealImage` component instead of `<img>` tag for images.

## Test Plan

Added a test `prefer-ideal-image` with:

- valid code: `<Image src={thumbnail}/>` and `<Image src='path/to/image'/>`.
- invalid code: `<img sec={thumbnail} />` and `<img sec='path/to/image' />`.


### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

[Rule docs page](https://deploy-preview-11416--docusaurus-2.netlify.app/docs/api/misc/@docusaurus/eslint-plugin/prefer-ideal-image/)
[Updated Rules Table](https://deploy-preview-11416--docusaurus-2.netlify.app/docs/api/misc/@docusaurus/eslint-plugin/#supported-rules)

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

#6472
