### PR TITLE
feat(theme): Add theme-tabs-container stable className

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -7,6 +7,7 @@
 
 import React, {cloneElement, type ReactElement, type ReactNode} from 'react';
 import clsx from 'clsx';
+import {ThemeClassNames} from '@docusaurus/theme-common';
 import {
   useScrollPositionBlocker,
   useTabs,
@@ -143,7 +144,14 @@ function TabContent({
 function TabsComponent(props: Props): ReactNode {
   const tabs = useTabs(props);
   return (
-    <div className={clsx('tabs-container', styles.tabList)}>
+    <div
+      className={clsx(
+        ThemeClassNames.tabs.container,
+        // former name kept for backward compatibility
+        // see https://github.com/facebook/docusaurus/pull/4086
+        'tabs-container',
+        styles.tabList,
+      )}>
       <TabList {...tabs} {...props} />
       <TabContent {...tabs} {...props} />
     </div>

--- a/packages/docusaurus-theme-common/src/utils/ThemeClassNames.ts
+++ b/packages/docusaurus-theme-common/src/utils/ThemeClassNames.ts
@@ -55,6 +55,10 @@ export const ThemeClassNames = {
     container: 'theme-announcement-bar',
   },
 
+  tabs: {
+    container: 'theme-tabs-container',
+  },
+
   layout: {
     navbar: {
       container: 'theme-layout-navbar',


### PR DESCRIPTION

## Motivation

Fix https://github.com/facebook/docusaurus/discussions/5468#discussioncomment-14485788

Let's officialize this CSS selector as stable.

It was already stable (https://github.com/facebook/docusaurus/pull/4086) but not "officially". I kept the former class for retro-compatibility, but we'll remove it for Docusaurus v4, as users using undocumented classes are more likely to review their sites on upgrades.


Note: the other tab items do not really need stable class names because they already have good accessibility roles useful for targeting (tab, tablist, tabpanel)

## Test Plan

preview

### Test links

https://deploy-preview-11426--docusaurus-2.netlify.app/

