### PR TITLE
fix(website): Crowdin: downgrade mdx parser to v1.2

### DIFF
--- a/crowdin-v2.yaml
+++ b/crowdin-v2.yaml
@@ -20,6 +20,19 @@ languages_mapping: &languages_mapping
   two_letters_code:
     pt-BR: pt-BR
 
+# Crowdin regularly update their MDX parser
+# Unfortunately, their v2 parser is more "MDX compliant" and thus can't parse
+# Docusaurus MDX files correctly due to our custom {#headingId} syntax.
+# Adding this type param permits using their older v1.2 parser.
+# Note: you can find the version of a file using browser DevTools
+# The source file icons will have a class such as "file_type_mdx_v1_2"
+#
+# TODO fix our headingId syntax
+# providing an explicit type is annoying and not future-proof
+# there's a risk that when adding an image in /docs, it will be parsed as mdx
+# and duplicating source file configs for various extensions is not great either
+mdx_file_type: &mdx_file_type mdx_v1_2
+
 #
 # Files configuration
 #
@@ -27,18 +40,26 @@ files:
   - source: /website/i18n/en/**/*
     translation: /website/i18n/%two_letters_code%/**/%original_file_name%
     languages_mapping: *languages_mapping
+
   - source: /website/docs/**/*
     translation: /website/i18n/%two_letters_code%/docusaurus-plugin-content-docs/current/**/%original_file_name%
     languages_mapping: *languages_mapping
-  - source: /website/community/**/*
-    translation: /website/i18n/%two_letters_code%/docusaurus-plugin-content-docs-community/current/**/%original_file_name%
-    languages_mapping: *languages_mapping
+    type: *mdx_file_type
+
   - source: /website/versioned_docs/**/*
     translation: /website/i18n/%two_letters_code%/docusaurus-plugin-content-docs/**/%original_file_name%
     languages_mapping: *languages_mapping
+    type: *mdx_file_type
+
+  - source: /website/community/**/*
+    translation: /website/i18n/%two_letters_code%/docusaurus-plugin-content-docs-community/current/**/%original_file_name%
+    languages_mapping: *languages_mapping
+    type: *mdx_file_type
+
   - source: /website/blog/**/*
     translation: /website/i18n/%two_letters_code%/docusaurus-plugin-content-blog/**/%original_file_name%
     languages_mapping: *languages_mapping
+
   - source: /website/src/pages/**/*
     translation: /website/i18n/%two_letters_code%/docusaurus-plugin-content-pages/**/%original_file_name%
     ignore: [/**/*.js, /**/*.jsx, /**/*.ts, /**/*.tsx, /**/*.css]


### PR DESCRIPTION


## Motivation

Crowdin regularly improves its source file parsers. 

Unfortunately, the new MDX parser v2 that they rolled out recently doesn't support our custom `{#headingId}` syntax.

When we cut a new docs version, this leads to errors for all newly created MDX files (existing ones keep their initial parser), and blocked our website deploy after the v3.9 release:

```
❌ File 'website/versioned_docs/version-3.9.0/guides/docs/versioning.mdx'
❌ Wrong parameters:
<key: storageId, code: fileInvalid, message: MDX file is invalid in line 97, column 65. Message: Could not parse expression with acorn: Unexpected token>
```

To unblock us, I had to downgrade the MDX parser to v1.2, which was the one they used a few months ago (v3.8 docs are using that version).

---

Unfortunately, the Crowdin setup I now use is not ideal because the all the new files in docs/versioned_docs will use that hardcoded parser.

If we add a new image Crowdin will try to parse it as mdx). We could duplicate source file configs using extensions and ignore attributes, but I'd like to avoid doing that for maintenance reason. 

We don't often add new docs images, and if we do, it would be acceptable to upload the file manually on Crowdin so that it gets parsed as an image. 

But to avoid being stuck in the future, I'll make it a priority to support a new markdown heading syntax + a CLI option to migrate old syntax to the new one. This way, we'll be able to revert this temporary workaround and use the new MDX parsers. 


---

Note: to find out the parser version of a Crowdin source file, you can use DevTools to inspect the source file icon on their UIs, they have a class such as `file_type_<parser_version>`:

<img width="549" height="323" alt="CleanShot 2025-09-26 at 10 35 56" src="https://github.com/user-attachments/assets/47f3e026-cb79-4666-b685-506c75d36e01" />


---

## Test Plan

Tested locally that I can upload a newly cut docs version


### Test links

https://deploy-preview-_____--docusaurus-2.netlify.app/


