### PR TITLE
fix(theme-mermaid): Fix Mermaid ELK layout dependency required bug on v3.9

### DIFF
--- a/packages/docusaurus-theme-mermaid/src/index.ts
+++ b/packages/docusaurus-theme-mermaid/src/index.ts
@@ -49,6 +49,18 @@ export default async function themeMermaid(): Promise<Plugin<void>> {
             ),
           }),
         ],
+
+        // Workaround for weird Rspack/SWC issue
+        // See https://github.com/facebook/docusaurus/issues/11430
+        resolve: {
+          alias: {
+            ...(elkLayoutEnabled
+              ? {}
+              : {
+                  '@mermaid-js/layout-elk': false,
+                }),
+          },
+        },
       };
     },
   };


### PR DESCRIPTION
## Motivation

Fix https://github.com/facebook/docusaurus/issues/11430

For some reason, the following code still tries to resolve/ bundle `@mermaid-js/layout-elk` even when `__DOCUSAURUS_MERMAID_LAYOUT_ELK_ENABLED__` is `false` (in which case the bundler is supposed to ignore/remove that code).

```ts
  if (__DOCUSAURUS_MERMAID_LAYOUT_ELK_ENABLED__) {
    const elkLayout = (await import('@mermaid-js/layout-elk')).default;
    mermaid.registerLayoutLoaders(elkLayout);
  }
```

This bug only happens with the following conditions:
- in the server config (not the client one)
- when using dynamic imports (and not require() calls)
- when using the SWC loader, Rspack built-in or not (and not when using Babel loader)
- when using Rspack (and not when using Webpack + SWC)

I tried to reproduce here in isolation, but unfortunately couldn't
https://github.com/slorber/rspack-webpack-bug-repro-template/blob/slorber/repro-definePlugin-optional-dep/test.js

Since I'm not able to reproduce, I'm going to implement a decent workaround, aliasing the non-existent package to "undefined" so that resolution never fails when the package is absent. Not ideal, but it works well.

## Test Plan

CI + local tests

### Test links

https://deploy-preview-11437--docusaurus-2.netlify.app/
