### PR TITLE
perf(theme-mermaid): lazy load the Mermaid library

### DIFF
--- a/packages/docusaurus-theme-mermaid/src/client/index.ts
+++ b/packages/docusaurus-theme-mermaid/src/client/index.ts
@@ -7,8 +7,7 @@
 
 import {useState, useEffect, useMemo} from 'react';
 import {useColorMode, useThemeConfig} from '@docusaurus/theme-common';
-import mermaid from 'mermaid';
-import {ensureLayoutsRegistered} from './layouts';
+import {loadMermaid} from './loadMermaid';
 
 import type {RenderResult, MermaidConfig} from 'mermaid';
 import type {ThemeConfig} from '@docusaurus/theme-mermaid';
@@ -55,7 +54,7 @@ async function renderMermaid({
   text: string;
   config: MermaidConfig;
 }): Promise<RenderResult> {
-  await ensureLayoutsRegistered();
+  const mermaid = await loadMermaid();
 
   /*
   Mermaid API is really weird :s

--- a/packages/docusaurus-theme-mermaid/src/client/loadMermaid.ts
+++ b/packages/docusaurus-theme-mermaid/src/client/loadMermaid.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import mermaid from 'mermaid';
+import type {Mermaid} from 'mermaid';
 
 declare global {
   // Global variable provided by bundler DefinePlugin
@@ -13,7 +13,9 @@ declare global {
   const __DOCUSAURUS_MERMAID_LAYOUT_ELK_ENABLED__: boolean;
 }
 
-async function registerOptionalElkLayout() {
+async function loadMermaidAndRegisterLayouts(): Promise<Mermaid> {
+  const mermaid = (await import('mermaid')).default;
+
   // Mermaid does not support ELK layouts by default
   // See https://github.com/mermaid-js/mermaid/tree/develop/packages/mermaid-layout-elk
   // ELK layouts are heavy, so we made it an optional peer dependency
@@ -22,13 +24,19 @@ async function registerOptionalElkLayout() {
     const elkLayout = (await import('@mermaid-js/layout-elk')).default;
     mermaid.registerLayoutLoaders(elkLayout);
   }
+
+  return mermaid;
 }
 
 // Ensure we only try to register layouts once
-let layoutsRegistered = false;
-export async function ensureLayoutsRegistered(): Promise<void> {
-  if (!layoutsRegistered) {
-    await registerOptionalElkLayout();
-    layoutsRegistered = true;
+let MermaidPromise: Promise<Mermaid> | null = null;
+
+// We load Mermeid with a dynamic import to code split / lazy load the library
+// It is only called inside a useEffect, so loading can be deferred
+// We memoize so that we don't load and register layouts multiple times
+export async function loadMermaid(): Promise<Mermaid> {
+  if (!MermaidPromise) {
+    MermaidPromise = loadMermaidAndRegisterLayouts();
   }
+  return MermaidPromise;
 }

--- a/packages/docusaurus-theme-mermaid/src/client/loadMermaid.ts
+++ b/packages/docusaurus-theme-mermaid/src/client/loadMermaid.ts
@@ -31,7 +31,7 @@ async function loadMermaidAndRegisterLayouts(): Promise<Mermaid> {
 // Ensure we only try to register layouts once
 let MermaidPromise: Promise<Mermaid> | null = null;
 
-// We load Mermeid with a dynamic import to code split / lazy load the library
+// We load Mermaid with a dynamic import to code split / lazy load the library
 // It is only called inside a useEffect, so loading can be deferred
 // We memoize so that we don't load and register layouts multiple times
 export async function loadMermaid(): Promise<Mermaid> {

--- a/project-words.txt
+++ b/project-words.txt
@@ -166,7 +166,6 @@ Mdxjs
 mdxjs
 Meilisearch
 meilisearch
-Mermeid
 merveilleuse
 metadatum
 Metastring

--- a/project-words.txt
+++ b/project-words.txt
@@ -166,6 +166,7 @@ Mdxjs
 mdxjs
 Meilisearch
 meilisearch
+Mermeid
 merveilleuse
 metadatum
 Metastring


### PR DESCRIPTION
## Motivation

I noticed that the Mermaid lib is heavy and is loaded eagerly.

It is only called in `useEffect`, so it's fine to defer the loading.

## Result

It doesn't impact all pages, but for some of them (in particular docs page not using diagrams), the amount of JS loaded can be quite significantly reduced, with one large chunk becoming much smaller. 

The mermaid code has probably been split by the bundler into another chunk that will not load on docs page without diagrams, and will load later, after hydration on docs pages using diagrams.

### Before

<img width="963" height="748" alt="CleanShot 2025-09-26 at 20 08 20" src="https://github.com/user-attachments/assets/43c1c175-216f-48bf-8dfd-19d826870fc3" />


### After

<img width="994" height="776" alt="CleanShot 2025-09-26 at 20 09 23" src="https://github.com/user-attachments/assets/9e80199d-4d91-42ab-8465-54c090e3a6c0" />


## Test Plan

CI + preview

### Test links


Deploy preview: https://deploy-preview-11438--docusaurus-2.netlify.app/

