### PR TITLE
docs: add warning for  globbing in i18n tutorial (#11158)

### DIFF
--- a/website/docs/i18n/i18n-tutorial.mdx
+++ b/website/docs/i18n/i18n-tutorial.mdx
@@ -403,6 +403,12 @@ mkdir -p i18n/fr/docusaurus-plugin-content-docs/current
 cp -r docs/** i18n/fr/docusaurus-plugin-content-docs/current
 ```
 
+:::warning
+
+If you notice duplicate files in the destination directory after running the commands in this section, your shell may be configured to enable globstar (https://www.linuxjournal.com/content/globstar-new-bash-globbing-option) functionality. Consult the documentation for your shell to tailor equivalent commands for your environment.
+
+:::
+
 :::info
 
 Notice that the `docusaurus-plugin-content-docs` plugin always divides its content by versions. The data in `./docs` folder will be translated in the `current` subfolder and `current.json` file. See [the doc versioning guide](../guides/docs/versioning.mdx#terminology) for more information about what "current" means.


### PR DESCRIPTION
Title : docs: add warning for `cp -r` globbing in i18n tutorial (#11158)

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

This PR addresses issue #11158, which describes an unexpected behavior when using `cp -r docs/** i18n/fr/docusaurus-plugin-content-docs/current` in the i18n tutorial. In some shell configurations (specifically those with globstar enabled), this command leads to duplicate files in the destination directory because the shell first globs all files and then recursively copies each one individually.

To help users understand and mitigate this issue, a warning message has been added to the i18n tutorial documentation.

## Test Plan

To verify this change, you can:
1.  Set up a Docusaurus project with i18n configured, following the tutorial steps up to the "Translate Markdown Files" section.
2.  Navigate to the `website/docs/i18n/i18n-tutorial.mdx` file (or its rendered equivalent in the deploy preview).
3.  Observe that the warning message has been correctly inserted after the first `cp -r` command block under "Translate the docs" section.

## Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/
(Once the Netlify deploy preview is available, please update this link to point to the `i18n-tutorial.mdx` page.)

## Related issues/PRs

Closes #11158