### PR TITLE
fix(theme-search-algolia): Fix Algolia AskAI validation logic

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/__tests__/validateThemeConfig.test.ts
+++ b/packages/docusaurus-theme-search-algolia/src/__tests__/validateThemeConfig.test.ts
@@ -229,10 +229,33 @@ describe('validateThemeConfig', () => {
           ...DEFAULT_CONFIG,
           ...algolia,
           askAi: {
-            indexName: 'index',
-            apiKey: 'apiKey',
-            appId: 'BH4D9OD16A',
             assistantId: 'my-assistant-id',
+            indexName: algolia.indexName,
+            apiKey: algolia.apiKey,
+            appId: algolia.appId,
+          },
+        },
+      });
+    });
+
+    it('accepts minimal object format', () => {
+      const algolia: AlgoliaInput = {
+        appId: 'BH4D9OD16A',
+        indexName: 'index',
+        apiKey: 'apiKey',
+        askAi: {
+          assistantId: 'my-assistant-id',
+        },
+      };
+      expect(testValidateThemeConfig(algolia)).toEqual({
+        algolia: {
+          ...DEFAULT_CONFIG,
+          ...algolia,
+          askAi: {
+            assistantId: 'my-assistant-id',
+            indexName: algolia.indexName,
+            apiKey: algolia.apiKey,
+            appId: algolia.appId,
           },
         },
       });
@@ -273,21 +296,18 @@ describe('validateThemeConfig', () => {
       );
     });
 
-    it('rejects object missing required fields', () => {
+    it('rejects empty askAi', () => {
       const algolia: AlgoliaInput = {
         appId: 'BH4D9OD16A',
         indexName: 'index',
         apiKey: 'apiKey',
         // @ts-expect-error: expected type error: missing mandatory fields
-        askAi: {
-          assistantId: 'my-assistant-id',
-          // Missing indexName, apiKey, appId
-        },
+        askAi: {},
       };
       expect(() =>
         testValidateThemeConfig(algolia),
       ).toThrowErrorMatchingInlineSnapshot(
-        `""algolia.askAi.indexName" is required"`,
+        `""algolia.askAi.assistantId" is required"`,
       );
     });
 

--- a/packages/docusaurus-theme-search-algolia/src/theme-search-algolia.d.ts
+++ b/packages/docusaurus-theme-search-algolia/src/theme-search-algolia.d.ts
@@ -11,7 +11,7 @@ declare module '@docsearch/react/useDocSearchKeyboardEvents';
 declare module '@docsearch/react/version';
 
 declare module '@docusaurus/theme-search-algolia' {
-  import type {DeepPartial, Overwrite} from 'utility-types';
+  import type {DeepPartial, Overwrite, Optional} from 'utility-types';
 
   import type {DocSearchProps} from '@docsearch/react';
   import type {FacetFilters} from 'algoliasearch/lite';
@@ -70,7 +70,9 @@ declare module '@docusaurus/theme-search-algolia' {
         apiKey: ThemeConfigAlgolia['apiKey'];
         indexName: ThemeConfigAlgolia['indexName'];
         // askAi also accepts a shorter string form
-        askAi?: string | AskAiConfig;
+        askAi?:
+          | string
+          | Optional<AskAiConfig, 'indexName' | 'appId' | 'apiKey'>;
       }
     >;
   };

--- a/packages/docusaurus-theme-search-algolia/src/validateThemeConfig.ts
+++ b/packages/docusaurus-theme-search-algolia/src/validateThemeConfig.ts
@@ -67,10 +67,11 @@ export const Schema = Joi.object<ThemeConfig>({
         Joi.string(),
         // Full configuration object
         Joi.object({
-          indexName: Joi.string().required(),
-          apiKey: Joi.string().required(),
-          appId: Joi.string().required(),
           assistantId: Joi.string().required(),
+          // Optional Ask AI configuration
+          indexName: Joi.string().optional(),
+          apiKey: Joi.string().optional(),
+          appId: Joi.string().optional(),
           searchParameters: Joi.object({
             facetFilters: FacetFiltersSchema.optional(),
           }).optional(),
@@ -102,6 +103,10 @@ export const Schema = Joi.object<ThemeConfig>({
             } satisfies ThemeConfigAlgolia['askAi'];
           }
 
+          // Fill in missing fields with the top-level Algolia config
+          askAiInput.indexName = askAiInput.indexName ?? algolia.indexName;
+          askAiInput.apiKey = askAiInput.apiKey ?? algolia.apiKey;
+          askAiInput.appId = askAiInput.appId ?? algolia.appId;
           if (
             askAiInput.searchParameters?.facetFilters === undefined &&
             algoliaFacetFilters
@@ -109,6 +114,7 @@ export const Schema = Joi.object<ThemeConfig>({
             askAiInput.searchParameters = askAiInput.searchParameters ?? {};
             askAiInput.searchParameters.facetFilters = algoliaFacetFilters;
           }
+
           return askAiInput;
         },
       )

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -662,9 +662,11 @@ export default async function createConfigAsync() {
         // eslint-disable-next-line @typescript-eslint/no-var-requires,global-require
         ...(require('@docsearch/react').version.startsWith('4.')
           ? {
-              // cSpell:ignore IMYF
-              askAi: 'RgIMYFUmTfrN',
-              // indexName: 'docusaurus-markdown',
+              askAi: {
+                // cSpell:ignore IMYF
+                assistantId: 'RgIMYFUmTfrN',
+                indexName: 'docusaurus-markdown',
+              },
             }
           : {}),
 


### PR DESCRIPTION

## Motivation

The current validation did not accept the following configs, which should both be fine IMHO:

```ts

    askAi: {
       assistantId: 'ASSISTANT_ID',
    },


    askAi: {
       assistantId: 'ASSISTANT_ID',
       indexName: 'docusaurus-markdown',
    },
```


I noticed this when trying to enable our markdown-based index that the DocSearch team prepared for us. This PR also adds the new index to our website.

## Test Plan

CI + deploy preview

### Test links

https://deploy-preview-11468--docusaurus-2.netlify.app/

