### PR TITLE
fix(docs): Fix deployment docs for v3.9.1 - Node.js version should be v20

### DIFF
--- a/website/versioned_docs/version-3.9.1/deployment.mdx
+++ b/website/versioned_docs/version-3.9.1/deployment.mdx
@@ -675,7 +675,7 @@ Continuous integration (CI) services are typically used to perform routine tasks
 ```yml title=".travis.yml"
 language: node_js
 node_js:
-  - 18
+  - 20
 branches:
   only:
     - main
@@ -734,7 +734,7 @@ steps:
 
   - task: NodeTool@0
     inputs:
-      versionSpec: '18'
+      versionSpec: '20'
     displayName: Install Node.js
 
   - script: |


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Updated my blog post to v3.9.1 and there was a need to update the GitHub actions to meet the NodeJS requirements. The  for v3.9.1 documentation has the old NodeJS specification. Although, the canary version includes the correct information.

Fix https://github.com/facebook/docusaurus/issues/11472

## Test Plan

This is a simple documentation change.

### Test links
This is a simple documentation change.

## Related issues/PRs
N/A