### PR TITLE
chore(ci): add nodejs 25 to CI jobs matrix

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['20.0', '20', '22', '24']
+        node: ['20.0', '20', '22', '24', '25']
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        node: ['20.0', '20', '22', '24']
+        node: ['20.0', '20', '22', '24', '25']
     steps:
       - name: Support longpaths
         run: git config --system core.longpaths true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['20.0', '20', '22', '24']
+        node: ['20.0', '20', '22', '24', '25']
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION

## Motivation

Node.js 25.0 is out: https://nodejs.org/en/blog/release/v25.0.0

So let's figure out if we have compatibility issues with this new version and prepare for Node 26 (Q2 2026)

It's not a top priority to support Node 25 but still useful to check

## Test Plan

CI
