### PR TITLE
fix(theme): retain focus-visible on enter with screen reader

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -241,3 +241,7 @@ html[data-navbar='false'] {
 html[data-red-border] div#__docusaurus {
   border: red solid thick;
 }
+
+body:not(.navigation-with-keyboard) *:not(input):focus-visible {
+  outline: auto !important;
+}


### PR DESCRIPTION
Fixes an accessibility issue where visible focus is lost when activating an element using the `Enter` key while a screen reader is active.

This occurs because the screen reader action can fire a `mousedown` event, which causes Docusaurus's keyboard navigation hook to incorrectly hide the focus outline.

This solution uses the `:focus-visible` CSS pseudo-class to ensure the focus outline is reliably displayed during keyboard navigation, solving the issue for screen reader users.

### Test Plan

1.  Enable a screen reader (NVDA, Narrator, VoiceOver).
2.  Navigate to an interactive element (like a filter button or sidebar link) using the `Tab` key.
3.  Press `Enter`.
4.  Confirm the visible focus outline remains on the element.

---

Closes #11314