### PR TITLE
fix(theme-classic): make copy/word wrap buttons opaque.

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -143,6 +143,12 @@ html[data-theme='dark'] {
   );
 }
 
+/* Add padding inside the code block so text doesn’t go under the buttons */
+.theme-code-block pre {
+  padding-right: 4.5rem !important; /* adjust this if buttons are wider */
+  position: relative;
+}
+
 .theme-announcement-bar {
   font-size: 20px;
 

--- a/website/src/theme/CodeBlock/index.tsx
+++ b/website/src/theme/CodeBlock/index.tsx
@@ -5,13 +5,84 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {type ReactNode} from 'react';
+import React, {type ReactNode, useEffect} from 'react';
 import CodeBlock from '@theme-original/CodeBlock';
 import type {Props} from '@theme/CodeBlock';
 
-// This component does nothing on purpose
-// Dogfood: wrapping a theme component already enhanced by another theme
-// See https://github.com/facebook/docusaurus/pull/5983
+function fixButtons(root: ParentNode = document) {
+  // wide selector to catch many possible button class/attribute patterns
+  const sel = [
+    '.theme-code-block button',
+    '.prism-react-renderer button',
+    'button[class*="copy"]',
+    'button[class*="Copy"]',
+    'button[class*="copyButton"]',
+    'button[class*="wordWrap"]',
+    'button[class*="wordWrapButton"]',
+    'button[title*="Copy"]',
+    'button[title*="copy"]',
+    'button[aria-label*="copy"]',
+    'button[aria-label*="Copy"]',
+  ].join(',');
+
+  const buttons = Array.from(root.querySelectorAll<HTMLButtonElement>(sel));
+  buttons.forEach((btn) => {
+    // strong inline styles to override anything else (last-resort)
+    btn.style.setProperty(
+      'background-color',
+      'rgba(30,30,30,0.98)',
+      'important',
+    );
+    btn.style.setProperty('color', '#fff', 'important');
+    btn.style.setProperty('opacity', '1', 'important');
+    btn.style.setProperty('mix-blend-mode', 'normal', 'important');
+    btn.style.setProperty('z-index', '9999', 'important');
+    btn.style.setProperty('border-radius', '6px', 'important');
+    btn.style.setProperty(
+      'border',
+      '1px solid rgba(255,255,255,0.12)',
+      'important',
+    );
+    btn.style.setProperty('backdrop-filter', 'none', 'important'); // disable blur interactions
+    btn.style.setProperty(
+      'box-shadow',
+      '0 2px 10px rgba(0,0,0,0.4)',
+      'important',
+    );
+    btn.style.setProperty('padding', '4px 8px', 'important');
+  });
+}
+
 export default function CodeBlockWrapper(props: Props): ReactNode {
+  useEffect(() => {
+    // initial fix
+    fixButtons(document);
+
+    // observe additions inside the whole document so if Docusaurus mounts codeblocks later we still catch them
+    const observer = new MutationObserver((mutations) => {
+      for (const m of mutations) {
+        if (m.addedNodes && m.addedNodes.length > 0) {
+          // try to fix inside each added node
+          m.addedNodes.forEach((node) => {
+            if (node instanceof Element) {
+              fixButtons(node);
+            }
+          });
+        }
+      }
+    });
+
+    observer.observe(document.documentElement || document.body, {
+      childList: true,
+      subtree: true,
+    });
+
+    const t = window.setTimeout(() => fixButtons(document), 300);
+    return () => {
+      observer.disconnect();
+      clearTimeout(t);
+    };
+  }, []);
+
   return <CodeBlock {...props} />;
 }


### PR DESCRIPTION
This PR attempts to fix the visual issue https://github.com/facebook/docusaurus/issues/10821 

where the “Copy” and “Toggle word wrap” buttons in code blocks were nearly invisible or overlapping code text when code wrapped to multiple lines.

Changes include:

Added opaque backgrounds to buttons for visibility.
Added right padding (4.5rem) to <pre> blocks to ensure code remains readable.

Before: Buttons blend with code text.

<img width="1438" height="841" alt="image" src="https://github.com/user-attachments/assets/9bac9ca6-8b6c-4869-850c-f5ecfacc39f1" />

After: Buttons have visible backgrounds and code text no longer overlaps.

[issue_1.webm](https://github.com/user-attachments/assets/8dd18093-6410-4d3b-a83b-ec8da7f31a91)
