### PR TITLE
Update @rspack/core dependency to version 1.6.0

### DIFF
--- a/packages/docusaurus-faster/package.json
+++ b/packages/docusaurus-faster/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "@docusaurus/types": "3.9.2",
-    "@rspack/core": "^1.5.0",
+    "@rspack/core": "^1.6.0",
     "@swc/core": "^1.7.39",
     "@swc/html": "^1.13.5",
     "browserslist": "^4.24.2",


### PR DESCRIPTION
## Motivation

Bump @rspack/core to version 1.6.0 to expose incompatibility with the latest version of the package.