### PR TITLE
docs: Remove stray word (attractive)from Code Conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ You can also try using the new [github.dev](https://github.dev/facebook/docusaur
 ### Code Conventions
 
 - **Most important: Look around.** Match the style you see used in the rest of the project. This includes formatting, naming files, naming things in code, naming things in documentation, etc.
-- "Attractive"
+
 - We do have Prettier (a formatter) and ESLint (a syntax linter) to catch most stylistic problems. If you are working locally, they should automatically fix some issues during every git commit.
 - **For documentation**: Do not wrap lines at 80 characters - configure your editor to soft-wrap when editing documentation.
 


### PR DESCRIPTION
Description I found a stray word ("Attractive") under the "Code Conventions" section of CONTRIBUTING.md that seemed to be a mistake.

Test Plan This is a documentation-only change. I have previewed the file to confirm the line is removed.