### PR TITLE
Add Juno to deployment docs

### DIFF
--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -790,6 +790,12 @@ Now, whenever you push a new tag to GitHub, this trigger will start the drone CI
 
 Get started by following [Flightcontrol's step-by-step Docusaurus guide](https://www.flightcontrol.dev/docs/reference/examples/docusaurus/?ref=docusaurus).
 
+## Deploying to Juno {#deploying-to-juno}
+
+[Juno](https://juno.build) is an open-source serverless platform for hosting static websites, building web applications, and running serverless functions with the privacy and control of self-hosting.
+
+You can deploy your Docusaurus site using either GitHub Actions or CLI by following the [step-by-step guide](https://juno.build/docs/guides/docusaurus/deploy).
+
 ## Deploying to Koyeb {#deploying-to-koyeb}
 
 [Koyeb](https://www.koyeb.com) is a developer-friendly serverless platform to deploy apps globally. The platform lets you seamlessly run Docker containers, web apps, and APIs with git-based deployment, native autoscaling, a global edge network, and built-in service mesh and discovery. Check out the [Koyeb's Docusaurus deployment guide](https://www.koyeb.com/tutorials/deploy-docusaurus-on-koyeb) to get started.


### PR DESCRIPTION
## Pre-flight checklist

- [X] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).

## Motivation

Hi,

I know you stopped accepting PRs to list new hosting options in the past, but since the [Juno](https://juno.build) website itself is built with Docusaurus, I wondered if you might consider an exception now. Given that the PR is relatively small and shouldn’t require much of your time, I decided to skip the question and go straight to opening it.

Feel free to close it if you’re still not accepting new additions to the list.


