### PR TITLE
chore(ci): upgrade Netlify to Node 24 (LTS) + add `git backfill` command

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -11,17 +11,17 @@
 [build.environment]
   NETLIFY_USE_YARN = "true"
   YARN_VERSION = "1.22.19"
-  NODE_VERSION = "22"
+  NODE_VERSION = "24"
   NODE_OPTIONS = "--max_old_space_size=8192"
 
 [context.production]
-  command = "yarn --cwd .. build:packages && yarn netlify:build:production"
+  command = "yarn --cwd .. build:packages && git backfill && yarn netlify:build:production"
 
 [context.branch-deploy]
-  command = "yarn --cwd .. build:packages && yarn netlify:build:branchDeploy"
+  command = "yarn --cwd .. build:packages && git backfill && yarn netlify:build:branchDeploy"
 
 [context.deploy-preview]
-  command = "yarn --cwd .. build:packages && yarn netlify:build:deployPreview"
+  command = "yarn --cwd .. build:packages && git backfill && yarn netlify:build:deployPreview"
 
 [[plugins]]
 package = "netlify-plugin-cache"


### PR DESCRIPTION

## Motivation

Use the new Node 24 LTS.

The `git backfill` command is useful because Netlify is doing "blobless clones" of the Git repository:
- https://answers.netlify.com/t/please-confirm-repo-clones-are-not-shallow/86587
- https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/


The problem is that when we try to read the Git history to compute the "last updated at" time, Git has to lazily download all the missing information from the blobless clone.

This slows down the VCS Git Eager integration, see https://github.com/facebook/docusaurus/pull/11512

We can reproduce the issue by running:

```bash
git clone --filter=blob:none git@github.com:facebook/docusaurus.git docusaurus-blobless
cd docusaurus-blobless
git --no-pager log --name-status
```

The last command is supposed to be very fast, but when the clone is blobless, it's super slow because it has to request to the Git server a lot of missing information, one at a time. 

The `git backfill` command looks designed to solve this exact purpose: https://git-scm.com/docs/git-backfill

> In the worst cases, commands that compute blob diffs, such as git blame, become very slow as they download the missing blobs in single-blob requests to satisfy the missing object as the Git command needs it. This leads to multiple download requests and no ability for the Git server to provide delta compression across those objects.
>
> The git backfill command provides a way for the user to request that Git downloads the missing blobs (with optional filters) such that the missing blobs representing historical versions of files can be downloaded in batches.

It's experimental and may change, but if it works, let's use it!


## Test Plan

CI

### Test links

https://deploy-preview-11553--docusaurus-2.netlify.app/

