### PR TITLE
fix(content-blog): filter unlisted posts from author pages

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/routes.ts
+++ b/packages/docusaurus-plugin-content-blog/src/routes.ts
@@ -294,12 +294,14 @@ export async function buildAllRoutes({
           sidebar: sidebarModulePath,
         },
         props: {
-          authors: authors.map((author) =>
-            toAuthorItemProp({
+          authors: authors.map((author) => {
+            const authorPosts = blogPostsByAuthorKey[author.key] ?? [];
+            const listedAuthorPosts = authorPosts.filter(shouldBeListed);
+            return toAuthorItemProp({
               author,
-              count: blogPostsByAuthorKey[author.key]?.length ?? 0,
-            }),
-          ),
+              count: listedAuthorPosts.length,
+            });
+          }),
         },
         context: {
           blogMetadata: blogMetadataModulePath,
@@ -309,12 +311,13 @@ export async function buildAllRoutes({
 
     function createAuthorPaginatedRoute(author: AuthorWithKey): RouteConfig[] {
       const authorBlogPosts = blogPostsByAuthorKey[author.key] ?? [];
+      const listedAuthorBlogPosts = authorBlogPosts.filter(shouldBeListed);
       if (!author.page) {
         return [];
       }
 
       const pages = paginateBlogPosts({
-        blogPosts: authorBlogPosts,
+        blogPosts: listedAuthorBlogPosts,
         basePageUrl: author.page.permalink,
         blogDescription,
         blogTitle,
@@ -332,7 +335,10 @@ export async function buildAllRoutes({
             sidebar: sidebarModulePath,
           },
           props: {
-            author: toAuthorItemProp({author, count: authorBlogPosts.length}),
+            author: toAuthorItemProp({
+              author,
+              count: listedAuthorBlogPosts.length,
+            }),
             listMetadata: metadata,
           },
           context: {


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.

- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--

Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.

If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.

-->

## Motivation

Fixes a bug where author pages were displaying unlisted blog posts. Author pages should only show listed posts, consistent with tag pages, archive pages, and the main blog list.

**Root Cause**: The `createAuthorPaginatedRoute` function was using unfiltered `authorBlogPosts` instead of filtering out unlisted posts before pagination. Unlike tag pages, archive pages, and the main blog list (which all use `listedBlogPosts`), author pages were missing the filtering step.

**Note**: The `isUnlisted()` function only returns `true` in production mode (or with `SIMULATE_PRODUCTION_VISIBILITY=true`). In development mode, unlisted posts appear as listed, but this is expected behavior - the fix works correctly in production builds.

## Test Plan

### Manual Testing
1. Created test blog posts (listed and unlisted) assigned to an author
2. Verified unlisted post does NOT appear on author page (`/blog/authors/slorber`)
3. Verified listed posts DO appear on author page
4. Verified direct link to unlisted post still works
5. Verified author list page shows correct counts (excluding unlisted)

### Consistency Check
- ✅ **Tag pages** filter unlisted posts - `packages/docusaurus-plugin-content-blog/src/blogUtils.ts:141-152` via `getTagVisibility()`
- ✅ **Archive page** filters unlisted posts - uses `listedBlogPosts` at `packages/docusaurus-plugin-content-blog/src/routes.ts:92,163`
- ✅ **Main blog list** filters unlisted posts - uses `listedBlogPosts` at `packages/docusaurus-plugin-content-blog/src/index.ts:259,295`
- ✅ **Author pages** now filter unlisted posts - uses `listedAuthorBlogPosts.filter(shouldBeListed)` at `packages/docusaurus-plugin-content-blog/src/routes.ts:321,306`

### Testing with Production Flag
Tested with `SIMULATE_PRODUCTION_VISIBILITY=true` to verify unlisted posts are correctly filtered in production mode.

### Commands Run
```bash
SIMULATE_PRODUCTION_VISIBILITY=true yarn workspace website start --port 3002
yarn workspace @docusaurus/plugin-content-blog build
```

### Test links

Deploy preview: 
https://deploy-preview-11559--docusaurus-2.netlify.app/

## Related issues/PRs

_None - this is a bug fix identified during code review. The bug report analysis showed that author pages were the only blog route type not filtering unlisted posts, while tag pages, archive pages, and the main blog list all correctly filter them._
