### PR TITLE
fix(theme): Change code block line from span to div, fix Firefox text selection/copy bug

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Line/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Line/index.tsx
@@ -12,23 +12,36 @@ import type {Props} from '@theme/CodeBlock/Line';
 
 import styles from './styles.module.css';
 
-/*
-This <br/ seems useful when the line has no content to prevent collapsing.
-For code blocks with "diff" languages, this makes the empty lines collapse to
-zero height lines, which is undesirable.
-See also https://github.com/facebook/docusaurus/pull/11565
-*/
+type Token = Props['line'][number];
+
+// This <br/ seems useful when the line has no content to prevent collapsing.
+// For code blocks with "diff" languages, this makes the empty lines collapse to
+// zero height lines, which is undesirable.
+// See also https://github.com/facebook/docusaurus/pull/11565
 function LineBreak() {
   return <br />;
 }
 
+// Replaces single lines with '\n' by '' so that we don't end up with
+// duplicate line breaks (the '\n' + the artificial <br/> above)
+// see also https://github.com/facebook/docusaurus/pull/11565
+function fixLineBreak(line: Token[]) {
+  const singleLineBreakToken =
+    line.length === 1 && line[0]!.content === '\n' ? line[0] : undefined;
+  if (singleLineBreakToken) {
+    return [{...singleLineBreakToken, content: ''}];
+  }
+  return line;
+}
+
 export default function CodeBlockLine({
-  line,
+  line: lineProp,
   classNames,
   showLineNumbers,
   getLineProps,
   getTokenProps,
 }: Props): ReactNode {
+  const line = fixLineBreak(lineProp);
   const lineProps = getLineProps({
     line,
     className: clsx(classNames, showLineNumbers && styles.codeLine),


### PR DESCRIPTION
## Motivation

Attempt to fix https://github.com/facebook/docusaurus/issues/10495



Note that the original issue happens for very weird reasons. Using `display: block` for lines fixes the problem for us, but I've seen various websites using lines with `display: inline` and Firefox can still copy text properly from those.

Anyway, it seems fine to use `<div>` (which is by default `display: block`). 

This is also what the React-Prism-Renderer example shows, so let's move back to a more "recommended" setup: https://github.com/FormidableLabs/prism-react-renderer



---

I also tried to remove things that do not seem useful. As long as Argos doesn't report any diff, it should be fine.

The `<br/>` for each line couldn't be removed unfortunately, since it leads to the line collapsing to 0px height for `diff` code blocks. It seems that for most languages, the collapsing doesn't happen because Prism sets `display: inline-block` to the empty token, but not for all 😅  This leads to this kind of visual change:

<img width="1485" height="315" alt="CleanShot 2025-11-21 at 18 41 16" src="https://github.com/user-attachments/assets/855c0f3f-e305-4c60-88a7-1d3cf3c3415d" />


The historical `fixLineBreak()` is also apparently useful for this situation where we have both a `\n` and a `<br/>` leading to 2 line breaks instead of just one:

http://localhost:3000/docs/markdown-features/code-blocks#multi-language-support-code-blocks

<img width="1418" height="752" alt="CleanShot 2025-11-21 at 18 58 42" src="https://github.com/user-attachments/assets/92d5e668-e1b4-4a42-937c-393e17ba7e3b" />

So, the 2 problems are kind of related 😅 
I hope we'll be able to remove these workarounds in the future, but I just wanted to document them to remember the context, and this PR will be conservative and preserve these 2 workarounds.

If you find a way to remove the `<br/>` without bugs, I guess the other `fixLineBreak()` hack could also be safely removed? 🤷‍♂️ 

## Test Plan

Argos + local tests on various browsers 😅 

### Test links

https://deploy-preview-11565--docusaurus-2.netlify.app/
