### PR TITLE
fix(blog): Fix author paginated page url: `/blog/authors/<author>/page/2`

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/__tests__/__snapshots__/routes.test.ts.snap
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/__snapshots__/routes.test.ts.snap
@@ -399,7 +399,7 @@ exports[`buildAllRoutes works for realistic blog post 2`] = `
       "listMetadata": {
         "blogDescription": "Custom blog description",
         "blogTitle": "Custom blog title",
-        "nextPage": "/blog/authors/author1/authors/2",
+        "nextPage": "/blog/authors/author1/page/2",
         "page": 1,
         "permalink": "/blog/authors/author1",
         "postsPerPage": 2,
@@ -429,7 +429,7 @@ exports[`buildAllRoutes works for realistic blog post 2`] = `
       ],
       "sidebar": "@aliased/data/blog-post-list-prop-default.json",
     },
-    "path": "/blog/authors/author1/authors/2",
+    "path": "/blog/authors/author1/page/2",
     "props": {
       "author": {
         "count": 3,
@@ -444,7 +444,7 @@ exports[`buildAllRoutes works for realistic blog post 2`] = `
         "blogTitle": "Custom blog title",
         "nextPage": undefined,
         "page": 2,
-        "permalink": "/blog/authors/author1/authors/2",
+        "permalink": "/blog/authors/author1/page/2",
         "postsPerPage": 2,
         "previousPage": "/blog/authors/author1",
         "totalCount": 3,

--- a/packages/docusaurus-plugin-content-blog/src/routes.ts
+++ b/packages/docusaurus-plugin-content-blog/src/routes.ts
@@ -327,7 +327,7 @@ export async function buildAllRoutes({
         basePageUrl: author.page.permalink,
         blogDescription,
         blogTitle,
-        pageBasePath: authorsBasePath,
+        pageBasePath,
         postsPerPageOption: postsPerPage,
       });
 


### PR DESCRIPTION

## Motivation

- Actual: https://docusaurus.io/blog/authors/slorber/authors/2
- Expected: https://docusaurus.io/blog/authors/slorber/page/2

We should use `/blog/authors/<author>/page/2`

This PR fixes the blog author paginated pages url. I consider it a bugfix, and not a breaking change considering this was the intended behavior.

It shouldn't have any SEO impact considering it's not particularly useful to backlink to paginated lists.


## Test Plan

CI + unit tests

### Test links

https://deploy-preview-11577--docusaurus-2.netlify.app/

