### PR TITLE
feat(theme-search-algolia): allow overriding transformSearchClient

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
@@ -67,10 +67,6 @@ interface DocSearchV4Props extends Omit<DocSearchProps, 'askAi'> {
   translations?: DocSearchTranslations;
 }
 
-type SearchBarProps = Partial<
-  Pick<DocSearchModalProps, 'transformSearchClient'>
->;
-
 let DocSearchModal: typeof DocSearchModalType | null = null;
 
 function importDocSearchModalIfNeeded() {
@@ -316,12 +312,15 @@ function DocSearch({externalUrlRegex, ...props}: DocSearchV4Props) {
   );
 }
 
-export default function SearchBar(props: SearchBarProps): ReactNode {
+export default function SearchBar(props: Partial<DocSearchV4Props>): ReactNode {
   const {siteConfig} = useDocusaurusContext();
-  return (
-    <DocSearch
-      {...(siteConfig.themeConfig.algolia as DocSearchV4Props)}
-      {...props}
-    />
-  );
+
+  const docSearchProps: DocSearchV4Props = {
+    ...(siteConfig.themeConfig.algolia as DocSearchV4Props),
+    // Let props override theme config
+    // See https://github.com/facebook/docusaurus/pull/11581
+    ...props,
+  };
+
+  return <DocSearch {...docSearchProps} />;
 }


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

See https://github.com/facebook/docusaurus/issues/11580

## Test Plan

1. add algolia search config 
2. swizzle @docusaurus/theme-search-algolia and choose to Wrap the component
3. Pass a custom `transformSearchClient ` function
4. Perform a search
5. Verify that the custom `transformSearchClient` function should be called

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs
Closes #11580

