### PR TITLE
fix(eslint-plugin): specify exact type of `no-untranslated-text` rule options

### DIFF
--- a/packages/eslint-plugin/src/rules/no-untranslated-text.ts
+++ b/packages/eslint-plugin/src/rules/no-untranslated-text.ts
@@ -30,6 +30,9 @@ export default createRule<Options, MessageIds>({
         properties: {
           ignoredStrings: {
             type: 'array',
+            items: {
+              type: 'string',
+            },
           },
         },
         additionalProperties: false,


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

`no-untranslated-text` ESLint rule's `ignoredStrings` option currently allows elements of any type. This makes it easier for typos/errors in rule options to go unnoticed. This PR strengthens the rule's options schema.

## Test Plan

N/A

## Related issues/PRs

N/A
