### PR TITLE
fix(core): Fix openBrowser AppleScript support for Arc

### DIFF
--- a/packages/docusaurus/src/commands/utils/openBrowser/openBrowser.ts
+++ b/packages/docusaurus/src/commands/utils/openBrowser/openBrowser.ts
@@ -95,6 +95,9 @@ async function tryOpenWithAppleScript({
       );
     }
 
+    // Test this manually with:
+    // osascript ./packages/docusaurus/src/commands/utils/openBrowser/openChrome.applescript "http://localhost:8080" "Google Chrome"
+    // osascript ./packages/docusaurus/src/commands/utils/openBrowser/openChrome.applescript "http://localhost:8080" "Arc"
     async function tryBrowser(browserName: string): Promise<boolean> {
       try {
         // This command runs the openChrome.applescript (copied from CRA)

--- a/packages/docusaurus/src/commands/utils/openBrowser/openChrome.applescript
+++ b/packages/docusaurus/src/commands/utils/openBrowser/openChrome.applescript
@@ -19,6 +19,16 @@ on run argv
     set theProgram to item 2 of argv
   end if
 
+  -- Arc: simple open + activate, no tab reuse
+  -- See https://github.com/facebook/docusaurus/issues/11582
+  if theProgram is "Arc" then
+    tell application "Arc"
+      activate
+      open location theURL
+    end tell
+    return
+  end if
+
   using terms from application "Google Chrome"
     tell application theProgram
 


### PR DESCRIPTION


## Motivation

In https://github.com/facebook/docusaurus/pull/11217, our `openBrowser()` API added AppleScript support for the Arc browser, alongside all the other existing Chromium-based browsers.

But it seems that Arc has a different AppleScript API/interface to others, and doesn't work the same. I added an "if (Arc)" in the ApppleScript to handle things differently for that browser and avoid a console error.


Fix https://github.com/facebook/docusaurus/issues/11582



## Test Plan

local 😓 
