### PR TITLE
docs: document VERCEL_DEEP_CLONE for showLastUpdateTime fix

### DIFF
--- a/website/docs/api/plugins/plugin-content-docs.mdx
+++ b/website/docs/api/plugins/plugin-content-docs.mdx
@@ -59,7 +59,7 @@ Accepted fields:
 | `beforeDefaultRemarkPlugins` | `any[]` | `[]` | Custom Remark plugins passed to MDX before the default Docusaurus Remark plugins. |
 | `beforeDefaultRehypePlugins` | `any[]` | `[]` | Custom Rehype plugins passed to MDX before the default Docusaurus Rehype plugins. |
 | `showLastUpdateAuthor` | `boolean` | `false` | Whether to display the author who last updated the doc. |
-| `showLastUpdateTime` | `boolean` | `false` | Whether to display the last date the doc was updated. This requires access to git history during the build, so will not work correctly with shallow clones (a common default for CI systems). With GitHub `actions/checkout`, use`fetch-depth: 0`. |
+| `showLastUpdateTime` | `boolean` | `false` | Whether to display the last date the doc was updated. This requires access to git history during the build, so will not work correctly with shallow clones (a common default for CI systems). With GitHub `actions/checkout`, use `fetch-depth: 0`. With Vercel, set the `VERCEL_DEEP_CLONE=true` environment variable. |
 | `breadcrumbs` | `boolean` | `true` | Enable or disable the breadcrumbs on doc pages. |
 | `disableVersioning` | `boolean` | `false` | Explicitly disable versioning even when multiple versions exist. This will make the site only include the current version. Will error if `includeCurrentVersion: false` and `disableVersioning: true`. |
 | `includeCurrentVersion` | `boolean` | `true` | Include the current version of your docs. |

--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -220,6 +220,21 @@ Import the project into Vercel using the [Import Flow](https://vercel.com/import
 
 After your project has been imported, all subsequent pushes to branches will generate [Preview Deployments](https://vercel.com/docs/platform/deployments#preview), and all changes made to the [Production Branch](https://vercel.com/docs/git-integrations#production-branch) (usually "main" or "master") will result in a [Production Deployment](https://vercel.com/docs/platform/deployments#production).
 
+:::tip Using `showLastUpdateTime`
+
+If you use [`showLastUpdateTime`](api/plugins/plugin-content-docs.mdx#showLastUpdateTime), you may notice incorrect dates when deploying to Vercel because it uses [shallow clones](https://vercel.com/docs/deployments/configure-a-build#build-container) by default.
+
+To fix this, add the following [environment variable](https://vercel.com/docs/projects/environment-variables) to your Vercel project settings:
+
+| Variable             | Value  |
+| -------------------- | ------ |
+| `VERCEL_DEEP_CLONE`  | `true` |
+
+This enables deep cloning, allowing Docusaurus to access the full Git history and display accurate last update timestamps.
+
+:::
+
+
 ## Deploying to GitHub Pages {#deploying-to-github-pages}
 
 Docusaurus provides an easy way to publish to [GitHub Pages](https://pages.github.com/), which comes free with every GitHub repository.


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #10031) and the maintainers have approved on my working plan.

## Motivation

This PR addresses issue #10031.

When deploying Docusaurus to Vercel with `showLastUpdateTime` enabled, users see incorrect "last updated" dates. This happens because Vercel uses shallow clones by default, which don't include the full Git history needed to determine file modification times.

The solution is to set the `VERCEL_DEEP_CLONE=true` environment variable in Vercel project settings. This information was previously undocumented.

## Test Plan

- Verified Markdown syntax renders correctly in both files
- Confirmed all links point to official Vercel documentation
- Checked that the tip block and table format display properly
- No code changes, documentation only

### Test links

- Deployment docs: https://deploy-preview-11633--docusaurus-2.netlify.app/docs/deployment#deploying-to-vercel
- API docs: https://deploy-preview-11633--docusaurus-2.netlify.app/docs/api/plugins/@docusaurus/plugin-content-docs#showLastUpdateTime

## Related issues/PRs

Closes #10031