### PR TITLE
docs(i18n): fix cp commands to avoid duplicate files

### DIFF
--- a/website/docs/i18n/i18n-git.mdx
+++ b/website/docs/i18n/i18n-git.mdx
@@ -112,10 +112,10 @@ Copy your untranslated Markdown files to the French folder:
 
 ```bash
 mkdir -p i18n/fr/docusaurus-plugin-content-docs/current
-cp -r docs/** i18n/fr/docusaurus-plugin-content-docs/current
+cp -r docs/. i18n/fr/docusaurus-plugin-content-docs/current
 
 mkdir -p i18n/fr/docusaurus-plugin-content-blog
-cp -r blog/** i18n/fr/docusaurus-plugin-content-blog
+cp -r blog/. i18n/fr/docusaurus-plugin-content-blog
 
 mkdir -p i18n/fr/docusaurus-plugin-content-pages
 cp -r src/pages/**.md i18n/fr/docusaurus-plugin-content-pages

--- a/website/docs/i18n/i18n-tutorial.mdx
+++ b/website/docs/i18n/i18n-tutorial.mdx
@@ -400,7 +400,7 @@ Copy your docs Markdown files from `docs/` to `i18n/fr/docusaurus-plugin-content
 
 ```bash
 mkdir -p i18n/fr/docusaurus-plugin-content-docs/current
-cp -r docs/** i18n/fr/docusaurus-plugin-content-docs/current
+cp -r docs/. i18n/fr/docusaurus-plugin-content-docs/current
 ```
 
 :::info
@@ -415,7 +415,7 @@ Copy your blog Markdown files to `i18n/fr/docusaurus-plugin-content-blog`, and t
 
 ```bash
 mkdir -p i18n/fr/docusaurus-plugin-content-blog
-cp -r blog/** i18n/fr/docusaurus-plugin-content-blog
+cp -r blog/. i18n/fr/docusaurus-plugin-content-blog
 ```
 
 #### Translate the pages {#translate-the-pages}


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #11158) and the maintainers have approved on my working plan.

## Motivation

Fixes #11158

The `cp` commands in the i18n tutorial use both `-r` (recursive) AND `**` (glob pattern), which causes **duplicate files** in some shells where the glob expands all files in subdirectories before the recursive copy runs.

For example, `cp -r docs/**` results in:
```
api/file1.md type/file2.md file1.md file2.md
```

Instead of just the directory structure.

## Test Plan

- Verified the syntax `cp -r docs/.` is POSIX-compliant and works correctly
- The `/. ` syntax copies directory contents recursively without relying on shell globbing
- No duplicate files are created with this approach

### Test links

Deploy preview: https://deploy-preview-____--docusaurus-2.netlify.app/docs/i18n/tutorial#translate-markdown-files

## Related issues/PRs

Closes #11158

Note: Previous PRs #11450 and #11471 attempted to fix this but were closed because the contributors did not sign the CLA.