### PR TITLE
feat(theme): add MDXComponents/Li to swizzle config

### DIFF
--- a/packages/docusaurus-theme-classic/src/getSwizzleConfig.ts
+++ b/packages/docusaurus-theme-classic/src/getSwizzleConfig.ts
@@ -368,6 +368,13 @@ export default function getSwizzleConfig(): SwizzleConfig {
         description:
           'The component used to render <img> tags and Markdown images in MDX',
       },
+      'MDXComponents/Li': {
+        actions: {
+          eject: 'safe',
+          wrap: 'safe',
+        },
+        description: 'The component used to render <li> tags in MDX',
+      },
       'MDXComponents/Pre': {
         actions: {
           eject: 'safe',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).


- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
> Covered by existing dogfooding script testSwizzleThemeClassic.mjs


- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.
> N/A - minor config addition, not a new API or substantial change

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

`MDXComponents/Li` was missing from the swizzle config, causing it to appear at the bottom of the components list as "unsafe" by default. This made it harder to discover and inconsistent with other similar MDX components (`Ul`, `A`, `Img`, etc.) which are all marked as "safe".

Since `Li` is just as safe to swizzle as the rest of the MDXComponents family, this PR adds it to the config with `safe` status for both `eject` and `wrap` actions.


## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->
Run swizzle and `node _dogfooding/testSwizzleThemeClassic.mjs` in the `website` directory.
<img width="1294" height="1037" alt="CleanShot 2025-12-27 at 15 27 58@2x" src="https://github.com/user-attachments/assets/5b1b0385-ef48-4768-8b14-113191c47639" />


### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-11635--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
