### PR TITLE
fix(dx): configure devcontainer to use the host network

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,5 +33,6 @@
       "version": "22"
     },
     "github-cli": "latest"
-  }
+  },
+  "runArgs": ["--network=host"]
 }


### PR DESCRIPTION
Add `"--network=host"` to tell docker to re-use the network connections of the host machine.  Otherwise the host system can't reach the dev-server inside the devcontainer (what is the default on Windows+WSL2, in which case the browser spins forever loading localhost:3000).

## Motivation

Devcontainers are an easy way to get started with the project. The `--network=host` was missing s.t. it did not work for a Windows+WSL setup.

