### PR TITLE
fix(create-docusaurus): avoid stdin race condition on Windows

### DIFF
--- a/packages/create-docusaurus/src/index.ts
+++ b/packages/create-docusaurus/src/index.ts
@@ -524,10 +524,8 @@ export default async function init(
   reqTemplate?: string,
   cliOptions: CLIOptions = {},
 ): Promise<void> {
-  const [templates, siteName] = await Promise.all([
-    readTemplates(),
-    getSiteName(reqName, rootDir),
-  ]);
+  const templates = await readTemplates();
+  const siteName = await getSiteName(reqName, rootDir);
   const dest = path.resolve(rootDir, siteName);
 
   const source = await getSource(reqTemplate, templates, cliOptions);


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the Contributing Guidelines on pull requests.
- [x] If this is a code change: I have manually verified the behavior change locally.
- [ ] If this is a new API or substantial change: the PR has an accompanying issue and the maintainers have approved on my working plan.

## Motivation

This PR fixes a Windows-only issue where interactive CLI prompts lose
keyboard focus during `create-docusaurus` initialization.

The problem was caused by running `readTemplates()` and `getSiteName()`
concurrently using `Promise.all()` . On Windows terminals, concurrent
stdin access can cause arrow key input to be ignored until Enter is
pressed.

## Test Plan

Since `pnpm create docusaurus` pulls the published package from the
registry, it does not reflect local source changes.

To test the fix locally:

1. Built the package to compile TypeScript to JavaScript
2. Ran the CLI directly using `node bin/index.js`
3. Verified that interactive prompts accept arrow key input immediately
   on Windows 11 without requiring an extra Enter key press

This approach ensures the test runs against the locally modified CLI implementation.


### Test links

N/A (CLI-only change, no UI impact)

## Related issues/PRs

Fixes #11651