### PR TITLE
feat(website): add recent blogs section to homepage

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -298,6 +298,8 @@ export default async function createConfigAsync() {
     ],
     themes: ['live-codeblock', ...dogfoodingThemeInstances],
     plugins: [
+      // Exposes recent blog posts as global data for the homepage
+      './src/plugins/recentBlogs/index.ts',
       function disableExpensiveBundlerOptimizationPlugin() {
         return {
           name: 'disable-expensive-bundler-optimizations',

--- a/website/src/components/RecentBlogs/index.tsx
+++ b/website/src/components/RecentBlogs/index.tsx
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import {usePluginData} from '@docusaurus/useGlobalData';
+import Translate from '@docusaurus/Translate';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import Heading from '@theme/Heading';
+
+import type {RecentBlogsPluginData} from '@site/src/plugins/recentBlogs';
+import styles from './styles.module.css';
+
+function BlogPostCard({
+  title,
+  permalink,
+  date,
+  description,
+  authors,
+}: {
+  title: string;
+  permalink: string;
+  date: string;
+  description: string;
+  authors: ReadonlyArray<{name?: string; imageURL?: string}>;
+}): ReactNode {
+  return (
+    <div className={clsx('col col--4')}>
+      <article className={clsx('card', styles.blogCard)}>
+        <div className="card__header">
+          <Heading as="h3" className={styles.blogCardTitle}>
+            <Link to={permalink}>{title}</Link>
+          </Heading>
+          <time dateTime={date} className={styles.blogCardDate}>
+            {new Date(date).toLocaleDateString(undefined, {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })}
+          </time>
+        </div>
+        <div className="card__body">
+          <p className={styles.blogCardDescription}>{description}</p>
+        </div>
+        <div className="card__footer">
+          <div className={styles.blogCardAuthors}>
+            {authors.slice(0, 3).map((author, index) => (
+              <div key={author.name ?? index} className={styles.blogCardAuthor}>
+                {author.imageURL && (
+                  <img
+                    src={author.imageURL}
+                    alt={author.name ?? 'Blog post author'}
+                    className={styles.blogCardAuthorImage}
+                    loading="lazy"
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+          <Link to={permalink} className="button button--secondary button--sm">
+            <Translate id="homepage.recentBlogs.readMore">Read more</Translate>
+          </Link>
+        </div>
+      </article>
+    </div>
+  );
+}
+
+export default function RecentBlogs(): ReactNode {
+  const {recentPosts} = usePluginData(
+    'recent-blogs-plugin',
+  ) as RecentBlogsPluginData;
+  const blogUrl = useBaseUrl('/blog');
+
+  if (!recentPosts || recentPosts.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className={clsx(styles.recentBlogs, 'padding-vert--lg')}>
+      <div className="container">
+        <Heading as="h2" className={clsx('text--center', 'margin-bottom--lg')}>
+          <Translate id="homepage.recentBlogs.title">Latest Blogs</Translate>
+        </Heading>
+        <div className="row">
+          {recentPosts.map((post) => (
+            <BlogPostCard key={post.permalink} {...post} />
+          ))}
+        </div>
+        <div className={clsx('text--center', 'margin-top--lg')}>
+          <Link to={blogUrl} className="button button--primary button--lg">
+            <Translate id="homepage.recentBlogs.viewAll">
+              View all blog posts
+            </Translate>
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/RecentBlogs/styles.module.css
+++ b/website/src/components/RecentBlogs/styles.module.css
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.recentBlogs {
+  background-color: var(--ifm-color-emphasis-100);
+}
+
+.blogCard {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.blogCard .card__body {
+  flex: 1;
+}
+
+.blogCardTitle {
+  font-size: 1.1rem;
+  margin-bottom: 0.5rem;
+}
+
+.blogCardDate {
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.85rem;
+}
+
+.blogCardDescription {
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.9rem;
+  display: -webkit-box;
+  line-clamp: 3;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.blogCardAuthors {
+  display: flex;
+  gap: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.blogCardAuthor {
+  display: flex;
+  align-items: center;
+}
+
+.blogCardAuthorImage {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px solid var(--ifm-color-emphasis-200);
+}

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -20,6 +20,7 @@ import Tweet from '@site/src/components/Tweet';
 import Tweets, {type TweetItem} from '@site/src/data/tweets';
 import Quotes from '@site/src/data/quotes';
 import Features, {type FeatureItem} from '@site/src/data/features';
+import RecentBlogs from '@site/src/components/RecentBlogs';
 import Heading from '@theme/Heading';
 
 import styles from './styles.module.css';
@@ -272,6 +273,7 @@ export default function Home(): ReactNode {
           <FeaturesContainer />
           <VideoContainer />
         </div>
+        <RecentBlogs />
         <TweetsSection />
         <QuotesSection />
       </main>

--- a/website/src/plugins/recentBlogs/index.ts
+++ b/website/src/plugins/recentBlogs/index.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type {LoadContext, Plugin, AllContent} from '@docusaurus/types';
+import type {BlogPost, BlogContent} from '@docusaurus/plugin-content-blog';
+
+export type RecentBlogPost = {
+  readonly title: string;
+  readonly permalink: string;
+  readonly date: string;
+  readonly description: string;
+  readonly authors: ReadonlyArray<{
+    readonly name?: string;
+    readonly imageURL?: string;
+  }>;
+};
+
+export type RecentBlogsPluginData = {
+  readonly recentPosts: RecentBlogPost[];
+};
+
+const PluginName = 'recent-blogs-plugin';
+
+/**
+ * A simple plugin that exposes the 3 most recent blog posts
+ * as global data for use on the homepage.
+ */
+export default function recentBlogsPlugin(
+  _context: LoadContext,
+): Plugin<undefined> {
+  return {
+    name: PluginName,
+
+    async allContentLoaded({allContent, actions}) {
+      const blogContent = getBlogPluginContent(allContent);
+      if (!blogContent) {
+        return;
+      }
+
+      const recentPosts = getRecentBlogPosts(blogContent.blogPosts, 3);
+      actions.setGlobalData({recentPosts});
+    },
+  };
+}
+
+function getBlogPluginContent(allContent: AllContent): BlogContent | undefined {
+  // The blog plugin uses 'default' as its plugin id by default
+  return allContent['docusaurus-plugin-content-blog']?.default as
+    | BlogContent
+    | undefined;
+}
+
+function getRecentBlogPosts(
+  blogPosts: BlogPost[],
+  count: number,
+): RecentBlogPost[] {
+  // Blog posts are already sorted by date (newest first)
+  // Filter out unlisted posts and take the first `count` posts
+  return blogPosts
+    .filter((post) => !post.metadata.unlisted)
+    .slice(0, count)
+    .map((post) => ({
+      title: post.metadata.title,
+      permalink: post.metadata.permalink,
+      date: post.metadata.date.toString(),
+      description: post.metadata.description,
+      authors: post.metadata.authors.map((author) => ({
+        name: author.name,
+        imageURL: author.imageURL,
+      })),
+    }));
+}


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

This PR adds a "Latest Blogs" section to the Docusaurus homepage that dynamically displays the 3 most recent blog posts. This helps visitors quickly discover recent content and encourages engagement with the blog.

**Changes:**
- Add `recentBlogs` plugin to expose recent blog posts via global data using the `allContentLoaded` lifecycle hook
- Add `RecentBlogs` component with responsive blog post cards
- Integrate component on homepage between Features and Tweets sections

**Features:**
- Automatically updates at build time (no manual editing needed)
- i18n support with `<Translate>` component
- Responsive grid layout (3 columns on desktop)
- Shows title, date, description, and author avatars

## Test Plan

1. `yarn install`
2. `yarn workspace website start`
3. Visit homepage at http://localhost:3000
4. Verify the "Latest Blogs" section appears between Features and Tweets
5. Verify it shows 3 blog post cards with correct titles, dates, and descriptions
6. Click through to verify links work correctly

### Test links

Deploy preview: https://deploy-preview-11665--docusaurus-2.netlify.app/

- Homepage with new Recent Blogs section: https://deploy-preview-11665--docusaurus-2.netlify.app/

## Related issues/PRs

N/A - This is a new feature contribution.