### PR TITLE
docs(deployment): recommend Cloudflare Workers over Cloudflare Pages

### DIFF
--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -931,7 +931,6 @@ See [docs](https://docs.quantcdn.io/docs/cli/continuous-integration) and [blog](
 - [Cloudflare's framework guide for deploying Docusaurus with Workers](https://developers.cloudflare.com/workers/framework-guides/web-apps/more-web-frameworks/docusaurus/).
 - [Cloudflare's guide to deploying Docusaurus with Pages](https://developers.cloudflare.com/pages/framework-guides/deploy-a-docusaurus-site/).
 
-
 ## Deploying to Azure Static Web Apps {#deploying-to-azure-static-web-apps}
 
 [Azure Static Web Apps](https://docs.microsoft.com/en-us/azure/static-web-apps/overview) is a service that automatically builds and deploys full-stack web apps to Azure directly from the code repository, simplifying the developer experience for CI/CD. Static Web Apps separates the web application's static assets from its dynamic (API) endpoints. Static assets are served from globally-distributed content servers, making it faster for clients to retrieve files using servers nearby. Dynamic APIs are scaled with serverless architectures using an event-driven functions-based approach that is more cost-effective and scales on demand. Get started in a few minutes by following [this step-by-step guide](https://dev.to/azure/11-share-content-with-docusaurus-azure-static-web-apps-30hc).


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

- Cloudflare Workers are the modern, recommended way to deploy Docusaurus sites.
- This change helps new users follow best practices.
- https://developers.cloudflare.com/pages/framework-guides/deploy-a-docusaurus-site/
- https://developers.cloudflare.com/workers/static-assets/migration-guides/migrate-from-pages/

## Test Plan

- Verified documentation renders correctly in local development \
/docs/deployment#deploying-to-cloudflare
- Verified documentation renders correctly on test environment \
https://deploy-preview-11673--docusaurus-2.netlify.app/docs/deployment/#deploying-to-cloudflare

<img width="2298" height="1532" alt="image" src="https://github.com/user-attachments/assets/9f3814d8-a242-4d85-90cb-da8b90a54989" />



