### PR TITLE
Improve Tabs error message for wrapped TabItem components

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx
@@ -38,7 +38,7 @@ describe('Tabs', () => {
         </TestProviders>,
       );
     }).toThrowErrorMatchingInlineSnapshot(
-      `"Docusaurus error: Bad <Tabs> child <div>: all children of the <Tabs> component should be <TabItem>, and every <TabItem> should have a unique "value" prop."`,
+      `"Docusaurus error: Bad <Tabs> child <div>: children of the <Tabs> component must be direct <TabItem> elements. Wrapper or custom components around <TabItem> are not supported, and every <TabItem> must have a unique \"value\" prop."`,
     );
   });
   it('rejects bad Tabs defaultValue', () => {

--- a/packages/docusaurus-theme-common/src/utils/tabsUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/tabsUtils.tsx
@@ -74,7 +74,7 @@ export function sanitizeTabsChildren(children: TabsProps['children']) {
         `Docusaurus error: Bad <Tabs> child <${
           // @ts-expect-error: guarding against unexpected cases
           typeof child.type === 'string' ? child.type : child.type.name
-        }>: all children of the <Tabs> component should be <TabItem>, and every <TabItem> should have a unique "value" prop.`,
+        }>: children of the <Tabs> component must be direct <TabItem> elements. Wrapper or custom components around <TabItem> are not supported, and every <TabItem> must have a unique "value" prop.`,
       );
     })
     ?.filter(Boolean) ?? []) as ReactElement<TabItemProps>[];


### PR DESCRIPTION
 Summary

This PR improves the error message thrown by the `<Tabs>` component when a non-`<TabItem>` child is provided.

The goal is to clarify that wrapper or custom components around `<TabItem>` are currently not supported by the existing validation logic, which checks the direct React element type.

 Changes

- Improved the `<Tabs>` child validation error message to mention unsupported wrapper/custom components.
- Updated the related test snapshot to match the new error message.

Context

This change is motivated by the discussion in the linked issue, where users attempted to wrap `<TabItem>` in custom components and encountered a confusing error.

I intentionally started with an error-message-only change to avoid modifying core behavior without guidance, and I’m very open to iterating on this approach if relaxing the validation is preferred.

 Related Issue

Link :-  https://github.com/facebook/docusaurus/issues/11672
