### PR TITLE
feat(create-docusaurus): make base TS config strict by default

### DIFF
--- a/packages/create-docusaurus/templates/classic-typescript/tsconfig.json
+++ b/packages/create-docusaurus/templates/classic-typescript/tsconfig.json
@@ -4,8 +4,7 @@
 {
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
-    "baseUrl": ".",
-    "strict": true
+    "baseUrl": "."
   },
   "exclude": [".docusaurus", "build"]
 }

--- a/packages/docusaurus-tsconfig/tsconfig.json
+++ b/packages/docusaurus-tsconfig/tsconfig.json
@@ -3,6 +3,7 @@
   "display": "Docusaurus",
   "docs": "https://docusaurus.io/docs/typescript-support",
   "compilerOptions": {
+    "strict": true,
     "allowJs": true,
     "esModuleInterop": true,
     "jsx": "preserve",


### PR DESCRIPTION

## Motivation

For Docusaurus v4, we want to make the base TS config stricter by default

This is a TS breaking change, so we'll merge it only for v4

We can now remove the local strict: true setting applied to newly initialized sites, added in https://github.com/facebook/docusaurus/pull/11696

## Test Plan

CI

