### PR TITLE
refactor(utils): remove lodash dependency from gitUtils

### DIFF
--- a/packages/docusaurus-utils/src/vcs/gitUtils.ts
+++ b/packages/docusaurus-utils/src/vcs/gitUtils.ts
@@ -8,7 +8,6 @@
 import path from 'path';
 import fs from 'fs-extra';
 import os from 'os';
-import _ from 'lodash';
 import execa from 'execa';
 import PQueue from 'p-queue';
 import logger from '@docusaurus/logger';
@@ -46,8 +45,17 @@ const realHasGitFn = () => {
 
 // The hasGit call is synchronous IO so we memoize it
 // The user won't install Git in the middle of a build anyway...
-const hasGit =
-  process.env.NODE_ENV === 'test' ? realHasGitFn : _.memoize(realHasGitFn);
+let hasGitCache: boolean | undefined;
+
+const hasGit = (): boolean => {
+  if (process.env.NODE_ENV === 'test') {
+    return realHasGitFn();
+  }
+  if (hasGitCache === undefined) {
+    hasGitCache = realHasGitFn();
+  }
+  return hasGitCache;
+};
 
 // TODO Docusaurus v4: remove this
 //  Exceptions are not made for control flow logic


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

#### Motivation

This PR removes the dependency on `lodash` in `packages/docusaurus-utils/src/gitUtils.ts`.

Currently, `lodash` is imported only to use `_.memoize` for the `hasGit` function. Replacing this with a native variable caching mechanism eliminates the need for the library import in this file, helping to reduce bundle size and external dependencies.

#### Test Plan

- Verified that the `hasGit` function logic remains consistent (caches the result after the first execution).
    
- Ran existing tests via `yarn jest packages/docusaurus-utils` to ensure no regressions.
    

#### Test links

N/A (Refactor of internal utility, no UI changes).

#### Related issues/PRs

N/A