### PR TITLE
fix(faster): remove deprecated experiments.lazyBarrel option

### DIFF
--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -171,16 +171,6 @@ export async function createBaseConfig({
         experiments.incremental = false;
       }
 
-      // See https://rspack.rs/blog/announcing-1-5#barrel-file-optimization
-      if (process.env.DISABLE_RSPACK_LAZY_BARREL) {
-        console.log('Rspack lazyBarrel disabled');
-        experiments.lazyBarrel = false;
-      } else {
-        // TODO remove after we upgrade to Rspack 1.6+
-        //  Enabled by default for Rspack >= 1.6
-        experiments.lazyBarrel = true;
-      }
-
       // TODO re-enable later, there's an Rspack performance issue
       //  see https://github.com/facebook/docusaurus/pull/11178
       experiments.parallelCodeSplitting = false;


### PR DESCRIPTION
## Motivation

Since Rspack 1.7+, the `experiments.lazyBarrel` option is deprecated and will be removed in Rspack 2.0. The feature is now stable and enabled by default, so the configuration is no longer needed.

This causes a deprecation warning when building:
```
[Rspack Deprecation] `experiments.lazyBarrel` config is deprecated and will be removed in Rspack v2.0. Lazy barrel is already stable and enabled by default. Remove this option from your Rspack configuration.
```

## Changes

- Removed the `experiments.lazyBarrel` configuration and the `DISABLE_RSPACK_LAZY_BARREL` environment variable check
- The TODO comment indicated this should be removed after Rspack 1.6+

## References

- Rspack deprecation commit: https://github.com/web-infra-dev/rspack/commit/ff4d368956a296062cbbc4e7411692de1e2caba2
- Fixes #11688

## Test Plan

The change is additive (removal of deprecated config). Rspack's lazy barrel optimization continues to work as it's now enabled by default.