### PR TITLE
fix(theme-common): properly memoize attributeFilter in useMutationObs…

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/reactUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/reactUtils.tsx
@@ -88,6 +88,17 @@ export function useShallowMemoObject<O extends object>(obj: O): O {
   return useMemo(() => obj, deps.flat());
 }
 
+/**
+ * Shallow-memoize an array. Returns the same array reference if elements
+ * are shallowly equal to the previous render.
+ *
+ * @param arr
+ */
+export function useShallowMemoArray<T>(arr: T[] | undefined): T[] | undefined {
+  // eslint-disable-next-line react-compiler/react-compiler,react-hooks/exhaustive-deps
+  return useMemo(() => arr, arr ?? []);
+}
+
 type SimpleProvider = ComponentType<{children: ReactNode}>;
 
 /**


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.

## Motivation

This PR addresses the TODO in `useMutationObserver.ts`:

The `useShallowMemoObject` hook only performs shallow comparison—it flattens object entries and compares values directly. This means `attributeFilter` (an array) is compared by reference, not by value. If a caller passes a new array instance with the same contents on each render, the options will be considered "changed" and the `MutationObserver` will be recreated unnecessarily.

## Solution

1. Added a new `useShallowMemoArray` utility to `reactUtils.tsx` that properly memoizes arrays by their element values
2. Updated `useMutationObserver` to extract and memoize `attributeFilter` separately before combining it back with the rest of the options

## Test Plan

```bash
yarn test packages/docusaurus-theme-common