### PR TITLE
fix(website): fix dogfood editUrl

### DIFF
--- a/website/_dogfooding/dogfooding.config.ts
+++ b/website/_dogfooding/dogfooding.config.ts
@@ -51,6 +51,7 @@ export const dogfoodingPluginInstances: PluginConfig[] = [
       id: 'docs-tests',
       routeBasePath: '/tests/docs',
       sidebarPath: '_dogfooding/docs-tests-sidebars.js',
+      editUrl: 'https://github.com/facebook/docusaurus/edit/main/website/',
       versions: {
         current: {
           noIndex: !isArgosBuild,
@@ -94,8 +95,7 @@ export const dogfoodingPluginInstances: PluginConfig[] = [
       id: 'blog-tests',
       path: '_dogfooding/_blog tests',
       routeBasePath: '/tests/blog',
-      editUrl:
-        'https://github.com/facebook/docusaurus/edit/main/website/_dogfooding/_blog-tests',
+      editUrl: 'https://github.com/facebook/docusaurus/edit/main/website/',
       postsPerPage: 3,
       blogSidebarCount: 'ALL',
       feedOptions: {


### PR DESCRIPTION
Just a tiny config issue on our website that prevents edit url links from working on dogfood blog/docs