### PR TITLE
docs: fix package readme consistency

### DIFF
--- a/packages/docusaurus-remark-plugin-npm2yarn/README.md
+++ b/packages/docusaurus-remark-plugin-npm2yarn/README.md
@@ -1,4 +1,4 @@
-# Remark plugin npm2yarn
+# `@docusaurus/remark-plugin-npm2yarn`
 
 ## Motivation:
 

--- a/packages/docusaurus-theme-classic/README.md
+++ b/packages/docusaurus-theme-classic/README.md
@@ -1,4 +1,4 @@
-# Docusaurus Theme Classic
+# `@docusaurus/theme-classic`
 
 The classic theme for Docusaurus.
 

--- a/packages/docusaurus-theme-live-codeblock/README.md
+++ b/packages/docusaurus-theme-live-codeblock/README.md
@@ -1,4 +1,4 @@
-# Docusaurus Live Codeblock
+# `@docusaurus/theme-live-codeblock`
 
 You can create live code editors with a code block `live` meta string.
 

--- a/packages/docusaurus-theme-mermaid/README.md
+++ b/packages/docusaurus-theme-mermaid/README.md
@@ -1,4 +1,4 @@
-# Docusaurus Theme Mermaid
+# `@docusaurus/theme-mermaid`
 
 The mermaid components for Docusaurus.
 

--- a/packages/docusaurus-theme-translations/README.md
+++ b/packages/docusaurus-theme-translations/README.md
@@ -1,4 +1,4 @@
-# Docusaurus theme translations
+# `@docusaurus/theme-translations`
 
 This package includes default translations for labels (like the pagination "Next" / "Previous") used by official Docusaurus themes.
 

--- a/packages/docusaurus-tsconfig/README.md
+++ b/packages/docusaurus-tsconfig/README.md
@@ -1,0 +1,3 @@
+# `@docusaurus/tsconfig`
+
+Base TypeScript configuration for Docusaurus websites

--- a/packages/docusaurus-tsconfig/package.json
+++ b/packages/docusaurus-tsconfig/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@docusaurus/tsconfig",
   "version": "3.9.2",
-  "description": "Docusaurus base TypeScript configuration.",
+  "description": "Base TypeScript configuration for Docusaurus websites",
   "main": "tsconfig.json",
   "publishConfig": {
     "access": "public"

--- a/packages/docusaurus-utils-common/README.md
+++ b/packages/docusaurus-utils-common/README.md
@@ -1,3 +1,3 @@
-# `@docusaurus/utils`
+# `@docusaurus/utils-common`
 
 Common (Node/Browser) utility functions for Docusaurus packages.

--- a/packages/docusaurus/README.md
+++ b/packages/docusaurus/README.md
@@ -1,1 +1,3 @@
-# Docusaurus core
+# `@docusaurus/core`
+
+The core package of Docusaurus


### PR DESCRIPTION

## Motivation

While manually configuring each npm package for trusted publishing on npm, I noticed some readme errors/inconsistencies.

Not a big deal, but let's normalize them a bit better
