### PR TITLE
fix(content-blog): fix wrong path variable in feed XSLT CSS file validation

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/feed.ts
+++ b/packages/docusaurus-plugin-content-blog/src/feed.ts
@@ -213,7 +213,7 @@ async function resolveXsltFilePaths({
     parsedPath.dir,
     `${parsedPath.name}.css`,
   );
-  if (!(await fs.pathExists(xsltAbsolutePath))) {
+  if (!(await fs.pathExists(cssAbsolutePath))) {
     throw new Error(
       logger.interpolate`Blog feed XSLT file was found at path=${path.relative(
         process.cwd(),


### PR DESCRIPTION
## Pre-flight checklist

  - [x] I have read the [Contributing Guidelines on pull
  requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
  - [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully    
  verify the new behavior.
  - [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000)   
  and the maintainers have approved on my working plan.

  ## Motivation

  In `resolveXsltFilePaths` inside `packages/docusaurus-plugin-content-blog/src/feed.ts`, there are two   
  sequential existence checks:

  1. Line 202: checks if the XSLT file exists -- uses `xsltAbsolutePath` 
  2. Line 216: checks if the co-located CSS file exists -- also uses `xsltAbsolutePath` 

  The 2nd check should use `cssAbsolutePath`. Because it rechecks the XSLT path (which already passed 
  the first check), the CSS validation never fails ;even when the CSS file is genuinely missing. The     
  downstream `fs.copy(cssAbsolutePath, ...)` at line 252 then crashes with an unhelpful filesystem error  
  instead of the err message that was written for this exact scenario.


  ## Test Plan

  1.)the logic is straightforward.       
  2.)The function is called once by `generateXsltFiles` (line 242), which destructures `{xsltAbsolutePath,
   cssAbsolutePath}` and copies both files. With this fix, a missing CSS file is now caught at validation 
  time with the intended error message instead of failing silently until the copy step.

  ### Test links

  N/A — no UI change.

  ## Related issues/PRs

  None - analyis of file