### PR TITLE
fix(google-tag-manager): rename pluginGoogleAnalytics to pluginGoogleTagManager

### DIFF
--- a/packages/docusaurus-plugin-google-tag-manager/src/index.ts
+++ b/packages/docusaurus-plugin-google-tag-manager/src/index.ts
@@ -13,7 +13,7 @@ import type {
 } from '@docusaurus/types';
 import type {PluginOptions, Options} from './options';
 
-export default function pluginGoogleAnalytics(
+export default function pluginGoogleTagManager(
   context: LoadContext,
   options: PluginOptions,
 ): Plugin | null {


### PR DESCRIPTION
## Pre-flight checklist

  - [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
  - [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
  - [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

  ## Motivation

  The default export function in `docusaurus-plugin-google-tag-manager/src/index.ts` is named
  `pluginGoogleAnalytics`. This is a copy-paste artifact from `docusaurus-plugin-google-analytics`, where 
  that name is correct.

  The other two Google plugins follow the correct naming convention:
    - `docusaurus-plugin-google-analytics` -> `pluginGoogleAnalytics`
    - `docusaurus-plugin-google-gtag` -> `pluginGoogleGtag`
    - `docusaurus-plugin-google-tag-manager` -> `pluginGoogleAnalytics` {wrong}

  The plugin's `name` property already returns the correct string
  `'docusaurus-plugin-google-tag-manager'`. Only the function identifier we looked into.

  ## Test Plan

    - No behavioral change. The function is a default export, so no external code references it by name.  
  Verified that no other file in therepo imports this function by identifier.

  ### Test links

  Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

  ## Related issues/PRs

  N/A