### PR TITLE
fix(utils): apply trailingSlash: false to baseUrl path

### DIFF
--- a/packages/docusaurus-utils-common/src/__tests__/applyTrailingSlash.test.ts
+++ b/packages/docusaurus-utils-common/src/__tests__/applyTrailingSlash.test.ts
@@ -42,13 +42,13 @@ describe('applyTrailingSlash', () => {
     );
   });
 
-  it('does not apply to /baseUrl/', () => {
+  it('does not apply to /baseUrl/ unless trailingSlash is false', () => {
     const baseUrl = '/baseUrl/';
     expect(applyTrailingSlash('/baseUrl/', params(true, baseUrl))).toBe(
       '/baseUrl/',
     );
     expect(applyTrailingSlash('/baseUrl/', params(false, baseUrl))).toBe(
-      '/baseUrl/',
+      '/baseUrl',
     );
     expect(applyTrailingSlash('/baseUrl/', params(undefined, baseUrl))).toBe(
       '/baseUrl/',
@@ -59,7 +59,7 @@ describe('applyTrailingSlash', () => {
     ).toBe('/baseUrl/?query#anchor');
     expect(
       applyTrailingSlash('/baseUrl/?query#anchor', params(false, baseUrl)),
-    ).toBe('/baseUrl/?query#anchor');
+    ).toBe('/baseUrl?query#anchor');
     expect(
       applyTrailingSlash('/baseUrl/?query#anchor', params(undefined, baseUrl)),
     ).toBe('/baseUrl/?query#anchor');

--- a/packages/docusaurus-utils-common/src/applyTrailingSlash.ts
+++ b/packages/docusaurus-utils-common/src/applyTrailingSlash.ts
@@ -42,10 +42,15 @@ export default function applyTrailingSlash(
   const [pathname] = path.split(/[#?]/) as [string, ...string[]];
 
   // Never transform '/' to ''
-  // Never remove the baseUrl trailing slash!
-  // If baseUrl = /myBase/, we want to emit /myBase/index.html and not
-  // /myBase.html! See https://github.com/facebook/docusaurus/issues/5077
-  const shouldNotApply = pathname === '/' || pathname === baseUrl;
+  // When trailingSlash is not explicitly false, never remove the baseUrl
+  // trailing slash! If baseUrl = /myBase/, we want to emit
+  // /myBase/index.html and not /myBase.html!
+  // See https://github.com/facebook/docusaurus/issues/5077
+  // However, when trailingSlash is explicitly false, we should remove the
+  // trailing slash from the baseUrl path for consistency (e.g. canonical URLs)
+  // See https://github.com/facebook/docusaurus/issues/11735
+  const shouldNotApply =
+    pathname === '/' || (pathname === baseUrl && trailingSlash !== false);
 
   const newPathname = shouldNotApply
     ? pathname


### PR DESCRIPTION
## Motivation

When `trailingSlash` is set to `false` in `docusaurus.config.ts`, the canonical URL for the site's root path (baseUrl) still included a trailing slash. For example, with `baseUrl: '/docs/'` and `trailingSlash: false`, the canonical would be `https://example.com/docs/` instead of `https://example.com/docs`.

This creates an SEO inconsistency where all pages use no trailing slash, but the root path does, triggering canonical link warnings in SEO auditing tools.

Reported in #11735 with a reproduction sandbox.

## Changes

Modified `applyTrailingSlash` to only preserve the baseUrl's trailing slash when `trailingSlash` is not explicitly `false`. When `trailingSlash: false`, the baseUrl path is treated the same as any other path and has its trailing slash removed.

The root path `/` is still never transformed to an empty string, regardless of the `trailingSlash` setting.

## Test Plan

- Updated the existing "does not apply to /baseUrl/" test case to reflect the new behavior when `trailingSlash: false`
- All existing tests continue to pass for `trailingSlash: true` and `trailingSlash: undefined`
- Verified with `yarn jest packages/docusaurus-utils-common/src/__tests__/applyTrailingSlash.test.ts`