### PR TITLE
Test: add error handling tests for runCommand with invalid commands

### DIFF
--- a/packages/create-docusaurus/src/__tests__/cross-spawn.d.ts
+++ b/packages/create-docusaurus/src/__tests__/cross-spawn.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+declare module 'cross-spawn';

--- a/packages/create-docusaurus/src/__tests__/utils.test.ts
+++ b/packages/create-docusaurus/src/__tests__/utils.test.ts
@@ -5,7 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {siteNameToPackageName} from '../utils';
+import {EventEmitter} from 'events';
+import spawn from 'cross-spawn';
+import {siteNameToPackageName, runCommand} from '../utils';
+
+// MY TEST CASE
 
 describe('siteNameToPackageName', () => {
   it('converts simple cases', () => {
@@ -38,5 +42,59 @@ describe('siteNameToPackageName', () => {
 
   it('skips !!!', () => {
     expect(siteNameToPackageName('!!!')).toEqual('!!!');
+  });
+});
+
+jest.mock('cross-spawn', () => {
+  const mockFn = jest.fn();
+  return {
+    default: mockFn,
+    __esModule: true,
+  };
+});
+
+// describe.skip(........) skips my test cases to get coverage before
+describe('runCommand error handling', () => {
+  beforeEach(() => {
+    // set spawn mock to a clean default state
+    jest.mocked(spawn).mockImplementation(() => {
+      const fakeProcess = new EventEmitter();
+      process.nextTick(() => fakeProcess.emit('close', 0));
+      return fakeProcess;
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('verifies error thrown for empty string commands', async () => {
+    await expect(runCommand('')).rejects.toThrow('Invalid command');
+  });
+
+  it('verifies error thrown for white spaces only command', async () => {
+    await expect(runCommand('  ')).rejects.toThrow('Invalid command');
+  });
+
+  it('verifies promise rejects when spawn emits error event', async () => {
+    jest.mocked(spawn).mockImplementation(() => {
+      const fakeProcess = new EventEmitter();
+      process.nextTick(() =>
+        fakeProcess.emit('error', new Error('spawn failed')),
+      );
+      return fakeProcess;
+    });
+    await expect(runCommand('some-command')).rejects.toThrow('spawn failed');
+  });
+
+  it('promise rejects when exit code is null', async () => {
+    jest.mocked(spawn).mockImplementation(() => {
+      const fakeProcess = new EventEmitter();
+      process.nextTick(() => fakeProcess.emit('close', null));
+      return fakeProcess;
+    });
+    await expect(runCommand('some-command')).rejects.toThrow(
+      'No exit code for command',
+    );
   });
 });


### PR DESCRIPTION
Closes [#8](https://github.com/dpantaleoni/docusaurus/issues/8)

## Summary of what changed

- Added unit tests in
- - /docusaurus/packages/create-docusaurus/src/__tests__/utils.test.ts
- - Verifies that an error is thrown for empty string commands
- - Verifies that an error is thrown for white spaces only commands
- - Verifies that promise rejects when spawn emits error event
- - Verifies that promise is rejected when exit code is null
- - Cross-spawn is mocked  to fake a child process (EventEmitter), allowing tests to simulate error events and abnormal exit codes without spawning real processes  

## How to run the relevant test
 
From the repo root: 

yarn test /docusaurus/packages/create-docusaurus/src/__tests__/utils.test.ts

To see code coverage:

yarn jest /docusaurus/packages/create-docusaurus/src/__tests__/utils.test.ts --coverage --collectCoverageFrom='packages/create-docusaurus/src/utils.ts'

## Evidence

These changes prevent site creation process from hanging or failing silently when users provide invalid commands or when package managers fail during installation. Without these tests, the following regressions would go undetected:
- - Removal of empty/whitespace input validation causing 'runCommand' to hang 
- - Loss of spawn error handling causing failures to be swallowed silently
- - Removal of null exit code handling causing killed processes to be incorrectly appear successful  


## Coverage improvement
|  Metric          |  Before   |  After   |
|---------------|-----------|---------|
|  Statements  |  44.44%   |  100% |
|  Branches     |  25%        |  87.5% |
|  Functions    |  40%        |  100%  |
|  Lines           | 41.17%     |  100%  |

## Pre-flight checklist

- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
