### PR TITLE
fix(cli): fix `write-heading-ids` CLI when no files provided

### DIFF
--- a/packages/docusaurus/src/commands/writeHeadingIds.ts
+++ b/packages/docusaurus/src/commands/writeHeadingIds.ts
@@ -47,12 +47,16 @@ export async function writeHeadingIds(
 ): Promise<void> {
   const siteDir = await fs.realpath(siteDirParam);
 
-  const markdownFiles = await safeGlobby(
-    files ?? (await getPathsToWatch(siteDir)),
-    {
-      expandDirectories: ['**/*.{md,mdx}'],
-    },
-  );
+  const patterns = files.length ? files : await getPathsToWatch(siteDir);
+
+  const markdownFiles = await safeGlobby(patterns, {
+    expandDirectories: ['**/*.{md,mdx}'],
+  });
+
+  if (markdownFiles.length === 0) {
+    logger.warn`No markdown files found in siteDir path=${siteDir} for patterns: ${patterns}`;
+    return;
+  }
 
   const result = await Promise.all(
     markdownFiles.map((p) => transformMarkdownFile(p, options)),


### PR DESCRIPTION


## Motivation

The CLI is supposed to find the md/mdx files to apply heading ids automatically, without having to provide files/patterns as CLI options.




## Test Plan

local

## Related issues/PRs

This feature broke in 2022 (#7583). Apparently, nobody complained so far 😅, but still, let's fix it.