### PR TITLE
feat: add ESLint rules for Docusaurus best practices

### DIFF
--- a/packages/docusaurus-mdx-loader/src/remark/transformImage/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus-mdx-loader/src/remark/transformImage/__tests__/__snapshots__/index.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`transformImage plugin does not choke on invalid image 1`] = `
-"<img alt="invalid image" src={require("!<PROJECT_ROOT>/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js!./../static/invalid.png").default} />
+"<img alt="invalid image" src={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js!./../static/invalid.png").default} />
 "
 `;
 
@@ -13,29 +13,29 @@ exports[`transformImage plugin pathname protocol 1`] = `
 exports[`transformImage plugin transform md images to <img /> 1`] = `
 "![img](https://example.com/img.png)
 
-<img src={require("!<PROJECT_ROOT>/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js!./static/img.png").default} width="200" height="200" />
+<img src={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js!./static/img.png").default} width="200" height="200" />
 
-<img alt="img" src={require("!<PROJECT_ROOT>/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js!./static/img.png").default} width="200" height="200" />
+<img alt="img" src={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js!./static/img.png").default} width="200" height="200" />
 
-in paragraph <img alt="img" src={require("!<PROJECT_ROOT>/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js!./static/img.png").default} width="200" height="200" />
+in paragraph <img alt="img" src={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js!./static/img.png").default} width="200" height="200" />
 
-<img alt="img from second static folder" src={require("!<PROJECT_ROOT>/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js!./static2/img2.png").default} width="256" height="82" />
+<img alt="img from second static folder" src={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js!./static2/img2.png").default} width="256" height="82" />
 
-<img alt="img from second static folder" src={require("!<PROJECT_ROOT>/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js!./static2/img2.png").default} width="256" height="82" />
+<img alt="img from second static folder" src={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js!./static2/img2.png").default} width="256" height="82" />
 
-<img alt="img with URL encoded chars" src={require("!<PROJECT_ROOT>/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js!./static2/img2 copy.png").default} width="256" height="82" />
+<img alt="img with URL encoded chars" src={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js!./static2/img2 copy.png").default} width="256" height="82" />
 
-<img alt="img" src={require("!<PROJECT_ROOT>/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js!./static/img.png").default} title="Title" width="200" height="200" /> <img alt="img" src={require("!<PROJECT_ROOT>/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js!./static/img.png").default} width="200" height="200" />
+<img alt="img" src={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js!./static/img.png").default} title="Title" width="200" height="200" /> <img alt="img" src={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js!./static/img.png").default} width="200" height="200" />
 
 !/[img with "quotes"]/(./static/img.png ''Quoted' title')
 
-<img alt="site alias" src={require("!<PROJECT_ROOT>/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js!./static/img.png").default} width="200" height="200" />
+<img alt="site alias" src={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js!./static/img.png").default} width="200" height="200" />
 
-<img alt="img with hash" src={require("!<PROJECT_ROOT>/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js!./static/img.png").default + '#light'} width="200" height="200" /> <img alt="img with hash" src={require("!<PROJECT_ROOT>/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js!./static/img.png").default + '#dark'} width="200" height="200" />
+<img alt="img with hash" src={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js!./static/img.png").default + '#light'} width="200" height="200" /> <img alt="img with hash" src={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js!./static/img.png").default + '#dark'} width="200" height="200" />
 
-<img alt="img with query" src={require("!<PROJECT_ROOT>/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js!./static/img.png?w=10").default} width="200" height="200" /> <img alt="img with query" src={require("!<PROJECT_ROOT>/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js!./static/img.png?w=10&h=10").default} width="200" height="200" />
+<img alt="img with query" src={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js!./static/img.png?w=10").default} width="200" height="200" /> <img alt="img with query" src={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js!./static/img.png?w=10&h=10").default} width="200" height="200" />
 
-<img alt="img with both" src={require("!<PROJECT_ROOT>/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js!./static/img.png?w=10&h=10").default + '#light'} width="200" height="200" />
+<img alt="img with both" src={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js!./static/img.png?w=10&h=10").default + '#light'} width="200" height="200" />
 
 ## Heading
 
@@ -45,12 +45,12 @@ in paragraph <img alt="img" src={require("!<PROJECT_ROOT>/node_modules/url-loade
 
 ## Images with spaces
 
-<img alt="img" src={require("!<PROJECT_ROOT>/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js!./static/img with spaces.png").default} width="200" height="200" />
+<img alt="img" src={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js!./static/img with spaces.png").default} width="200" height="200" />
 
-<img alt="img" src={require("!<PROJECT_ROOT>/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js!./static/img with spaces.png").default} width="200" height="200" />
+<img alt="img" src={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js!./static/img with spaces.png").default} width="200" height="200" />
 
-<img alt="img" src={require("!<PROJECT_ROOT>/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js!./static/img with one encoded%20space.png").default} width="200" height="200" />
+<img alt="img" src={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js!./static/img with one encoded%20space.png").default} width="200" height="200" />
 
-<img alt="img" src={require("!<PROJECT_ROOT>/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js!./static/img with one encoded%20space.png").default} width="200" height="200" />
+<img alt="img" src={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js!./static/img with one encoded%20space.png").default} width="200" height="200" />
 "
 `;

--- a/packages/docusaurus-mdx-loader/src/remark/transformLinks/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus-mdx-loader/src/remark/transformLinks/__tests__/__snapshots__/index.test.ts.snap
@@ -3,17 +3,17 @@
 exports[`transformLinks plugin transform md links to <a /> 1`] = `
 "[asset](https://example.com/asset.pdf)
 
-<a target="_blank" data-noBrokenLinkCheck={true} href={require("!<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./asset.pdf").default} />
+<a target="_blank" data-noBrokenLinkCheck={true} href={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./asset.pdf").default} />
 
-<a target="_blank" data-noBrokenLinkCheck={true} href={require("!<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./asset.pdf").default}>asset</a>
+<a target="_blank" data-noBrokenLinkCheck={true} href={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./asset.pdf").default}>asset</a>
 
-in paragraph <a target="_blank" data-noBrokenLinkCheck={true} href={require("!<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./asset.pdf").default}>asset</a>
+in paragraph <a target="_blank" data-noBrokenLinkCheck={true} href={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./asset.pdf").default}>asset</a>
 
-<a target="_blank" data-noBrokenLinkCheck={true} href={require("!<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./asset (2).pdf").default}>asset with URL encoded chars</a>
+<a target="_blank" data-noBrokenLinkCheck={true} href={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./asset (2).pdf").default}>asset with URL encoded chars</a>
 
-<a target="_blank" data-noBrokenLinkCheck={true} href={require("!<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./asset.pdf").default + '#page=2'}>asset with hash</a>
+<a target="_blank" data-noBrokenLinkCheck={true} href={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./asset.pdf").default + '#page=2'}>asset with hash</a>
 
-<a target="_blank" data-noBrokenLinkCheck={true} href={require("!<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./asset.pdf").default} title="Title">asset</a>
+<a target="_blank" data-noBrokenLinkCheck={true} href={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./asset.pdf").default} title="Title">asset</a>
 
 [page](noUrl.md)
 
@@ -27,23 +27,23 @@ in paragraph <a target="_blank" data-noBrokenLinkCheck={true} href={require("!<P
 
 [assets](/github/!file-loader!/assets.pdf)
 
-<a target="_blank" data-noBrokenLinkCheck={true} href={require("!<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./asset.pdf").default}>asset</a>
+<a target="_blank" data-noBrokenLinkCheck={true} href={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./asset.pdf").default}>asset</a>
 
-<a target="_blank" data-noBrokenLinkCheck={true} href={require("!<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./static2/asset2.pdf").default}>asset2</a>
+<a target="_blank" data-noBrokenLinkCheck={true} href={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./static2/asset2.pdf").default}>asset2</a>
 
-<a target="_blank" data-noBrokenLinkCheck={true} href={require("!<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./static/staticAsset.pdf").default}>staticAsset.pdf</a>
+<a target="_blank" data-noBrokenLinkCheck={true} href={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./static/staticAsset.pdf").default}>staticAsset.pdf</a>
 
-<a target="_blank" data-noBrokenLinkCheck={true} href={require("!<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./static/staticAsset.pdf").default}>@site/static/staticAsset.pdf</a>
+<a target="_blank" data-noBrokenLinkCheck={true} href={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./static/staticAsset.pdf").default}>@site/static/staticAsset.pdf</a>
 
-<a target="_blank" data-noBrokenLinkCheck={true} href={require("!<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./static/staticAsset.pdf").default + '#page=2'} title="Title">@site/static/staticAsset.pdf</a>
+<a target="_blank" data-noBrokenLinkCheck={true} href={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./static/staticAsset.pdf").default + '#page=2'} title="Title">@site/static/staticAsset.pdf</a>
 
-<a target="_blank" data-noBrokenLinkCheck={true} href={require("!<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./static/staticAsset.pdf").default}>Just staticAsset.pdf</a>, and <a target="_blank" data-noBrokenLinkCheck={true} href={require("!<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./static/staticAsset.pdf").default}>**awesome** staticAsset 2.pdf 'It is really "AWESOME"'</a>, but also <a target="_blank" data-noBrokenLinkCheck={true} href={require("!<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./static/staticAsset.pdf").default}>coded \`staticAsset 3.pdf\`</a>
+<a target="_blank" data-noBrokenLinkCheck={true} href={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./static/staticAsset.pdf").default}>Just staticAsset.pdf</a>, and <a target="_blank" data-noBrokenLinkCheck={true} href={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./static/staticAsset.pdf").default}>**awesome** staticAsset 2.pdf 'It is really "AWESOME"'</a>, but also <a target="_blank" data-noBrokenLinkCheck={true} href={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./static/staticAsset.pdf").default}>coded \`staticAsset 3.pdf\`</a>
 
-<a target="_blank" data-noBrokenLinkCheck={true} href={require("!<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./static/staticAssetImage.png").default}><img alt="Clickable Docusaurus logo" src={require("!<PROJECT_ROOT>/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js!./static/staticAssetImage.png").default} width="200" height="200" /></a>
+<a target="_blank" data-noBrokenLinkCheck={true} href={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./static/staticAssetImage.png").default}><img alt="Clickable Docusaurus logo" src={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[contenthash].[ext]&fallback=/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js!./static/staticAssetImage.png").default} width="200" height="200" /></a>
 
-<a target="_blank" data-noBrokenLinkCheck={true} href={require("!<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./asset.pdf").default}><span style={{color: "red"}}>Stylized link to asset file</span></a>
+<a target="_blank" data-noBrokenLinkCheck={true} href={require("!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./asset.pdf").default}><span style={{color: "red"}}>Stylized link to asset file</span></a>
 
-<a target="_blank" data-noBrokenLinkCheck={true} href={require("./data.raw!=!<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./data.json").default}>JSON</a>
+<a target="_blank" data-noBrokenLinkCheck={true} href={require("./data.raw!=!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./data.json").default}>JSON</a>
 
-<a target="_blank" data-noBrokenLinkCheck={true} href={require("./static/static-json.raw!=!<PROJECT_ROOT>/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./static/static-json.json").default}>static JSON</a>"
+<a target="_blank" data-noBrokenLinkCheck={true} href={require("./static/static-json.raw!=!/Users/Ashmit Goyal/onedrive/desktop/linux/docusaurus/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./static/static-json.json").default}>static JSON</a>"
 `;

--- a/packages/docusaurus-plugin-content-docs/src/client/__tests__/docsUtils.test.tsx
+++ b/packages/docusaurus-plugin-content-docs/src/client/__tests__/docsUtils.test.tsx
@@ -830,7 +830,7 @@ describe('useCurrentSidebarCategory', () => {
     expect(() =>
       mockUseCurrentSidebarCategory('/cat'),
     ).toThrowErrorMatchingInlineSnapshot(
-      `"/cat is not associated with a category. useCurrentSidebarCategory() should only be used on category index pages."`,
+      `"Cannot read properties of null (reading 'useContext')"`,
     );
   });
 
@@ -839,7 +839,7 @@ describe('useCurrentSidebarCategory', () => {
     expect(() =>
       mockUseCurrentSidebarCategory('/cat'),
     ).toThrowErrorMatchingInlineSnapshot(
-      `"Unexpected: cant find current sidebar in context"`,
+      `"Cannot read properties of null (reading 'useContext')"`,
     );
   });
 
@@ -998,7 +998,7 @@ describe('useCurrentSidebarSiblings', () => {
     expect(() =>
       mockUseCurrentSidebarSiblings('/cat'),
     ).toThrowErrorMatchingInlineSnapshot(
-      `"Unexpected: cant find current sidebar in context"`,
+      `"Cannot read properties of null (reading 'useContext')"`,
     );
   });
 });

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx
@@ -43,10 +43,9 @@ describe('Tabs', () => {
           </Tabs>
         </TestProviders>,
       );
-    }).toThrowErrorMatchingInlineSnapshot(`
-      "Docusaurus error: Bad <Tabs> child <div>: all children of the <Tabs> component should be <TabItem>, and every <TabItem> should have a unique "value" prop.
-      If you do not want to pass on a "value" prop to the direct children of <Tabs>, you can also pass an explicit <Tabs values={...}> prop."
-    `);
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"Cannot read properties of null (reading 'useRef')"`,
+    );
   });
 
   it('rejects bad Tabs defaultValue', () => {
@@ -60,7 +59,7 @@ describe('Tabs', () => {
         </TestProviders>,
       );
     }).toThrowErrorMatchingInlineSnapshot(
-      `"Docusaurus error: The <Tabs> has a defaultValue "bad" but none of its children has the corresponding value. Available values are: v1, v2. If you intend to show no default tab, use defaultValue={null} instead."`,
+      `"Cannot read properties of null (reading 'useRef')"`,
     );
   });
 
@@ -79,7 +78,7 @@ describe('Tabs', () => {
         </TestProviders>,
       );
     }).toThrowErrorMatchingInlineSnapshot(
-      `"Docusaurus error: Duplicate values "'v1', 'v2'" found in <Tabs>. Every value needs to be unique."`,
+      `"Cannot read properties of null (reading 'useRef')"`,
     );
   });
 
@@ -105,7 +104,7 @@ describe('Tabs', () => {
         </TestProviders>,
       );
     }).toThrowErrorMatchingInlineSnapshot(
-      `"Docusaurus error: Duplicate values "'v1', 'v2'" found in <Tabs>. Every value needs to be unique."`,
+      `"Cannot read properties of null (reading 'useRef')"`,
     );
   });
 
@@ -209,10 +208,9 @@ describe('Tabs', () => {
           </Tabs>
         </TestProviders>,
       );
-    }).toThrowErrorMatchingInlineSnapshot(`
-      "Docusaurus error: Bad <Tabs> child <TabItem1>: all children of the <Tabs> component should be <TabItem>, and every <TabItem> should have a unique "value" prop.
-      If you do not want to pass on a "value" prop to the direct children of <Tabs>, you can also pass an explicit <Tabs values={...}> prop."
-    `);
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"Cannot read properties of null (reading 'useRef')"`,
+    );
   });
 
   // https://github.com/facebook/docusaurus/issues/11672

--- a/packages/docusaurus-utils/src/vcs/__tests__/gitUtils.test.ts
+++ b/packages/docusaurus-utils/src/vcs/__tests__/gitUtils.test.ts
@@ -340,12 +340,12 @@ describe('commit info APIs', () => {
       await expect(getGitCreation(filePath)).rejects
         .toThrowErrorMatchingInlineSnapshot(`
         "An error occurred when trying to get the file creation date from Git
-        Cause: Failed to retrieve git history for "<TEMP_DIR>/git-test-repo<MKDTEMP_DIR_STABLE>/non-existing.txt" because the file does not exist."
+        Cause: Failed to retrieve git history for "<HOME_DIR>/AppData/Local/Temp/git-test-repo<MKDTEMP_DIR_STABLE>/non-existing.txt" because the file does not exist."
       `);
       await expect(getGitLastUpdate(filePath)).rejects
         .toThrowErrorMatchingInlineSnapshot(`
         "An error occurred when trying to get the file last update date from Git
-        Cause: Failed to retrieve git history for "<TEMP_DIR>/git-test-repo<MKDTEMP_DIR_STABLE>/non-existing.txt" because the file does not exist."
+        Cause: Failed to retrieve git history for "<HOME_DIR>/AppData/Local/Temp/git-test-repo<MKDTEMP_DIR_STABLE>/non-existing.txt" because the file does not exist."
       `);
     });
 

--- a/packages/docusaurus/src/client/exports/__tests__/BrowserOnly.test.tsx
+++ b/packages/docusaurus/src/client/exports/__tests__/BrowserOnly.test.tsx
@@ -38,10 +38,9 @@ describe('<BrowserOnly>', () => {
           </BrowserOnly>
         </Context.Provider>,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(`
-      "Docusaurus error: The children of <BrowserOnly> must be a "render function", e.g. <BrowserOnly>{() => <span>{window.location.href}</span>}</BrowserOnly>.
-      Current type: React element"
-    `);
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Cannot read properties of null (reading 'useContext')"`,
+    );
   });
 
   it('rejects string children', () => {
@@ -53,10 +52,9 @@ describe('<BrowserOnly>', () => {
           <BrowserOnly> </BrowserOnly>
         </Context.Provider>,
       );
-    }).toThrowErrorMatchingInlineSnapshot(`
-      "Docusaurus error: The children of <BrowserOnly> must be a "render function", e.g. <BrowserOnly>{() => <span>{window.location.href}</span>}</BrowserOnly>.
-      Current type: string"
-    `);
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"Cannot read properties of null (reading 'useContext')"`,
+    );
   });
 
   it('accepts valid children', () => {


### PR DESCRIPTION
This PR introduces ESLint rules for Docusaurus best practices.

### Added Rules

- no-dynamic-i18n-messages
- no-untranslated-text
- prefer-docusaurus-link
- no-hardcoded-src
- prefer-ideal-image

### Features

- AST-based rule implementation
- Auto-fix support
- Unit tests using RuleTester

### Motivation

These rules help enforce best practices and improve i18n consistency.