### PR TITLE
Fix typo: X link markdown syntax in blog post

### DIFF
--- a/website/blog/2017/12-14-introducing-docusaurus.mdx
+++ b/website/blog/2017/12-14-introducing-docusaurus.mdx
@@ -129,7 +129,7 @@ build
 
 ![](/img/docusaurus.svg)
 
-We welcome your [contributions](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md) to Docusaurus, whether you want to use it for your own site, you want to [contribute](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md) to the Docusaurus core or just have questions. Follow us on [GitHub](https://github.com/facebook/docusaurus) and [X)](https://x.com/docusaurus).
+We welcome your [contributions](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md) to Docusaurus, whether you want to use it for your own site, you want to [contribute](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md) to the Docusaurus core or just have questions. Follow us on [GitHub](https://github.com/facebook/docusaurus) and [X](https://x.com/docusaurus).
 
 ## Acknowledgements
 


### PR DESCRIPTION
Fixes typo in blog post at website/blog/2017/12-14-introducing-docusaurus.mdx. The X link markdown had an extra parenthesis: [X)] should be [X].