### PR TITLE
fix(theme-classic): make code block Copy and Word wrap buttons visible (#10821)

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Buttons/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Buttons/styles.module.css
@@ -17,7 +17,8 @@
 .buttonGroup button {
   display: flex;
   align-items: center;
-  background: var(--prism-background-color);
+  /* Use opaque background so buttons remain visible and don't blend with code text */
+  background: var(--ifm-background-surface-color);
   color: var(--prism-color);
   border: 1px solid var(--ifm-color-emphasis-300);
   border-radius: var(--ifm-global-radius);
@@ -33,5 +34,5 @@
 }
 
 :global(.theme-code-block:hover) .buttonGroup button {
-  opacity: 0.4;
+  opacity: 1;
 }


### PR DESCRIPTION
Fixes #10821

The Copy and Toggle word wrap buttons in code blocks were nearly invisible due to semi-transparent backgrounds blending with the code text.

**Changes:**
- Use opaque background (`--ifm-background-surface-color`) so buttons remain visible
- Set opacity to 1 on code block hover (was 0.4) for clearer visibility