### PR TITLE
fix(theme): constrain navbar width to match main layout on wide displays

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/Layout/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/Layout/styles.module.css
@@ -12,3 +12,18 @@
 .navbarHidden {
   transform: translate3d(0, calc(-100% - 2px), 0);
 }
+
+/*
+Constrain navbar inner content width to match main layout on wide screens.
+The navbar background still spans full width, but navbar items are aligned
+with the rest of the page content.
+See https://github.com/facebook/docusaurus/issues/7562
+*/
+:global(.navbar) {
+  justify-content: center;
+}
+
+:global(.navbar__inner) {
+  max-width: var(--ifm-container-width);
+  width: 100%;
+}


### PR DESCRIPTION
## Summary

On wide screens (1400px+), the navbar stretches to the screen edges while the main content area and footer are constrained by `--ifm-container-width`. This creates a visual disconnect where navbar items sit far from the page content they relate to.

This PR adds two small CSS rules to constrain the navbar inner content:

- `.navbar` gets `justify-content: center` so the inner content centers within the full-width navbar
- `.navbar__inner` gets `max-width: var(--ifm-container-width)` and `width: 100%` to constrain its width while the navbar background still spans the full viewport

This matches the approach suggested in the issue and aligns with how Docusaurus v1 handled navbar width. The navbar background color/border still spans the full viewport width; only the inner content (logo, links, search) is constrained and centered.

## Motivation

- Navbar items at screen edges on ultrawide/large displays are hard to scan
- Main content, footer, and navbar should form a consistent vertical column
- Several users in #7562 independently arrived at this same CSS solution

Closes #7562

## Test plan

- [ ] Verify navbar content is centered and constrained on wide screens (>1440px)
- [ ] Verify navbar background still spans full viewport width
- [ ] Verify no layout changes on screens <= 1140px (below container max-width)
- [ ] Verify mobile navbar/sidebar is unaffected
- [ ] Verify docs pages with sidebar still render correctly

Co-authored-by: Egger <egger@horny-toad.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)