### PR TITLE
docs(website): change recommended syntax for math equations

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-math-equations.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-math-equations.mdx
@@ -35,7 +35,15 @@ Let $f\colon[a,b] \to \R$ be Riemann integrable. Let $F\colon[a,b]\to\R$ be $F(x
 
 ### Blocks {#blocks}
 
-For equation block or display mode, use line breaks and `$$`:
+For equation block or display mode, use <code>```math</code> fenced code blocks.
+
+````latex
+```math
+I = \int_0^{2\pi} \sin(x)\,dx
+```
+````
+
+You can also use line breaks and `$$`, although this syntax relies on a [Markdown syntax extension](https://github.com/micromark/micromark-extension-math) and is less portable:
 
 ```latex
 $$
@@ -45,9 +53,9 @@ $$
 
 <BrowserWindow>
 
-$$
+```math
 I = \int_0^{2\pi} \sin(x)\,dx
-$$
+```
 
 </BrowserWindow>
 

--- a/website/versioned_docs/version-2.x/guides/markdown-features/markdown-features-math-equations.mdx
+++ b/website/versioned_docs/version-2.x/guides/markdown-features/markdown-features-math-equations.mdx
@@ -31,9 +31,15 @@ Let $f\colon[a,b] \to \R$ be Riemann integrable. Let $F\colon[a,b]\to\R$ be $F(x
 
 </BrowserWindow>
 
-### Blocks {#blocks}
+For equation block or display mode, use <code>```math</code> fenced code blocks.
 
-For equation block or display mode, use line breaks and `$$`:
+````latex
+```math
+I = \int_0^{2\pi} \sin(x)\,dx
+```
+````
+
+You can also use line breaks and `$$`, although this syntax relies on a [Markdown syntax extension](https://github.com/micromark/micromark-extension-math) and is less portable:
 
 ```latex
 $$
@@ -43,9 +49,9 @@ $$
 
 <BrowserWindow>
 
-$$
+```math
 I = \int_0^{2\pi} \sin(x)\,dx
-$$
+```
 
 </BrowserWindow>
 

--- a/website/versioned_docs/version-3.0.1/guides/markdown-features/markdown-features-math-equations.mdx
+++ b/website/versioned_docs/version-3.0.1/guides/markdown-features/markdown-features-math-equations.mdx
@@ -33,7 +33,15 @@ Let $f\colon[a,b] \to \R$ be Riemann integrable. Let $F\colon[a,b]\to\R$ be $F(x
 
 ### Blocks {#blocks}
 
-For equation block or display mode, use line breaks and `$$`:
+For equation block or display mode, use <code>```math</code> fenced code blocks.
+
+````latex
+```math
+I = \int_0^{2\pi} \sin(x)\,dx
+```
+````
+
+You can also use line breaks and `$$`, although this syntax relies on a [Markdown syntax extension](https://github.com/micromark/micromark-extension-math) and is less portable:
 
 ```latex
 $$
@@ -43,9 +51,9 @@ $$
 
 <BrowserWindow>
 
-$$
+```math
 I = \int_0^{2\pi} \sin(x)\,dx
-$$
+```
 
 </BrowserWindow>
 

--- a/website/versioned_docs/version-3.1.1/guides/markdown-features/markdown-features-math-equations.mdx
+++ b/website/versioned_docs/version-3.1.1/guides/markdown-features/markdown-features-math-equations.mdx
@@ -33,7 +33,15 @@ Let $f\colon[a,b] \to \R$ be Riemann integrable. Let $F\colon[a,b]\to\R$ be $F(x
 
 ### Blocks {#blocks}
 
-For equation block or display mode, use line breaks and `$$`:
+For equation block or display mode, use <code>```math</code> fenced code blocks.
+
+````latex
+```math
+I = \int_0^{2\pi} \sin(x)\,dx
+```
+````
+
+You can also use line breaks and `$$`, although this syntax relies on a [Markdown syntax extension](https://github.com/micromark/micromark-extension-math) and is less portable:
 
 ```latex
 $$
@@ -43,9 +51,9 @@ $$
 
 <BrowserWindow>
 
-$$
+```math
 I = \int_0^{2\pi} \sin(x)\,dx
-$$
+```
 
 </BrowserWindow>
 

--- a/website/versioned_docs/version-3.2.1/guides/markdown-features/markdown-features-math-equations.mdx
+++ b/website/versioned_docs/version-3.2.1/guides/markdown-features/markdown-features-math-equations.mdx
@@ -33,7 +33,15 @@ Let $f\colon[a,b] \to \R$ be Riemann integrable. Let $F\colon[a,b]\to\R$ be $F(x
 
 ### Blocks {#blocks}
 
-For equation block or display mode, use line breaks and `$$`:
+For equation block or display mode, use <code>```math</code> fenced code blocks.
+
+````latex
+```math
+I = \int_0^{2\pi} \sin(x)\,dx
+```
+````
+
+You can also use line breaks and `$$`, although this syntax relies on a [Markdown syntax extension](https://github.com/micromark/micromark-extension-math) and is less portable:
 
 ```latex
 $$
@@ -43,9 +51,9 @@ $$
 
 <BrowserWindow>
 
-$$
+```math
 I = \int_0^{2\pi} \sin(x)\,dx
-$$
+```
 
 </BrowserWindow>
 

--- a/website/versioned_docs/version-3.3.2/guides/markdown-features/markdown-features-math-equations.mdx
+++ b/website/versioned_docs/version-3.3.2/guides/markdown-features/markdown-features-math-equations.mdx
@@ -33,7 +33,15 @@ Let $f\colon[a,b] \to \R$ be Riemann integrable. Let $F\colon[a,b]\to\R$ be $F(x
 
 ### Blocks {#blocks}
 
-For equation block or display mode, use line breaks and `$$`:
+For equation block or display mode, use <code>```math</code> fenced code blocks.
+
+````latex
+```math
+I = \int_0^{2\pi} \sin(x)\,dx
+```
+````
+
+You can also use line breaks and `$$`, although this syntax relies on a [Markdown syntax extension](https://github.com/micromark/micromark-extension-math) and is less portable:
 
 ```latex
 $$
@@ -43,9 +51,9 @@ $$
 
 <BrowserWindow>
 
-$$
+```math
 I = \int_0^{2\pi} \sin(x)\,dx
-$$
+```
 
 </BrowserWindow>
 

--- a/website/versioned_docs/version-3.4.0/guides/markdown-features/markdown-features-math-equations.mdx
+++ b/website/versioned_docs/version-3.4.0/guides/markdown-features/markdown-features-math-equations.mdx
@@ -33,7 +33,15 @@ Let $f\colon[a,b] \to \R$ be Riemann integrable. Let $F\colon[a,b]\to\R$ be $F(x
 
 ### Blocks {#blocks}
 
-For equation block or display mode, use line breaks and `$$`:
+For equation block or display mode, use <code>```math</code> fenced code blocks.
+
+````latex
+```math
+I = \int_0^{2\pi} \sin(x)\,dx
+```
+````
+
+You can also use line breaks and `$$`, although this syntax relies on a [Markdown syntax extension](https://github.com/micromark/micromark-extension-math) and is less portable:
 
 ```latex
 $$
@@ -43,9 +51,9 @@ $$
 
 <BrowserWindow>
 
-$$
+```math
 I = \int_0^{2\pi} \sin(x)\,dx
-$$
+```
 
 </BrowserWindow>
 

--- a/website/versioned_docs/version-3.5.2/guides/markdown-features/markdown-features-math-equations.mdx
+++ b/website/versioned_docs/version-3.5.2/guides/markdown-features/markdown-features-math-equations.mdx
@@ -33,7 +33,15 @@ Let $f\colon[a,b] \to \R$ be Riemann integrable. Let $F\colon[a,b]\to\R$ be $F(x
 
 ### Blocks {#blocks}
 
-For equation block or display mode, use line breaks and `$$`:
+For equation block or display mode, use <code>```math</code> fenced code blocks.
+
+````latex
+```math
+I = \int_0^{2\pi} \sin(x)\,dx
+```
+````
+
+You can also use line breaks and `$$`, although this syntax relies on a [Markdown syntax extension](https://github.com/micromark/micromark-extension-math) and is less portable:
 
 ```latex
 $$
@@ -43,9 +51,9 @@ $$
 
 <BrowserWindow>
 
-$$
+```math
 I = \int_0^{2\pi} \sin(x)\,dx
-$$
+```
 
 </BrowserWindow>
 

--- a/website/versioned_docs/version-3.6.3/guides/markdown-features/markdown-features-math-equations.mdx
+++ b/website/versioned_docs/version-3.6.3/guides/markdown-features/markdown-features-math-equations.mdx
@@ -33,7 +33,15 @@ Let $f\colon[a,b] \to \R$ be Riemann integrable. Let $F\colon[a,b]\to\R$ be $F(x
 
 ### Blocks {#blocks}
 
-For equation block or display mode, use line breaks and `$$`:
+For equation block or display mode, use <code>```math</code> fenced code blocks.
+
+````latex
+```math
+I = \int_0^{2\pi} \sin(x)\,dx
+```
+````
+
+You can also use line breaks and `$$`, although this syntax relies on a [Markdown syntax extension](https://github.com/micromark/micromark-extension-math) and is less portable:
 
 ```latex
 $$
@@ -43,9 +51,9 @@ $$
 
 <BrowserWindow>
 
-$$
+```math
 I = \int_0^{2\pi} \sin(x)\,dx
-$$
+```
 
 </BrowserWindow>
 

--- a/website/versioned_docs/version-3.7.0/guides/markdown-features/markdown-features-math-equations.mdx
+++ b/website/versioned_docs/version-3.7.0/guides/markdown-features/markdown-features-math-equations.mdx
@@ -33,7 +33,15 @@ Let $f\colon[a,b] \to \R$ be Riemann integrable. Let $F\colon[a,b]\to\R$ be $F(x
 
 ### Blocks {#blocks}
 
-For equation block or display mode, use line breaks and `$$`:
+For equation block or display mode, use <code>```math</code> fenced code blocks.
+
+````latex
+```math
+I = \int_0^{2\pi} \sin(x)\,dx
+```
+````
+
+You can also use line breaks and `$$`, although this syntax relies on a [Markdown syntax extension](https://github.com/micromark/micromark-extension-math) and is less portable:
 
 ```latex
 $$
@@ -43,9 +51,9 @@ $$
 
 <BrowserWindow>
 
-$$
+```math
 I = \int_0^{2\pi} \sin(x)\,dx
-$$
+```
 
 </BrowserWindow>
 

--- a/website/versioned_docs/version-3.8.1/guides/markdown-features/markdown-features-math-equations.mdx
+++ b/website/versioned_docs/version-3.8.1/guides/markdown-features/markdown-features-math-equations.mdx
@@ -35,7 +35,15 @@ Let $f\colon[a,b] \to \R$ be Riemann integrable. Let $F\colon[a,b]\to\R$ be $F(x
 
 ### Blocks {#blocks}
 
-For equation block or display mode, use line breaks and `$$`:
+For equation block or display mode, use <code>```math</code> fenced code blocks.
+
+````latex
+```math
+I = \int_0^{2\pi} \sin(x)\,dx
+```
+````
+
+You can also use line breaks and `$$`, although this syntax relies on a [Markdown syntax extension](https://github.com/micromark/micromark-extension-math) and is less portable:
 
 ```latex
 $$
@@ -45,9 +53,9 @@ $$
 
 <BrowserWindow>
 
-$$
+```math
 I = \int_0^{2\pi} \sin(x)\,dx
-$$
+```
 
 </BrowserWindow>
 

--- a/website/versioned_docs/version-3.9.2/guides/markdown-features/markdown-features-math-equations.mdx
+++ b/website/versioned_docs/version-3.9.2/guides/markdown-features/markdown-features-math-equations.mdx
@@ -35,7 +35,15 @@ Let $f\colon[a,b] \to \R$ be Riemann integrable. Let $F\colon[a,b]\to\R$ be $F(x
 
 ### Blocks {#blocks}
 
-For equation block or display mode, use line breaks and `$$`:
+For equation block or display mode, use <code>```math</code> fenced code blocks.
+
+````latex
+```math
+I = \int_0^{2\pi} \sin(x)\,dx
+```
+````
+
+You can also use line breaks and `$$`, although this syntax relies on a [Markdown syntax extension](https://github.com/micromark/micromark-extension-math) and is less portable:
 
 ```latex
 $$
@@ -45,9 +53,9 @@ $$
 
 <BrowserWindow>
 
-$$
+```math
 I = \int_0^{2\pi} \sin(x)\,dx
-$$
+```
 
 </BrowserWindow>
 


### PR DESCRIPTION


## Motivation

Our docs mention that we should use the `$$` syntax for equation blocks:

```latex
$$
I = \int_0^{2\pi} \sin(x)\,dx
$$
```

But in reality, this syntax is non-ideal and is extending Markdown/MDX with a syntax that is not natively supported. An MDX document with the equation above will not compile unless remark-math is installed, so that document is less portable and will usually fail to compile with external tools that expect native MDX.

(I noticed while working on https://github.com/facebook/docusaurus/pull/11779: Crowdin would reject that document due to unescaped `{` inside the `$$` equation)


In reality, using fenced code blocks also works and looks to be a much better alternative:

````latex
```math
I = \int_0^{2\pi} \sin(x)\,dx
```
````


See also https://github.com/remarkjs/remark-math

> When dealing with markdown, you optionally use remark-math, or alternatively use fenced code (```math). Then, you either use rehype-katex or rehype-mathjax to render math in HTML.

> The extra syntax extension supported by remark-math for math in markdown does not work everywhere so it makes markdown less portable.


## Test Plan

Preview

### Test links

https://deploy-preview-11784--docusaurus-2.netlify.app/


