### PR TITLE
chore(ci): canary/trusted publishing shouldn't use any caching

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,10 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: lts/*
-          cache: yarn
+          #  ⚠️ Do not use any cache on purpose
+          # It increases the chance of a compromised release being publish
+          # See https://github.com/actions/setup-node/issues/1445#issuecomment-4040130833
+          # cache: yarn
       - name: Prepare git
         run: |
           git config --global user.name "Docusaurus Canary"


### PR DESCRIPTION
## Motivation

We have recently set up Trusted Publishing for canary releases (https://github.com/facebook/docusaurus/pull/11712), and would like our stable releases to use it soon, too.

This workflow is quite sensitive since it's the only one that can publish to npm.

However, using a shared GitHub Actions cache in a sensitive, high-privileged workflow is risky, but this is what we do today by using `setup-node` with `cache: yarn`.

https://github.com/facebook/docusaurus/actions/caches

<img width="2628" height="814" alt="CleanShot 2026-03-11 at 16 51 18@2x" src="https://github.com/user-attachments/assets/99ecfa12-aede-466b-8aa1-53cb2cc21eac" />




Another workflow could be compromised and write something harmful to that cache, that later gets restored/run by the publish workflow. 

We have seen popular npm packages become compromised that way, see https://github.com/actions/setup-node/issues/1445#issuecomment-4040130833

For that reason, sensitive workflows should not use any shared cache.

## Test Plan

CI
