### PR TITLE
chore: gitignore claude/codex folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ website/bundler-cpu-profile.json
 website/profile.json.gz
 
 
+.claude
+.codex
+


### PR DESCRIPTION


## Motivation

Maybe there are cases to commit some content, but for now it's safer to gitignore them entirely
