### PR TITLE
Add Dockerfile,nginx conf file and docker-compose for deploy in prod …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,69 @@
+# =============================================================================
+# Stage 1: Builder — install deps & build the static site
+#  
+# Select locale to build yarn build --locale <locale>  or yarn build for all locales
+# =============================================================================
+FROM node:20-alpine AS builder
+RUN apk add --no-cache \
+    git \
+    python3 \
+    py3-pip \
+    make \
+    g++ \
+    cmake \
+    libc6-compat \
+    && ln -sf python3 /usr/bin/python
+
+WORKDIR /app
+COPY . .
+RUN NODE_OPTIONS="--dns-result-order=ipv4first" \
+    yarn install --frozen-lockfile
+RUN yarn build --locale en
+
+# =============================================================================
+# Stage 2: Production — lightweight Nginx image to serve the built site
+# =============================================================================
+FROM nginx:1.27-alpine AS production
+COPY --from=builder /app/website/build /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]
+
+
+# =============================================================================
+# Stage 3 (optional): Dev server — for local development with hot reload
+# =============================================================================
+
+FROM node:20-alpine AS development
+ 
+RUN apk add --no-cache \
+    git \
+    python3 \
+    make \
+    g++ \
+    cmake \
+    libc6-compat \
+    && ln -sf python3 /usr/bin/python
+ 
+WORKDIR /app
+ 
+RUN yarn config set registry https://registry.npmjs.org/ && \
+    yarn config set network-timeout 600000
+ 
+# Copy full repo first — lerna.json is required by postinstall scripts
+COPY . .
+ 
+RUN node -e " \
+    const fs = require('fs'); \
+    const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8')); \
+    if (!pkg.private) { pkg.private = true; } \
+    fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2)); \
+"
+ 
+RUN NODE_OPTIONS="--dns-result-order=ipv4first" \
+    yarn install --frozen-lockfile
+ 
+EXPOSE 3000
+ 
+CMD ["yarn", "start", "--host", "0.0.0.0"]
+ 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,51 @@
+version: "3.9"
+
+# =============================================================================
+# Docusaurus — Docker Compose
+#
+# Profiles:
+#   (default / no profile)  →  production build served by Nginx
+#   --profile dev           →  live-reload dev server on port 3000
+# =============================================================================
+
+services:
+
+  # ---------------------------------------------------------------------------
+  # Production: multi-stage build → Nginx static file server
+  # ---------------------------------------------------------------------------
+  docusaurus:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: production       # uses the "production" stage from Dockerfile
+    container_name: docusaurus_prod
+    restart: unless-stopped
+    ports:
+      - "80:80"     
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    profiles: ["", "prod"]  
+
+  # ---------------------------------------------------------------------------
+  # Development: hot-reload dev server (yarn start)
+  # ---------------------------------------------------------------------------
+  docusaurus-dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: development      # uses the "development" stage from Dockerfile
+    container_name: docusaurus_dev
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app
+      - /app/node_modules
+    environment:
+      - NODE_ENV=development
+      - CHOKIDAR_USEPOLLING=true  
+    profiles: ["dev"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,30 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    root   /usr/share/nginx/html;
+    index  index.html;
+
+    # Enable gzip compression
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript
+               text/xml application/xml application/xml+rss text/javascript;
+    gzip_min_length 1000;
+
+    # Cache static assets aggressively (Docusaurus hashes filenames)
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+    # All other routes — try the file, fall back to index.html (SPA routing)
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-Content-Type-Options "nosniff";
+    add_header X-XSS-Protection "1; mode=block";
+}


### PR DESCRIPTION
## Pre-flight checklist

- [X] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

This PR adds first-class Docker support for the Docusaurus monorepo, so that contributors and users can run the project in a consistent, containerized environment without having to install Node.js/Yarn directly on their host machine.

It provides:
- **Production-like image** suitable for deployment (using `Dockerfile` + `nginx.conf`).
- **Local development setup with hot reload**, so that changes to the docs/site are reflected immediately inside the running container.

This should make it easier to:
- Try Docusaurus locally with minimal setup.
- Onboard new contributors.
- Run the site in containerized CI/CD or production environments.


## Test Plan

**Production image**

1. Build the image:

   ```bash
   docker build -t docusaurus:prod .
   ```

2. Run the container:

   ```bash
   docker run --rm -p 8080:80 docusaurus:prod
   ```

3. Open `http://localhost:8080` and verify:
   - The site builds successfully.
   - Static assets are served correctly via Nginx.
   - Navigation, docs, and blog pages load as expected.

**Local development with hot reload**

1. Start the dev stack (hot reload enabled, via `docker-compose.yaml`):

   ```bash
   docker compose up --build
   ```

2. Open the dev URL from `docker-compose` (for example `http://localhost:3000`) and verify:
   - The dev server starts successfully inside the container.
   - Editing source files (e.g. docs or pages) on the host triggers **hot reload** in the browser without restarting the container.

3. Stop the stack:

   ```bash
   docker compose down
   ```

No unit tests are added because this change only introduces Docker/Nginx configuration and does not modify runtime JS/TS logic.

## Test links

This change only affects Docker/Nginx configuration and local/production environments, and does not change any existing UI or documentation pages. There are no specific UI pages to link beyond the main site served from the container at `http://localhost:8080` (production image) and the dev URL (e.g. `http://localhost:3000`) for hot reload.


## Related issues/PRs

I did not find an existing official Docker setup in this repository or a tracking issue specifically for adding Docker support. If there is a preferred issue to link, I am happy to update this section accordingly.
