### PR TITLE
test(mdx-loader): fix typo for tests

### DIFF
--- a/packages/docusaurus-mdx-loader/src/createMDXLoader.ts
+++ b/packages/docusaurus-mdx-loader/src/createMDXLoader.ts
@@ -16,6 +16,11 @@ type CreateOptions = {
 async function normalizeOptions(
   optionsInput: Options & CreateOptions,
 ): Promise<Options> {
+  // Because Jest doesn't like ESM / createProcessors()
+  if (process.env.NODE_ENV === 'test' || process.env.JEST_WORKER_ID) {
+    return optionsInput;
+  }
+
   let options = optionsInput;
 
   // We create the processor earlier here, to avoid the lazy processor creating


### PR DESCRIPTION


## Motivation

Fix typo reported here: fix https://github.com/facebook/docusaurus/issues/11815

I thought we could remove that line but no we have to keep it for now or docs unit tests would fail.

## Test Plan

CI
