### PR TITLE
docs: add docusaurus-theme-search-altor to community search plugins

### DIFF
--- a/website/community/2-resources.mdx
+++ b/website/community/2-resources.mdx
@@ -38,6 +38,7 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [docusaurus-lunr-search](https://github.com/lelouch77/docusaurus-lunr-search) - Offline Search for Docusaurus
 - [docusaurus-search-local](https://github.com/cmfcmf/docusaurus-search-local) - Offline/local search for Docusaurus
 - [@easyops-cn/docusaurus-search-local](https://github.com/easyops-cn/docusaurus-search-local) - Offline/local search for Docusaurus (language of zh supported)
+- [docusaurus-theme-search-altor](https://github.com/Altor-lab/altor-vec/tree/main/docusaurus-theme-search-altor) - Hybrid semantic + keyword search powered by [altor-vec](https://github.com/Altor-lab/altor-vec) WASM. Sub-millisecond client-side vector search.
 - [docusaurus-theme-search-typesense](https://github.com/typesense/docusaurus-theme-search-typesense) - Docusaurus plugin for [Typesense DocSearch](https://typesense.org/docs/latest/guide/docsearch.html)
 - [@markprompt/docusaurus-theme-search](https://github.com/motifland/markprompt-js/tree/main/packages/docusaurus-theme-search) - Docusaurus plugin to add generative AI / LLM-powered docs search, powered by [Markprompt](https://markprompt.com).
 - [meilisearch-docsearch](https://github.com/tauri-apps/meilisearch-docsearch) - Docusaurus plugin for [Meilisearch](https://www.meilisearch.com)


### PR DESCRIPTION
## Summary

Adds [docusaurus-theme-search-altor](https://www.npmjs.com/package/docusaurus-theme-search-altor) to the community search plugins list.

**What it does**: Hybrid BM25 keyword + semantic vector search for Docusaurus sites. Combines a lightweight embedding API with client-side HNSW search via [altor-vec](https://github.com/Altor-lab/altor-vec) WASM (54KB).

- **npm**: [`docusaurus-theme-search-altor`](https://www.npmjs.com/package/docusaurus-theme-search-altor)
- **Source**: https://github.com/Altor-lab/altor-vec/tree/main/docusaurus-theme-search-altor
- **License**: MIT
- **Docusaurus**: v3 compatible