### PR TITLE
docs(pwa): add guide for environment-specific manifests (#10458)

### DIFF
--- a/website/docs/api/plugins/plugin-pwa.mdx
+++ b/website/docs/api/plugins/plugin-pwa.mdx
@@ -291,6 +291,22 @@ import CodeBlock from '@theme/CodeBlock';
   {JSON.stringify(require('@site/static/manifest.json'),null,2)}
 </CodeBlock>
 ```
+## Environment-specific manifests {/* #environment-specific-manifests */}
+
+By default, the PWA plugin expects a single `manifest.json` file located in the `static/` folder. However, you may need different manifest configurations (e.g., app icons, name, or theme color) for different environments like staging and production. You can achieve this by maintaining multiple manifest files and copying the appropriate one before building.
+
+Add the following scripts to your `package.json`:
+
+```json title="package.json"
+{
+  "scripts": {
+    "build:staging": "cp static/manifest.staging.json static/manifest.json && docusaurus build",
+    "build:prod": "cp static/manifest.prod.json static/manifest.json && docusaurus build"
+  }
+}
+```
+
+Alternatively, you can write a short Node.js script to replace string placeholders inside a single `manifest.json` template based on `process.env` variables before running the `docusaurus build` command.
 
 ## Customizing reload popup {/* #customizing-reload-popup */}
 


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Closes #10458. 

The current PWA plugin documentation does not explain how to handle multiple `manifest.json` files for different environments (e.g., staging vs. production). This PR adds a brief guide demonstrating how to manage environment-specific manifests using a pre-build file copy script in `package.json`, which is the safest and most standard approach.

## Test Plan

N/A - This is a pure documentation update. Verified MDX formatting and layout locally.

## Related issues/PRs

Resolves #10458