### PR TITLE
fix(theme-classic): blog post footer not rendered when only last_update is set

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Footer/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Footer/index.tsx
@@ -29,7 +29,10 @@ export default function BlogPostItemFooter(): ReactNode {
 
   const tagsExists = tags.length > 0;
 
-  const renderFooter = tagsExists || truncatedPost || editUrl;
+  const renderFooter =
+    tagsExists ||
+    truncatedPost ||
+    !!(editUrl || lastUpdatedAt || lastUpdatedBy);
 
   if (!renderFooter) {
     return null;

--- a/website/_dogfooding/dogfooding.config.ts
+++ b/website/_dogfooding/dogfooding.config.ts
@@ -115,6 +115,8 @@ export const dogfoodingPluginInstances: PluginConfig[] = [
               locale: 'en',
               options: {wordsPerMinute: 5},
             }),
+      showLastUpdateAuthor: true,
+      showLastUpdateTime: true,
       onInlineTags: 'warn',
       onInlineAuthors: 'ignore',
       onUntruncatedBlogPosts: 'ignore',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

`BlogPostItemFooter` returns `null` on the blog post page when the post has no tags, no `editUrl`, but has `last_update` configured in front matter. The `lastUpdatedAt` and `lastUpdatedBy` values are absent from the guard condition, so the function returns `null` before they are ever evaluated.

The root cause is the outer guard in `BlogPostItem/Footer/index.tsx`:

```ts
const renderFooter = tagsExists || truncatedPost || editUrl;
```

`truncatedPost` is always `false` on the post page (`!isBlogPostPage && hasTruncateMarker`), so this reduces to `tagsExists || editUrl`. `lastUpdatedAt` and `lastUpdatedBy` are absent from the condition, so the function returns `null` before the inner `canDisplayEditMetaRow` check at line 40 is ever reached.

`DocItem/Footer/index.tsx` does not have this problem. Its guard is:

```ts
const canDisplayFooter = canDisplayTagsRow || canDisplayEditMetaRow;
// where:
const canDisplayEditMetaRow = !!(editUrl || lastUpdatedAt || lastUpdatedBy);
```

This is a feature parity gap between the docs and blog footers.

**Fix:** align `renderFooter` with the existing `canDisplayEditMetaRow` condition that was already correct:

```ts
const renderFooter =
  tagsExists || truncatedPost || !!(editUrl || lastUpdatedAt || lastUpdatedBy);
```

## Test Plan

Add a blog post with only `last_update` set (no tags, no `custom_edit_url`):

```md
---
title: Test last_update visibility
last_update:
  date: 2026-01-01
  author: Akshat Sinha
---
Content.
```

After running `yarn workspace website start`, to navigate to the post page.

Before this fix: the footer section is absent entirely.  
After this fix: "Last updated on Jan 1, 2026 by Akshat Sinha" renders correctly.

### Test links

Deploy preview: https://deploy-preview-11841--docusaurus-2.netlify.app/

## Related issues/PRs

No related issues found.
