### PR TITLE
fix(docs): exclude unlisted category links from DocBreadcrumbs structured data

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/client/__tests__/structuredDataUtils.test.tsx
+++ b/packages/docusaurus-plugin-content-docs/src/client/__tests__/structuredDataUtils.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment jsdom
+ */
+
+// Jest doesn't allow pragma below other comments. https://github.com/facebook/jest/issues/12573
+// eslint-disable-next-line header/header
+import React from 'react';
+import {renderHook} from '@testing-library/react';
+import {Context} from '@docusaurus/core/src/client/docusaurusContext';
+import {useBreadcrumbsStructuredData} from '../structuredDataUtils';
+import type {PropSidebarBreadcrumbsItem} from '@docusaurus/plugin-content-docs';
+import type {DocusaurusContext} from '@docusaurus/types';
+
+const siteUrl = 'https://example.com';
+
+function renderStructuredData(breadcrumbs: PropSidebarBreadcrumbsItem[]) {
+  return renderHook(() => useBreadcrumbsStructuredData({breadcrumbs}), {
+    wrapper: ({children}) => (
+      <Context.Provider
+        value={
+          {
+            siteConfig: {url: siteUrl},
+          } as unknown as DocusaurusContext
+        }>
+        {children}
+      </Context.Provider>
+    ),
+  }).result.current;
+}
+
+// Narrow itemListElement to a flat array for easier assertions
+type ListItem = {
+  '@type': 'ListItem';
+  position: number;
+  name: string;
+  item: string;
+};
+
+function getItems(result: ReturnType<typeof renderStructuredData>): ListItem[] {
+  return (result.itemListElement ?? []) as unknown as ListItem[];
+}
+
+describe('useBreadcrumbsStructuredData', () => {
+  it('returns a valid BreadcrumbList schema object', () => {
+    // @context and @type are required for valid JSON-LD. A refactor that drops
+    // either field would invalidate all structured data without any test failing.
+    const result = renderStructuredData([
+      {type: 'link', href: '/docs/intro', label: 'Introduction'},
+    ]);
+    expect(result['@context']).toBe('https://schema.org');
+    expect(result['@type']).toBe('BreadcrumbList');
+  });
+
+  it('includes breadcrumbs with href in itemListElement', () => {
+    const breadcrumbs: PropSidebarBreadcrumbsItem[] = [
+      {type: 'link', href: '/docs/intro', label: 'Introduction'},
+      {
+        type: 'category',
+        href: '/docs/guides',
+        label: 'Guides',
+        items: [],
+        collapsed: false,
+        collapsible: true,
+      },
+    ];
+    const items = getItems(renderStructuredData(breadcrumbs));
+    expect(items).toEqual([
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Introduction',
+        item: `${siteUrl}/docs/intro`,
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'Guides',
+        item: `${siteUrl}/docs/guides`,
+      },
+    ]);
+  });
+
+  it('excludes breadcrumbs without href from itemListElement', () => {
+    const breadcrumbs: PropSidebarBreadcrumbsItem[] = [
+      {type: 'link', href: '/docs/intro', label: 'Introduction'},
+      {
+        type: 'category',
+        href: undefined,
+        label: 'No-link Category',
+        items: [],
+        collapsed: false,
+        collapsible: true,
+      },
+    ];
+    const items = getItems(renderStructuredData(breadcrumbs));
+    expect(items).toHaveLength(1);
+    expect(items[0]!.name).toBe('Introduction');
+  });
+
+  it('excludes unlisted category links from itemListElement', () => {
+    const breadcrumbs: PropSidebarBreadcrumbsItem[] = [
+      {type: 'link', href: '/docs/intro', label: 'Introduction'},
+      {
+        type: 'category',
+        href: '/docs/unlisted-category',
+        label: 'Unlisted Category',
+        linkUnlisted: true,
+        items: [],
+        collapsed: false,
+        collapsible: true,
+      },
+      {type: 'link', href: '/docs/intro/page', label: 'Page'},
+    ];
+    const items = getItems(renderStructuredData(breadcrumbs));
+    // The unlisted category has an href but must not appear in structured data
+    expect(items).toHaveLength(2);
+    expect(items.map((item) => item.name)).toEqual(['Introduction', 'Page']);
+  });
+
+  it('re-numbers positions contiguously after a filtered item', () => {
+    // BreadcrumbList requires sequential position integers starting at 1.
+    // Filtering an item from the middle must not leave a gap (e.g. 1, 3).
+    // Also verifies that the item URLs of surviving entries are correct.
+    const breadcrumbs: PropSidebarBreadcrumbsItem[] = [
+      {type: 'link', href: '/docs/intro', label: 'Introduction'},
+      {
+        type: 'category',
+        href: '/docs/unlisted-category',
+        label: 'Unlisted Category',
+        linkUnlisted: true,
+        items: [],
+        collapsed: false,
+        collapsible: true,
+      },
+      {type: 'link', href: '/docs/intro/page', label: 'Page'},
+    ];
+    const items = getItems(renderStructuredData(breadcrumbs));
+    expect(items).toHaveLength(2);
+    expect(items[0]!.position).toBe(1);
+    expect(items[1]!.position).toBe(2); // not 3
+    expect(items[0]!.item).toBe(`${siteUrl}/docs/intro`);
+    expect(items[1]!.item).toBe(`${siteUrl}/docs/intro/page`);
+  });
+
+  it('includes listed category links in itemListElement', () => {
+    const breadcrumbs: PropSidebarBreadcrumbsItem[] = [
+      {
+        type: 'category',
+        href: '/docs/listed-category',
+        label: 'Listed Category',
+        linkUnlisted: false,
+        items: [],
+        collapsed: false,
+        collapsible: true,
+      },
+    ];
+    const items = getItems(renderStructuredData(breadcrumbs));
+    expect(items).toHaveLength(1);
+    expect(items[0]!.item).toBe(`${siteUrl}/docs/listed-category`);
+  });
+
+  it('does not exclude link-type breadcrumbs that have unlisted:true', () => {
+    // PropSidebarItemLink has `unlisted?: boolean` — a different field from
+    // PropSidebarItemCategory's `linkUnlisted`. An unlisted doc that appears
+    // in a breadcrumb trail is the current page; its URL is valid and should
+    // be emitted. The filter must not conflate the two fields.
+    const breadcrumbs: PropSidebarBreadcrumbsItem[] = [
+      {type: 'link', href: '/docs/intro', label: 'Introduction'},
+      {
+        type: 'link',
+        href: '/docs/unlisted-doc',
+        label: 'Unlisted Doc',
+        unlisted: true,
+      },
+    ];
+    const items = getItems(renderStructuredData(breadcrumbs));
+    expect(items).toHaveLength(2);
+    expect(items[1]!.name).toBe('Unlisted Doc');
+    expect(items[1]!.item).toBe(`${siteUrl}/docs/unlisted-doc`);
+  });
+});

--- a/packages/docusaurus-plugin-content-docs/src/client/structuredDataUtils.ts
+++ b/packages/docusaurus-plugin-content-docs/src/client/structuredDataUtils.ts
@@ -21,7 +21,14 @@ export function useBreadcrumbsStructuredData({
     itemListElement: breadcrumbs
       // We filter breadcrumb items without links, they are not allowed
       // See also https://github.com/facebook/docusaurus/issues/9319#issuecomment-2643560845
-      .filter((breadcrumb) => breadcrumb.href)
+      // We also filter unlisted category links: the href is present on the
+      // item (so the sidebar highlight still works) but must not be emitted
+      // into structured data where it would be crawled by search engines.
+      .filter(
+        (breadcrumb) =>
+          breadcrumb.href &&
+          !(breadcrumb.type === 'category' && breadcrumb.linkUnlisted),
+      )
       .map((breadcrumb, index) => ({
         '@type': 'ListItem',
         position: index + 1,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

When a docs category has an unlisted generated-index page (`linkUnlisted: true`), its `href` is kept on the sidebar item intentionally so the active sidebar highlight still works. That `href` was leaking into the `DocBreadcrumbs` JSON-LD structured data and being emitted to Googlebot even though the link is invisible to human visitors.

The suppression in `DocBreadcrumbs/index.tsx` only applies to the rendered `<a>` element:

```tsx
// DocBreadcrumbs/index.tsx
const href =
  item.type === 'category' && item.linkUnlisted
    ? undefined
    : item.href;
```

This does not mutate the `breadcrumbs` array. The raw array is passed unchanged to `<DocBreadcrumbsStructuredData breadcrumbs={breadcrumbs} />`, so `structuredDataUtils.ts` receives the item with `href` set and the existing `.filter((b) => b.href)` passes it through. The result is a `BreadcrumbList` `ListItem` pointing at an unlisted URL in the page's `<script type="application/ld+json">`.

**Fix:** extend the filter in `structuredDataUtils.ts` to also exclude category items where `linkUnlisted` is `true`:

```ts
.filter(
  (breadcrumb) =>
    breadcrumb.href &&
    !(breadcrumb.type === 'category' && breadcrumb.linkUnlisted),
)
```

## Test Plan

Unit tests added in `packages/docusaurus-plugin-content-docs/src/client/__tests__/structuredDataUtils.test.tsx` (AI assistance was taken here):

- Verifies breadcrumbs with `href` are included in `itemListElement`.
- Verifies breadcrumbs without `href` are excluded.
- Verifies a category with `linkUnlisted: true` and a non-null `href` is excluded from `itemListElement`.
- Verifies a category with `linkUnlisted: false` and a non-null `href` is included normally.

Run: `yarn test packages/docusaurus-plugin-content-docs/src/client/__tests__/structuredDataUtils.test.tsx`

### Test links

Deploy preview: https://deploy-preview-11842--docusaurus-2.netlify.app/

## Related issues/PRs

No related issues found.
