### PR TITLE
fix(core): fix `url.resolve()` Node.js deprecation warning

### DIFF
--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -62,7 +62,7 @@
     "prompts": "^2.4.2",
     "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
     "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-    "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+    "react-loadable-ssr-addon-v5-slorber": "^1.0.3",
     "react-router": "^5.3.4",
     "react-router-config": "^5.1.1",
     "react-router-dom": "^5.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15508,10 +15508,10 @@ react-live@^4.1.6:
     sucrase "^3.31.0"
     use-editable "^2.3.3"
 
-react-loadable-ssr-addon-v5-slorber@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.1.tgz#2cdc91e8a744ffdf9e3556caabeb6e4278689883"
-  integrity sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==
+react-loadable-ssr-addon-v5-slorber@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.3.tgz#bb3791bf481222c63a5bc6b96ee23f68cb5614b9"
+  integrity sha512-GXfh9VLwB5ERaCsU6RULh7tkemeX15aNh6wuMEBtfdyMa7fFG8TXrhXlx1SoEK2Ty/l6XIkzzYIQmyaWW3JgdQ==
   dependencies:
     "@babel/runtime" "^7.10.3"
 


### PR DESCRIPTION

## Motivation

Running `docusaurus build` emits a Node.js deprecation warning

> ● Server ██████████████████████████████████████████████████ (100%) emitting after emit (node:19890) [DEP0169] DeprecationWarning: url.parse() behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for url.parse() vulnerabilities.


This is due to `url.resolve()` used in one of our forked/unmaintained dependencies. I just upgraded it to fix the warning: https://github.com/slorber/react-loadable-ssr-addon/pull/1

## Test Plan

CI
