### PR TITLE
chore(website): disable `mdx1Compat.comments` on our site

### DIFF
--- a/website/_dogfooding/_docs tests/tests/links/test-markdown-links.mdx
+++ b/website/_dogfooding/_docs tests/tests/links/test-markdown-links.mdx
@@ -65,8 +65,6 @@ MDX/HTML comments with invalid file references should not be resolved nor report
 
 {/* [doesNotExist.mdx](doesNotExist.mdx) */}
 
-<!-- [doesNotExist.mdx](doesNotExist.mdx) -->
-
 ## Reference-style links
 
 The following should also work:

--- a/website/_dogfooding/_pages tests/markdown-tests-mdx.mdx
+++ b/website/_dogfooding/_pages tests/markdown-tests-mdx.mdx
@@ -50,23 +50,18 @@ import TabItem from '@theme/TabItem';
 
 ## Comments
 
-Html comment: <!-- comment -->
-
-Html comment multi-line:
-
-<!--
-comment
--->
-
-<!-- prettier-ignore -->
 MDX comment: {/* comment */}
 
-MDX comment multi-line:
+MDX comment in JSX:
 
-<!-- prettier-ignore -->
-{/*
-comment
-*/}
+<>
+  {/* comment */}
+  <span>
+    {/* comment */}
+    TEST
+    {/* comment */}
+  </span>
+</>
 
 ## Import code block from source code file
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -235,7 +235,7 @@ export default async function createConfigAsync() {
       },
       mdx1Compat: {
         headingIds: false,
-        // comments: false,
+        comments: false,
       },
       remarkRehypeOptions: {
         footnoteLabel: getLocalizedConfigValue('remarkRehypeOptions_footnotes'),


### PR DESCRIPTION
## Motivation

We want to be sure it's fine to use Docusaurus MDX without relying on MDX v1 HTML comments.

## Test Plan

CI + dogfood

### Test links

https://deploy-preview-11846--docusaurus-2.netlify.app/
