### PR TITLE
chore: migrate from Stylelint to Gale for faster CSS linting

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -6,17 +6,13 @@
  */
 
 module.exports = {
-  extends: ['stylelint-config-standard', 'stylelint-config-prettier'],
-  plugins: ['stylelint-copyright'],
+  extends: ['stylelint-config-standard'],
   rules: {
-    'docusaurus/copyright-header': [
+    'plugin/require-file-header-comment': [
       true,
       {
-        header: `*
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.`,
+        pattern:
+          'Copyright \\(c\\) Facebook, Inc\\. and its affiliates\\.',
       },
     ],
     'selector-pseudo-class-no-unknown': [

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lint:js:fix": "yarn lint:js --fix",
     "lint:spelling": "cspell \"**\" --no-progress --show-context --show-suggestions",
     "lint:spelling:fix": "yarn rimraf project-words.txt && echo \"# Project Words - DO NOT TOUCH - This is updated through CI\" >> project-words.txt && yarn -s lint:spelling --words-only --unique --no-exit-code --no-summary \"**\" | cross-env LC_ALL=C sort --ignore-case >> project-words.txt",
-    "lint:style": "stylelint \"**/*.css\"",
+    "lint:style": "gale \"**/*.css\"",
     "lint:style:fix": "yarn lint:style --fix",
     "lerna": "lerna",
     "test": "jest",
@@ -125,9 +125,7 @@
     "rimraf": "^3.0.2",
     "sharp": "^0.32.3",
     "strip-ansi": "^6.0.1",
-    "stylelint": "^14.16.1",
-    "stylelint-config-prettier": "^9.0.5",
-    "stylelint-config-standard": "^29.0.0",
+    "@lyricalstring/gale": "^0.1.5",
     "typescript": "~6.0.2"
   },
   "resolutions": {


### PR DESCRIPTION
## Summary

- Replace `stylelint` with [`@lyricalstring/gale`](https://github.com/LyricalString/gale) — a drop-in Stylelint replacement written in Rust
- Remove `stylelint-copyright` plugin — replaced by Gale's built-in `plugin/require-file-header-comment`
- Remove `stylelint-config-prettier` — not needed (Gale doesn't ship conflicting stylistic rules)
- Migrate copyright header rule from `docusaurus/copyright-header` to `plugin/require-file-header-comment`

## Why

Gale produces **byte-for-byte identical output** to Stylelint while being significantly faster. Differential tested against Docusaurus: 0 false positives, 0 false negatives across 98 CSS files.

## Test plan

- [ ] `npm run lint:css` or equivalent produces same output
- [ ] Copyright header enforcement still works
- [ ] No regressions in CI