### PR TITLE
fix(theme-classic): constrain navbar on large displays

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/Layout/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/Layout/styles.module.css
@@ -12,3 +12,13 @@
 .navbarHidden {
   transform: translate3d(0, calc(-100% - 2px), 0);
 }
+
+@media (min-width: 1440px) {
+  :global(.navbar) {
+    justify-content: center;
+  }
+
+  :global(.navbar__inner) {
+    max-width: var(--ifm-container-width-xl);
+  }
+}


### PR DESCRIPTION
Improves navbar width consistency on very large screens by centering and constraining navbar inner width behind a large-screen media query.