### PR TITLE
fix(a11y): remove superfluous skip-link region landmark

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/skipToContentUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/skipToContentUtils.tsx
@@ -94,10 +94,7 @@ export function SkipToContentLink(props: SkipToContentLinkProps): ReactNode {
   const linkLabel = props.children ?? DefaultSkipToContentLabel;
   const {containerRef, onClick} = useSkipToContent();
   return (
-    <div
-      ref={containerRef}
-      role="region"
-      aria-label={DefaultSkipToContentLabel}>
+    <div ref={containerRef}>
       {/* eslint-disable-next-line @docusaurus/no-html-links */}
       <a
         {...props}


### PR DESCRIPTION
Removes the dedicated region landmark wrapper around the skip-to-content link.