### PR TITLE
docs(plugin-api): remove unimplemented dev server hooks

### DIFF
--- a/website/docs/api/plugin-methods/README.mdx
+++ b/website/docs/api/plugin-methods/README.mdx
@@ -75,16 +75,6 @@ export default async function myPlugin(context, opts) {
       // docusaurus <start> finish
     },
 
-    // TODO
-    afterDevServer(app, server) {
-      // https://webpack.js.org/configuration/dev-server/#devserverbefore
-    },
-
-    // TODO
-    beforeDevServer(app, server) {
-      // https://webpack.js.org/configuration/dev-server/#devserverafter
-    },
-
     configureWebpack(config, isServer, utils, content) {
       // Modify internal webpack config. If returned value is an Object, it
       // will be merged into the final config using webpack-merge;


### PR DESCRIPTION
Removes beforeDevServer and afterDevServer from plugin methods docs example because these hooks are not implemented APIs.