### PR TITLE
fix(theme-classic): align inline code to baseline

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeInline/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeInline/index.tsx
@@ -6,11 +6,13 @@
  */
 
 import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
 import type {Props} from '@theme/CodeInline';
+import styles from './styles.module.css';
 
 // Simple component used to render inline code blocks
 // its purpose is to be swizzled and customized
 // MDX 1 used to have a inlineCode comp, see https://mdxjs.com/migrating/v2/
 export default function CodeInline(props: Props): ReactNode {
-  return <code {...props} />;
+  return <code {...props} className={clsx(styles.codeInline, props.className)} />;
 }

--- a/packages/docusaurus-theme-classic/src/theme/CodeInline/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeInline/styles.module.css
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.codeInline {
+  vertical-align: baseline;
+}


### PR DESCRIPTION
Aligns inline code text with surrounding text baseline to improve typography alignment.