### PR TITLE
fix(theme-classic): make code block action buttons fully visible

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Buttons/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Buttons/styles.module.css
@@ -33,5 +33,5 @@
 }
 
 :global(.theme-code-block:hover) .buttonGroup button {
-  opacity: 0.4;
+  opacity: 1;
 }


### PR DESCRIPTION
It contains the same #10821 fix (code block action buttons fully visible).