### PR TITLE
fix(utils): handle XML-like tags in inline code during metadata extraction

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
@@ -184,6 +184,30 @@ describe('createExcerpt', () => {
         `),
     ).toBe('Lorem ipsum dolor sit amet, consectetur adipiscing elit.');
   });
+
+  it('creates excerpt with XML tag inside inline code', () => {
+    expect(
+      createExcerpt(dedent`
+          # Markdown Regular Title
+
+          This paragraph includes a link to the \`<metadata>\` documentation.
+        `),
+    ).toBe(
+      'This paragraph includes a link to the &lt;metadata&gt; documentation.',
+    );
+  });
+
+  it('creates excerpt with XML tag inside inline code with hyperlink', () => {
+    expect(
+      createExcerpt(dedent`
+          # Markdown Regular Title
+
+          This paragraph includes a link to the [\`<metadata>\`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/metadata) documentation.
+        `),
+    ).toBe(
+      'This paragraph includes a link to the &lt;metadata&gt; documentation.',
+    );
+  });
 });
 
 describe('parseMarkdownContentTitle', () => {

--- a/packages/docusaurus-utils/src/markdownUtils.ts
+++ b/packages/docusaurus-utils/src/markdownUtils.ts
@@ -128,6 +128,13 @@ export function createExcerpt(fileString: string): string | undefined {
     }
 
     const cleanedLine = fileLine
+      // Remove inline code (must come before HTML tag removal so that
+      // XML-like tags inside backticks are not stripped as HTML).
+      // Angle brackets in code content are escaped to HTML entities so they
+      // survive the HTML-tag removal step that follows.
+      .replace(/`(?<text>.+?)`/g, (_match, text: string) =>
+        text.replace(/</g, '&lt;').replace(/>/g, '&gt;'),
+      )
       // Remove HTML tags.
       .replace(/<[^>]*>/g, '')
       // Remove Title headers
@@ -144,8 +151,6 @@ export function createExcerpt(fileString: string): string | undefined {
       .replace(/\[\^.+?\](?:: .*$)?/g, '')
       // Remove inline links.
       .replace(/\[(?<alt>.*?)\][[(].*?[\])]/g, '$1')
-      // Remove inline code.
-      .replace(/`(?<text>.+?)`/g, '$1')
       // Remove blockquotes.
       .replace(/^\s{0,3}>\s?/g, '')
       // Remove admonition definition.


### PR DESCRIPTION
## Summary

Fixes #11818

Page metadata/description generation breaks when the first paragraph contains inline code with XML-like tags (e.g. `` [`<metadata>`](url) ``). The `createExcerpt` function in `@docusaurus/utils` strips HTML tags **before** processing inline code backticks, so `<metadata>` inside backticks is removed as if it were an HTML element — producing broken output like `Removes the `` element from the document.`

## Fix

Moved the inline code processing step **before** the HTML tag removal step in `createExcerpt()`. When extracting text from inline code, angle brackets are now escaped to HTML entities (`&lt;`/`&gt;`) so they survive the subsequent HTML-stripping regex without being mistakenly removed as tags.

**Changed files:**
- `packages/docusaurus-utils/src/markdownUtils.ts` — reordered and updated the inline code regex replacement
- `packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts` — added 2 test cases from the issue (inline code with XML tag, and inline code with XML tag inside a hyperlink)

## Test plan

- [x] All 72 existing tests in `markdownUtils.test.ts` continue to pass
- [x] New test: `` `<metadata>` `` in inline code produces `&lt;metadata&gt;` in excerpt
- [x] New test: `` [`<metadata>`](url) `` in inline code with hyperlink produces `&lt;metadata&gt;` in excerpt
- [x] Regular inline code without angle brackets is unaffected
- Reproduction repo: https://github.com/SethFalco/metadata-sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)