### PR TITLE
fix(utils): escape HTML entities in inline code before removing HTML tags

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
@@ -184,6 +184,26 @@ describe('createExcerpt', () => {
         `),
     ).toBe('Lorem ipsum dolor sit amet, consectetur adipiscing elit.');
   });
+
+  it('creates excerpt with XML tag inside inline code', () => {
+    expect(
+      createExcerpt(dedent`
+          # Markdown Regular Title
+
+          This paragraph includes a link to the \`<metadata>\` documentation.
+        `),
+    ).toBe('This paragraph includes a link to the &lt;metadata&gt; documentation.');
+  });
+
+  it('creates excerpt with XML tag inside inline code with hyperlink', () => {
+    expect(
+      createExcerpt(dedent`
+          # Markdown Regular Title
+
+          This paragraph includes a link to the [\`<metadata>\`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/metadata) documentation.
+        `),
+    ).toBe('This paragraph includes a link to the &lt;metadata&gt; documentation.');
+  });
 });
 
 describe('parseMarkdownContentTitle', () => {

--- a/packages/docusaurus-utils/src/markdownUtils.ts
+++ b/packages/docusaurus-utils/src/markdownUtils.ts
@@ -128,6 +128,10 @@ export function createExcerpt(fileString: string): string | undefined {
     }
 
     const cleanedLine = fileLine
+      // Escape HTML entities inside inline code before removing HTML tags.
+      .replace(/`(?<text>.+?)`/g, (_, text) =>
+        `\`${text.replace(/</g, '&lt;').replace(/>/g, '&gt;')}\``,
+      )
       // Remove HTML tags.
       .replace(/<[^>]*>/g, '')
       // Remove Title headers
@@ -144,7 +148,7 @@ export function createExcerpt(fileString: string): string | undefined {
       .replace(/\[\^.+?\](?:: .*$)?/g, '')
       // Remove inline links.
       .replace(/\[(?<alt>.*?)\][[(].*?[\])]/g, '$1')
-      // Remove inline code.
+      // Remove inline code (now just removes backticks, content already escaped).
       .replace(/`(?<text>.+?)`/g, '$1')
       // Remove blockquotes.
       .replace(/^\s{0,3}>\s?/g, '')


### PR DESCRIPTION
## Description

Fixes #11818

This PR fixes an issue where XML tags inside inline code (e.g., `` `<metadata>` ``) were being incorrectly removed when creating page excerpts, resulting in empty backticks in the metadata description tags.

## Problem

When Docusaurus generates page metadata (description, og:description), it uses the `createExcerpt` function to extract the first meaningful sentence. However, when that sentence contains inline code with XML-like tags, the tags were being removed, leaving only empty backticks.

**Example:**
```md
Removes the [`<metadata>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/metadata) element from the document.
```

**Before this fix:**
```html
<meta name="description" content="Removes the `` element from the document.">
```

**After this fix:**
```html
<meta name="description" content="Removes the &lt;metadata&gt; element from the document.">
```

## Solution

The issue was in the order of regex replacements in `createExcerpt`:
1. HTML tags were removed first: `.replace(/<[^>]*>/g, '')` 
2. Then inline code was processed: `.replace(/`(?<text>.+?)`/g, '$1')`

This meant `<metadata>` inside backticks was treated as an HTML tag and removed before the inline code processing could preserve it.

The fix:
1. **First**, escape HTML entities (`<` → `&lt;`, `>` → `&gt;`) inside inline code
2. **Then**, remove HTML tags (which now won't match the escaped entities)
3. **Finally**, remove the backticks (content is already escaped)

## Changes Made

- Modified `packages/docusaurus-utils/src/markdownUtils.ts`:
  - Added a new regex replacement at the beginning of the cleaning chain to escape HTML entities inside inline code
  - Updated comment for the inline code removal step to clarify it now just removes backticks

- Added test cases in `packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts`:
  - Test for XML tag inside inline code
  - Test for XML tag inside inline code with hyperlink

## Testing

- [x] Code follows project style guidelines
- [x] No TypeScript errors or linting issues
- [x] Added test cases that verify the fix
- [x] Tested manually with the provided test cases from the issue
- [x] Existing functionality preserved (regression tests pass)

## Test Results

All new tests pass:
```javascript
it('creates excerpt with XML tag inside inline code', () => {
  expect(
    createExcerpt(dedent`
        # Markdown Regular Title

        This paragraph includes a link to the \`<metadata>\` documentation.
      `),
  ).toBe('This paragraph includes a link to the &lt;metadata&gt; documentation.');
});

it('creates excerpt with XML tag inside inline code with hyperlink', () => {
  expect(
    createExcerpt(dedent`
        # Markdown Regular Title

        This paragraph includes a link to the [\`<metadata>\`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/metadata) documentation.
      `),
  ).toBe('This paragraph includes a link to the &lt;metadata&gt; documentation.');
});
```

## Related Issue

Closes #11818
