### PR TITLE
fix dependabot error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,21 +11,6 @@ updates:
       - 'pr: dependencies'
 
   ########################
-  # NPM SECURITY UPDATES
-  - package-ecosystem: 'npm'
-    directory: '/'
-    exclude-paths:
-      - 'examples/**'
-    schedule:
-      interval: 'daily'
-    # Disable version updates for npm dependencies
-    # This is what restricts Dependabot to security updates only
-    # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
-    open-pull-requests-limit: 0
-    labels:
-      - 'pr: dependencies'
-
-  ########################
   # NPM VERSION UPDATES
   - package-ecosystem: 'npm'
     directory: '/'


### PR DESCRIPTION


## Motivation

Fix CI error after merging https://github.com/facebook/docusaurus/pull/11874

> Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'npm' has overlapping directories.

https://github.com/facebook/docusaurus/runs/69731004417

I think we don't need the 2 entries anyway because security updates do not respect the cooldown period and PR limit, so have one npm config will do exactly what I intended to do initially.
