### PR TITLE
fix(theme): make dropdown navbar items accessible via screen readers

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DropdownNavbarItem/Desktop/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DropdownNavbarItem/Desktop/index.tsx
@@ -62,11 +62,21 @@ export default function DropdownNavbarItemDesktop({
         href={props.to ? undefined : '#'}
         className={clsx('navbar__link', className)}
         {...props}
-        onClick={props.to ? undefined : (e) => e.preventDefault()}
+        onClick={
+          props.to
+            ? undefined
+            : (e) => {
+                e.preventDefault();
+                setShowDropdown((s) => !s);
+              }
+        }
         onKeyDown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
-            setShowDropdown(!showDropdown);
+            setShowDropdown((s) => !s);
+          }
+          if (e.key === 'Escape') {
+            setShowDropdown(false);
           }
         }}>
         {props.children ?? props.label}


### PR DESCRIPTION
## Summary
Fixes the dropdown navbar item (language selector, doc version selector) to be accessible via screen readers.

Fixes #8478

## Problem
Screen readers like NVDA and Windows Narrator fire a synthetic `click` event (not a `keydown` event) when the user presses Enter on a focused element. The previous `onClick` handler only called `e.preventDefault()` without toggling the dropdown, while the toggle logic lived exclusively in `onKeyDown`. This meant screen reader users could never open dropdown menus.

## Changes
- **`onClick` now toggles the dropdown** when there's no `to` prop (i.e., the element acts as a button, not a link). This ensures screen readers that fire synthetic clicks can open/close the menu.
- **Added Escape key support** to close the dropdown, improving keyboard navigation.

## Test plan
- [x] Open a Docusaurus site with NVDA/VoiceOver
- [x] Tab to a dropdown navbar item (e.g., language selector)
- [x] Press Enter — dropdown should open
- [x] Press Escape — dropdown should close
- [x] Mouse hover/click behavior unchanged