### PR TITLE
break: require TypeScript >= 6.0

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -165,21 +165,13 @@ jobs:
         working-directory: ../test-website
         run: yarn typecheck
 
-      - name: TypeCheck website - min version - v5.1
+      - name: TypeCheck website - min version - v6.0
         # TODO: there're some lingering issues with PnP + tsc. Enable tsc in PnP later.
         if: matrix.variant == '-st' && matrix.nodeLinker != 'pnp'
         working-directory: ../test-website
         run: |
-          yarn add typescript@5.1.6 --exact
-
-          # Downgrade TS ignoreDeprecations option
-          node -e "const fs = require('fs'); const f = 'tsconfig.json'; fs.writeFileSync(f, fs.readFileSync(f,'utf8').replace('\"ignoreDeprecations\": \"6.0\"', '\"ignoreDeprecations\": \"5.0\"'))"
-
+          yarn add typescript@6.0 --exact
           yarn typecheck
-
-          # Restore TS ignoreDeprecations option
-          node -e "const fs = require('fs'); const f = 'tsconfig.json'; fs.writeFileSync(f, fs.readFileSync(f,'utf8').replace('\"ignoreDeprecations\": \"5.0\"', '\"ignoreDeprecations\": \"6.0\"'))"
-
       - name: TypeCheck website - max version - Latest
         # TODO: there're some lingering issues with PnP + tsc. Enable tsc in PnP later.
         if: matrix.variant == '-st' && matrix.nodeLinker != 'pnp'

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -62,22 +62,14 @@ jobs:
         # see https://github.com/facebook/docusaurus/pull/10486
         run: yarn workspace website typecheck
 
+      - name: TypeCheck website - min version - v6.0
+        run: |
+          yarn add typescript@6.0 --exact -D -W --ignore-scripts
+          yarn workspace website typecheck
+
       - name: TypeCheck website - max version - Latest
         # For latest TS there are often lib check errors, so we disable it
         # Details: https://github.com/facebook/docusaurus/pull/10486
         run: |
           yarn add typescript@latest --exact -D -W --ignore-scripts
           yarn workspace website typecheck --project tsconfig.skipLibCheck.json
-
-      - name: TypeCheck website - min version - v5.1
-        run: |
-          yarn add typescript@5.1.6 --exact -D -W --ignore-scripts
-
-          # Downgrade TS ignoreDeprecations option
-          node -e 'const fs = require("fs"); const f = "website/tsconfig.json"; fs.writeFileSync(f, fs.readFileSync(f, "utf8").replace(/"ignoreDeprecations"\s*:\s*"6\.0"/, "\"ignoreDeprecations\": \"5.0\""));'
-
-          # DocSearch@4/ai@5 doesn't support TS 5.1 (with skipLibCheck=false)
-          jq '.resolutions."@docsearch/react" = "^3.9.0"' package.json > package.json.tmp && mv -Force package.json.tmp package.json
-          yarn add @docsearch/react@^3.9.0 --exact -D -W --ignore-scripts
-
-          yarn workspace website typecheck

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,21 +59,10 @@ jobs:
         # see https://github.com/facebook/docusaurus/pull/10486
         run: yarn workspace website typecheck
 
-      - name: TypeCheck website - min version - v5.1
+      - name: TypeCheck website - min version - v6.0
         run: |
-          yarn add typescript@5.1.6 --exact -D -W --ignore-scripts
-
-          # Downgrade TS ignoreDeprecations option
-          node -e "const fs = require('fs'); const f = 'website/tsconfig.json'; fs.writeFileSync(f, fs.readFileSync(f,'utf8').replace('\"ignoreDeprecations\": \"6.0\"', '\"ignoreDeprecations\": \"5.0\"'))"
-
-          # DocSearch@4/ai@5 doesn't support TS 5.1 (with skipLibCheck=false)
-          jq '.resolutions."@docsearch/react" = "^3.9.0"' package.json > package.json.tmp && mv -f package.json.tmp package.json
-          yarn add @docsearch/react@^3.9.0 --exact -D -W --ignore-scripts
-
+          yarn add typescript@6.0 --exact -D -W --ignore-scripts
           yarn workspace website typecheck
-
-          # Restore TS ignoreDeprecations option
-          node -e "const fs = require('fs'); const f = 'website/tsconfig.json'; fs.writeFileSync(f, fs.readFileSync(f,'utf8').replace('\"ignoreDeprecations\": \"5.0\"', '\"ignoreDeprecations\": \"6.0\"'))"
 
       - name: TypeCheck website - max version - Latest
         # For latest TS there are often lib check errors, so we disable it

--- a/packages/create-docusaurus/templates/classic-typescript/tsconfig.json
+++ b/packages/create-docusaurus/templates/classic-typescript/tsconfig.json
@@ -1,7 +1,7 @@
 // This file is not used by "docusaurus start/build" commands.
-// It is here to improve your IDE experience (type-checking, autocompletion...),
-// and can also run the package.json "typecheck" script manually.
+// It helps improve your IDE experience (type-checking, autocompletion...),
+// You can run the package.json "typecheck" script manually.
+// Our base config is often good enough, but feel free to customize it!
 {
-  "extends": "@docusaurus/tsconfig",
-  "compilerOptions": {}
+  "extends": "@docusaurus/tsconfig"
 }

--- a/packages/create-docusaurus/templates/classic-typescript/tsconfig.json
+++ b/packages/create-docusaurus/templates/classic-typescript/tsconfig.json
@@ -3,10 +3,5 @@
 // and can also run the package.json "typecheck" script manually.
 {
   "extends": "@docusaurus/tsconfig",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
-    "strict": true
-  },
-  "exclude": [".docusaurus", "build"]
+  "compilerOptions": {}
 }

--- a/packages/create-docusaurus/templates/classic-typescript/tsconfig.json
+++ b/packages/create-docusaurus/templates/classic-typescript/tsconfig.json
@@ -1,6 +1,6 @@
 // This file is not used by "docusaurus start/build" commands.
 // It helps improve your IDE experience (type-checking, autocompletion...),
-// You can run the package.json "typecheck" script manually.
+// You can also run the package.json "typecheck" script manually.
 // Our base config is often good enough, but feel free to customize it!
 {
   "extends": "@docusaurus/tsconfig"

--- a/packages/docusaurus-tsconfig/package.json
+++ b/packages/docusaurus-tsconfig/package.json
@@ -16,5 +16,8 @@
     "url": "https://github.com/facebook/docusaurus.git",
     "directory": "packages/docusaurus-tsconfig"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "peerDependencies": {
+    "typescript": ">=6.0"
+  }
 }

--- a/packages/docusaurus-tsconfig/tsconfig.json
+++ b/packages/docusaurus-tsconfig/tsconfig.json
@@ -11,10 +11,10 @@
     "moduleResolution": "bundler",
     "module": "esnext",
     "noEmit": true,
-    "baseUrl": ".",
     "paths": {
-      "@site/*": ["./*"]
+      "@site/*": ["${configDir}/*"]
     },
+    "exclude": ["${configDir}/.docusaurus", "${configDir}/build"],
     "skipLibCheck": true
   }
 }

--- a/packages/docusaurus-tsconfig/tsconfig.json
+++ b/packages/docusaurus-tsconfig/tsconfig.json
@@ -14,7 +14,7 @@
     "paths": {
       "@site/*": ["${configDir}/*"]
     },
-    "exclude": ["${configDir}/.docusaurus", "${configDir}/build"],
     "skipLibCheck": true
-  }
+  },
+  "exclude": ["${configDir}/.docusaurus", "${configDir}/build"]
 }


### PR DESCRIPTION


## Motivation

Follow up on https://github.com/facebook/docusaurus/pull/11843

Fix https://github.com/facebook/docusaurus/issues/11893

Scheduled for Docusaurus v4 (breaking change), see  https://github.com/facebook/docusaurus/issues/11719

We want to require TypeScript v6.0+, which helps simplify our base TS config + the local site config + our complex CI setup.

Since v7 is a Go rewrite that is supposed to be compatible with v6.0, Docusaurus v4 should also be ready for TypeScript 7.0.


TypeScript v6.0 release notes: https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/

A site TS config could now be as simple as this:


```json
{
  "extends": "@docusaurus/tsconfig",
}
```

`@site` alias and excludes are now fully encapsulated iunto the base config, thanks to TS 5.5+ `{configDir}` placeholder ([ref](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#the-configdir-template-variable-for-configuration-files))


Technically, it should remain possible to keep using TS < 6.0 with Docusaurus v4. However, you won't be able to use our base config: you'd need to copy its content

## Test Plan

CI

### Test links

https://deploy-preview-11915--docusaurus-2.netlify.app/


