### PR TITLE
docs: add package-manager tabs for create-docusaurus

### DIFF
--- a/website/docs/api/misc/create-docusaurus.mdx
+++ b/website/docs/api/misc/create-docusaurus.mdx
@@ -9,7 +9,7 @@ A scaffolding utility to help you instantly set up a functional Docusaurus app.
 
 ## Usage {/* #usage */}
 
-```bash
+```bash npm2yarn
 npx create-docusaurus@latest [name] [template] [rootDir]
 ```
 

--- a/website/docs/i18n/i18n-crowdin.mdx
+++ b/website/docs/i18n/i18n-crowdin.mdx
@@ -52,7 +52,7 @@ The end result can be seen at [docusaurus-crowdin-example.netlify.app](https://d
 
 Initialize a new Docusaurus site:
 
-```bash
+```bash npm2yarn
 npx create-docusaurus@latest website classic
 ```
 

--- a/website/docs/i18n/i18n-git.mdx
+++ b/website/docs/i18n/i18n-git.mdx
@@ -39,7 +39,7 @@ This is a walk-through of using Git to translate a newly initialized English Doc
 
 Initialize a new Docusaurus site:
 
-```bash
+```bash npm2yarn
 npx create-docusaurus@latest website classic
 ```
 

--- a/website/docs/i18n/i18n-tutorial.mdx
+++ b/website/docs/i18n/i18n-tutorial.mdx
@@ -15,7 +15,11 @@ This tutorial will walk you through the basics of the **Docusaurus i18n system**
 
 We will add **French** translations to a **newly initialized English Docusaurus website**.
 
-Initialize a new site with `npx create-docusaurus@latest website classic` (like [this one](https://github.com/facebook/docusaurus/tree/main/examples/classic)).
+Initialize a new site (like [this one](https://github.com/facebook/docusaurus/tree/main/examples/classic)):
+
+```bash npm2yarn
+npx create-docusaurus@latest website classic
+```
 
 ## Configure your site {/* #configure-your-site */}
 

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -28,7 +28,7 @@ Use **[docusaurus.new](https://docusaurus.new)** to test Docusaurus immediately 
 
 The easiest way to install Docusaurus is to use the [`create-docusaurus`](./api/misc/create-docusaurus.mdx) command line tool that helps you scaffold a skeleton Docusaurus website. You can run this command anywhere in a new empty repository or within an existing repository, it will create a new directory containing the scaffolded files.
 
-```bash
+```bash npm2yarn
 npx create-docusaurus@latest my-website classic
 ```
 
@@ -36,7 +36,7 @@ We recommend the `classic` template so that you can get started quickly, and it 
 
 You can also use the template's TypeScript variant by passing the `--typescript` flag. See [TypeScript support](./typescript-support.mdx) for more information.
 
-```bash
+```bash npm2yarn
 npx create-docusaurus@latest my-website classic --typescript
 ```
 

--- a/website/docs/introduction.mdx
+++ b/website/docs/introduction.mdx
@@ -25,7 +25,7 @@ Create a new Docusaurus site and follow the **very short** embedded tutorial.
 
 Install [Node.js](https://nodejs.org/en/download/) and create a new Docusaurus site:
 
-```bash
+```bash npm2yarn
 npx create-docusaurus@latest my-website classic
 ```
 

--- a/website/docs/typescript-support.mdx
+++ b/website/docs/typescript-support.mdx
@@ -12,7 +12,7 @@ The minimum required version is **TypeScript 5.1**.
 
 Docusaurus supports writing and using TypeScript theme components. If the init template provides a TypeScript variant, you can directly [initialize a site](./installation.mdx#scaffold-project-website) with full TypeScript support by using the `--typescript` flag.
 
-```bash
+```bash npm2yarn
 npx create-docusaurus@latest my-website classic --typescript
 ```
 


### PR DESCRIPTION
## Summary
- add package-manager tabs to the remaining create-docusaurus initialization code blocks in the docs
- convert the i18n tutorial inline init command into an npm2yarn code block so it renders npm/yarn/pnpm/bun alternatives
- keep the changes limited to current docs pages under website/docs

Fixes #10355.

## Test plan
- git diff --check
- npx --yes prettier@2.8.8 --check website/docs/installation.mdx website/docs/typescript-support.mdx website/docs/introduction.mdx website/docs/i18n/i18n-git.mdx website/docs/i18n/i18n-crowdin.mdx website/docs/i18n/i18n-tutorial.mdx website/docs/api/misc/create-docusaurus.mdx