### PR TITLE
fix(theme-classic): improve screen reader landmark navigation and keyboard handling

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogSidebar/Desktop/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogSidebar/Desktop/index.tsx
@@ -33,7 +33,13 @@ const ListComponent: BlogSidebarContentProps['ListComponent'] = ({items}) => {
 function BlogSidebarDesktop({sidebar}: Props) {
   const items = useVisibleBlogSidebarItems(sidebar.items);
   return (
-    <aside className="col col--3">
+    <aside
+      className="col col--3"
+      aria-label={translate({
+        id: 'theme.blog.sidebar.containerAriaLabel',
+        message: 'Blog sidebar',
+        description: 'The ARIA label for the blog sidebar container',
+      })}>
       <nav
         className={clsx(styles.sidebar, 'thin-scrollbar')}
         aria-label={translate({

--- a/packages/docusaurus-theme-classic/src/theme/DocRoot/Layout/Sidebar/ExpandButton/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocRoot/Layout/Sidebar/ExpandButton/index.tsx
@@ -32,7 +32,12 @@ export default function DocRootLayoutSidebarExpandButton({
       })}
       tabIndex={0}
       role="button"
-      onKeyDown={toggleSidebar}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          toggleSidebar();
+        }
+      }}
       onClick={toggleSidebar}>
       <IconArrow className={styles.expandButtonIcon} />
     </div>

--- a/packages/docusaurus-theme-classic/src/theme/DocRoot/Layout/Sidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocRoot/Layout/Sidebar/index.tsx
@@ -7,6 +7,7 @@
 
 import React, {type ReactNode, useState, useCallback} from 'react';
 import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
 import {prefersReducedMotion, ThemeClassNames} from '@docusaurus/theme-common';
 import {useDocsSidebar} from '@docusaurus/plugin-content-docs/client';
 import {useLocation} from '@docusaurus/router';
@@ -50,6 +51,11 @@ export default function DocRootLayoutSidebar({
 
   return (
     <aside
+      aria-label={translate({
+        id: 'theme.docs.sidebar.containerAriaLabel',
+        message: 'Docs sidebar',
+        description: 'The ARIA label for the docs sidebar container',
+      })}
       className={clsx(
         ThemeClassNames.docs.docSidebarContainer,
         styles.docSidebarContainer,

--- a/packages/docusaurus-theme-classic/src/theme/Footer/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/Layout/index.tsx
@@ -7,6 +7,7 @@
 
 import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import type {Props} from '@theme/Footer/Layout';
 
@@ -18,6 +19,11 @@ export default function FooterLayout({
 }: Props): ReactNode {
   return (
     <footer
+      aria-label={translate({
+        id: 'theme.footer.ariaLabel',
+        message: 'Site footer',
+        description: 'The ARIA label for the footer landmark',
+      })}
       className={clsx(ThemeClassNames.layout.footer.container, 'footer', {
         'footer--dark': style === 'dark',
       })}>

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/MobileSidebar/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/MobileSidebar/Layout/index.tsx
@@ -7,6 +7,7 @@
 
 import React, {version, type ReactNode} from 'react';
 import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
 import {useNavbarSecondaryMenu} from '@docusaurus/theme-common/internal';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import type {Props} from '@theme/Navbar/MobileSidebar/Layout';
@@ -49,7 +50,12 @@ export default function NavbarMobileSidebarLayout({
 }: Props): ReactNode {
   const {shown: secondaryMenuShown} = useNavbarSecondaryMenu();
   return (
-    <div
+    <nav
+      aria-label={translate({
+        id: 'theme.navbar.mobileSidebarAriaLabel',
+        message: 'Navigation bar',
+        description: 'The ARIA label for the mobile sidebar navigation',
+      })}
       className={clsx(
         ThemeClassNames.layout.navbar.mobileSidebar.container,
         'navbar-sidebar',
@@ -66,6 +72,6 @@ export default function NavbarMobileSidebarLayout({
           {secondaryMenu}
         </NavbarMobileSidebarPanel>
       </div>
-    </div>
+    </nav>
   );
 }

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DropdownNavbarItem/Desktop/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DropdownNavbarItem/Desktop/index.tsx
@@ -51,7 +51,17 @@ export default function DropdownNavbarItemDesktop({
       className={clsx('navbar__item', 'dropdown', 'dropdown--hoverable', {
         'dropdown--right': position === 'right',
         'dropdown--show': showDropdown,
-      })}>
+      })}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape' && showDropdown) {
+          e.stopPropagation();
+          setShowDropdown(false);
+          // Return focus to the dropdown trigger
+          const trigger =
+            dropdownRef.current?.querySelector<HTMLElement>('.navbar__link');
+          trigger?.focus();
+        }
+      }}>
       <NavbarNavLink
         aria-haspopup="true"
         aria-expanded={showDropdown}

--- a/packages/docusaurus-theme-classic/src/theme/TOC/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TOC/index.tsx
@@ -7,6 +7,7 @@
 
 import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
 import TOCItems from '@theme/TOCItems';
 import type {Props} from '@theme/TOC';
 
@@ -19,12 +20,18 @@ const LINK_ACTIVE_CLASS_NAME = 'table-of-contents__link--active';
 
 export default function TOC({className, ...props}: Props): ReactNode {
   return (
-    <div className={clsx(styles.tableOfContents, 'thin-scrollbar', className)}>
+    <nav
+      aria-label={translate({
+        id: 'theme.TOC.navAriaLabel',
+        message: 'On this page',
+        description: 'The ARIA label for the table of contents navigation',
+      })}
+      className={clsx(styles.tableOfContents, 'thin-scrollbar', className)}>
       <TOCItems
         {...props}
         linkClassName={LINK_CLASS_NAME}
         linkActiveClassName={LINK_ACTIVE_CLASS_NAME}
       />
-    </div>
+    </nav>
   );
 }

--- a/packages/docusaurus-theme-classic/src/theme/TOCCollapsible/CollapseButton/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TOCCollapsible/CollapseButton/index.tsx
@@ -19,6 +19,7 @@ export default function TOCCollapsibleCollapseButton({
   return (
     <button
       type="button"
+      aria-expanded={!collapsed}
       {...props}
       className={clsx(
         'clean-btn',


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

> **AI disclosure:** This PR was developed with AI assistance (Claude). Every change was manually verified against the live site and a local dev build. All claims below describe observable, reproducible behavior.

## Motivation

Docusaurus sites score well on automated accessibility audits (Lighthouse reports 97–100), but automated tools don't measure **navigation cost** — how many steps a screen reader user needs to reach a given control. Several friction points, identified using [Tactual](https://github.com/tactual-dev/tactual) (a screen-reader navigation cost analyzer), are invisible to standard audits:

1. **Dropdown menus lose focus on Escape.** Opening a navbar dropdown (version selector, language selector) and pressing Escape closes the dropdown but focus is lost — the user ends up at an unpredictable position on the page.

2. **Tabbing past the sidebar expand button toggles the sidebar.** The collapsed sidebar's expand button (`<div role="button">`) fires its action on any keypress, including Tab. A keyboard user trying to Tab past it accidentally toggles the sidebar open/closed. The [WAI-ARIA button pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/) specifies only Enter and Space should activate `role="button"` elements.

3. **Several landmarks are invisible or unlabeled.** The table of contents, footer, sidebar container, blog sidebar, and mobile navigation panel are either missing landmark roles entirely or lack `aria-label` attributes, making them unreachable or indistinguishable via landmark navigation.

4. **TOC collapse button doesn't expose expanded/collapsed state.** The mobile "On this page" toggle button has no `aria-expanded` attribute, so screen reader users can't tell whether the table of contents is open or closed before pressing it.

## Changes

### Keyboard interaction fixes

| File | Change |
|---|---|
| `NavbarItem/DropdownNavbarItem/Desktop/index.tsx` | Add Escape key handler that closes the dropdown and returns focus to the trigger element |
| `DocRoot/Layout/Sidebar/ExpandButton/index.tsx` | Filter `onKeyDown` to only activate on Enter/Space (was firing on every keypress including Tab) |

### Landmark labeling (zero visual change)

| File | Change |
|---|---|
| `TOC/index.tsx` | Change wrapper from `<div>` to `<nav aria-label="On this page">` — makes TOC reachable via landmark navigation |
| `Footer/Layout/index.tsx` | Add `aria-label="Site footer"` to `<footer>` — distinguishes it in landmark navigation |
| `DocRoot/Layout/Sidebar/index.tsx` | Add `aria-label="Docs sidebar"` to `<aside>` wrapper |
| `BlogSidebar/Desktop/index.tsx` | Add `aria-label="Blog sidebar"` to `<aside>` wrapper |
| `Navbar/MobileSidebar/Layout/index.tsx` | Change container from `<div>` to `<nav aria-label="Navigation bar">` — makes mobile nav a landmark |
| `TOCCollapsible/CollapseButton/index.tsx` | Add `aria-expanded` attribute to collapse button |

All labels use the existing `translate()` pattern for i18n support. Both `<div>` → `<nav>` changes have no visual impact (`<nav>` is `display: block` by default, same as `<div>`).

## Test Plan

### Automated
- `yarn test --testPathPatterns="theme-classic"` — all 64 tests pass (4 suites)
- `npx prettier --check` on all 8 files — passes

### Manual verification (local dev server)

**Dropdown Escape (version/language selectors):**
1. Navigate to `/docs`
2. Tab to the version dropdown trigger
3. Press Enter to open → dropdown opens
4. Tab into a menu item
5. Press Escape → dropdown closes, focus returns to trigger ✓

**ExpandButton keyboard filter:**
1. Collapse the docs sidebar via the `«` chevron
2. Tab to the "Expand sidebar" button
3. Press Tab → focus moves to next element without toggling sidebar ✓ (previously: sidebar toggled as side effect)
4. Shift+Tab back, press Enter → sidebar expands ✓

**Landmark labels (all pages):**
- `<footer aria-label="Site footer">` present on site footer ✓
- `<aside aria-label="Docs sidebar">` present on docs pages ✓
- `<nav aria-label="On this page">` wraps table of contents ✓
- Mobile sidebar renders as `<nav aria-label="Navigation bar">` ✓
- TOC collapse button has `aria-expanded="false"/"true"` ✓

**NVDA screen reader testing (Windows):**
- All landmark labels announced correctly when navigating by landmark (NVDA+D)
- Dropdown Escape returns focus to trigger with correct announcement
- TOC collapse button announces expanded/collapsed state
- Skip-to-content equivalent behavior confirmed via heading navigation

**Visual regression:** Desktop and mobile screenshots compared — zero visual difference from `<div>` → `<nav>` changes.

### Test links

Deploy preview: https://deploy-preview-11937--docusaurus-2.netlify.app/

- `/docs` — test dropdown Escape, sidebar expand button, TOC nav, footer label, sidebar label
- `/blog` — test blog sidebar label
- `/docs/configuration` — test on a deeper docs page

## Related issues/PRs

- #9463 — addressed `aria-expanded` for mobile navigation dropdowns; those specific issues appear to have been resolved in a subsequent refactor that introduced a proper `<button>` with `aria-expanded` in the mobile `CollapseButton` component. This PR addresses remaining gaps in the desktop dropdown keyboard handling, landmark structure, and TOC collapse state.
- #8110 — related route announcer work

🤖 Generated with [Claude Code](https://claude.com/claude-code)


