### PR TITLE
fix(theme): remove superfluous ARIA region from SkipToContent link

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/skipToContentUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/skipToContentUtils.tsx
@@ -48,18 +48,18 @@ function programmaticFocus(el: HTMLElement) {
 /** This hook wires the logic for a skip-to-content link. */
 function useSkipToContent(): {
   /**
-   * The ref to the container. On page transition, the container will be focused
-   * so that keyboard navigators can instantly interact with the link and jump
-   * to content.
+   * The ref to the skip link anchor. On page transition, the anchor will be
+   * focused so that keyboard navigators can instantly interact with the link
+   * and jump to content.
    */
-  containerRef: React.RefObject<HTMLDivElement | null>;
+  anchorRef: React.RefObject<HTMLAnchorElement | null>;
   /**
    * Callback fired when the skip to content link has been clicked.
    * It will programmatically focus the main content.
    */
   onClick: (e: React.MouseEvent<HTMLAnchorElement>) => void;
 } {
-  const containerRef = useRef<HTMLDivElement>(null);
+  const anchorRef = useRef<HTMLAnchorElement>(null);
   const {action} = useHistory();
 
   const onClick = useCallback((e: React.MouseEvent<HTMLAnchorElement>) => {
@@ -73,12 +73,12 @@ function useSkipToContent(): {
   // "Reset" focus when navigating.
   // See https://github.com/facebook/docusaurus/pull/8204#issuecomment-1276547558
   useLocationChange(({location}) => {
-    if (containerRef.current && !location.hash && action === 'PUSH') {
-      programmaticFocus(containerRef.current);
+    if (anchorRef.current && !location.hash && action === 'PUSH') {
+      programmaticFocus(anchorRef.current);
     }
   });
 
-  return {containerRef, onClick};
+  return {anchorRef, onClick};
 }
 
 const DefaultSkipToContentLabel = translate({
@@ -92,21 +92,17 @@ type SkipToContentLinkProps = Omit<ComponentProps<'a'>, 'href' | 'onClick'>;
 
 export function SkipToContentLink(props: SkipToContentLinkProps): ReactNode {
   const linkLabel = props.children ?? DefaultSkipToContentLabel;
-  const {containerRef, onClick} = useSkipToContent();
+  const {anchorRef, onClick} = useSkipToContent();
+  // eslint-disable-next-line @docusaurus/no-html-links
   return (
-    <div
-      ref={containerRef}
-      role="region"
-      aria-label={DefaultSkipToContentLabel}>
-      {/* eslint-disable-next-line @docusaurus/no-html-links */}
-      <a
-        {...props}
-        // Note this is a fallback href in case JS is disabled
-        // It has limitations, see https://github.com/facebook/docusaurus/issues/6411#issuecomment-1284136069
-        href={`#${SkipToContentFallbackId}`}
-        onClick={onClick}>
-        {linkLabel}
-      </a>
-    </div>
+    <a
+      {...props}
+      ref={anchorRef}
+      // Note this is a fallback href in case JS is disabled
+      // It has limitations, see https://github.com/facebook/docusaurus/issues/6411#issuecomment-1284136069
+      href={`#${SkipToContentFallbackId}`}
+      onClick={onClick}>
+      {linkLabel}
+    </a>
   );
 }


### PR DESCRIPTION
Removes the `<div role="region">` wrapper around the skip-to-content link. Screen readers were announcing the element twice: once for the region landmark and once for the link itself, e.g. "skip to main content region, link, skip to main content".

The ref used for page-transition focus management is moved directly onto the `<a>` element, eliminating the need for the wrapper div entirely.

Fixes #8418

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

Fixes #8418
The `SkipToContentLink` component wrapped the skip link in a `<div role="region" aria-label="Skip to main content">`. This caused screen readers to announce the element twice. Once for the landmark region and once for the link itself, e.g.: 
> "skip to main content region, link, skip to main content"

A skip link does not need to be a landmark region. It should be a bare `<a>` element.

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Changes
- Removed the `<div role="region" aria-label={...}>` wrapper from `SkipToContentLink`
- Moved the focus-management `ref` directly onto the `<a>` element (renamed `containerRef`  => `anchorRef`, type updated to `HTMLAnchorElement`)


## Test Plan
- Tested with a screen reader (NVDA + Firefox): the skip link is now announced as "Skip to main content, link" with no duplicate region announcement.
- Clicking the skip link still moves focus to `<main>`.
- Page navigation still refocuses the skip link correctly.
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
