### PR TITLE
feat(theme-search-algolia): support agentStudio flag in askAi config

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/__tests__/validateThemeConfig.test.ts
+++ b/packages/docusaurus-theme-search-algolia/src/__tests__/validateThemeConfig.test.ts
@@ -525,6 +525,102 @@ describe('validateThemeConfig', () => {
           `""algolia.askAi.suggestedQuestions" must be a boolean"`,
         );
       });
+
+      it('accepts agentStudio flag', () => {
+        const algolia = {
+          appId: 'BH4D9OD16A',
+          indexName: 'index',
+          apiKey: 'apiKey',
+          askAi: {
+            assistantId: 'my-assistant-id',
+            agentStudio: true,
+          },
+        } satisfies AlgoliaInput;
+
+        expect(testValidateThemeConfig(algolia)).toEqual({
+          algolia: {
+            ...DEFAULT_CONFIG,
+            ...algolia,
+            askAi: {
+              assistantId: 'my-assistant-id',
+              agentStudio: true,
+              indexName: 'index',
+              apiKey: 'apiKey',
+              appId: 'BH4D9OD16A',
+            },
+          },
+        });
+      });
+
+      it('does not inject facetFilters into agentStudio askAi', () => {
+        const algolia = {
+          appId: 'BH4D9OD16A',
+          indexName: 'index',
+          apiKey: 'apiKey',
+          searchParameters: {
+            facetFilters: ['version:1.0'],
+          },
+          askAi: {
+            assistantId: 'my-assistant-id',
+            agentStudio: true,
+          },
+        } satisfies AlgoliaInput;
+
+        const result = testValidateThemeConfig(algolia);
+        expect(result.algolia.askAi).toEqual({
+          assistantId: 'my-assistant-id',
+          agentStudio: true,
+          indexName: 'index',
+          apiKey: 'apiKey',
+          appId: 'BH4D9OD16A',
+        });
+      });
+
+      it('accepts index-keyed searchParameters when agentStudio is true', () => {
+        const algolia = {
+          appId: 'BH4D9OD16A',
+          indexName: 'index',
+          apiKey: 'apiKey',
+          askAi: {
+            assistantId: 'my-assistant-id',
+            agentStudio: true,
+            searchParameters: {
+              index: {distinct: false},
+            },
+          },
+        } satisfies AlgoliaInput;
+
+        expect(testValidateThemeConfig(algolia)).toEqual({
+          algolia: {
+            ...DEFAULT_CONFIG,
+            ...algolia,
+            askAi: {
+              ...algolia.askAi,
+              indexName: 'index',
+              apiKey: 'apiKey',
+              appId: 'BH4D9OD16A',
+            },
+          },
+        });
+      });
+
+      it('rejects non-boolean agentStudio', () => {
+        const algolia: AlgoliaInput = {
+          appId: 'BH4D9OD16A',
+          indexName: 'index',
+          apiKey: 'apiKey',
+          askAi: {
+            assistantId: 'my-assistant-id',
+            // @ts-expect-error: expected type error
+            agentStudio: 'yes',
+          },
+        };
+        expect(() =>
+          testValidateThemeConfig(algolia),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `""algolia.askAi.agentStudio" must be a boolean"`,
+        );
+      });
     });
   });
 });

--- a/packages/docusaurus-theme-search-algolia/src/client/useAlgoliaAskAi.ts
+++ b/packages/docusaurus-theme-search-algolia/src/client/useAlgoliaAskAi.ts
@@ -58,13 +58,20 @@ function applyAskAiContextualSearch(
   if (!contextualSearchFilters) {
     return askAi;
   }
-  const askAiFacetFilters = askAi.searchParameters?.facetFilters;
+  // When agentStudio is enabled, searchParameters is keyed by index name and
+  // doesn't accept facetFilters at the top level — skip contextual merging.
+  if (askAi.agentStudio) {
+    return askAi;
+  }
+  const searchParameters = askAi.searchParameters as
+    | {facetFilters?: FacetFilters}
+    | undefined;
   return {
     ...askAi,
     searchParameters: {
-      ...askAi.searchParameters,
+      ...searchParameters,
       facetFilters: mergeFacetFilters(
-        askAiFacetFilters,
+        searchParameters?.facetFilters,
         contextualSearchFilters,
       ),
     },

--- a/packages/docusaurus-theme-search-algolia/src/theme-search-algolia.d.ts
+++ b/packages/docusaurus-theme-search-algolia/src/theme-search-algolia.d.ts
@@ -23,10 +23,15 @@ declare module '@docusaurus/theme-search-algolia' {
     apiKey: string;
     appId: string;
     assistantId: string;
-    searchParameters?: {
-      facetFilters?: FacetFilters;
-    };
+    // When `agentStudio: true`, searchParameters is keyed by index name rather
+    // than being a flat Algolia SearchParams object. See DocSearch v4 types.
+    searchParameters?:
+      | {facetFilters?: FacetFilters}
+      | Record<string, unknown>;
     suggestedQuestions?: boolean;
+    // Experimental: route Ask AI through Algolia's Agent Studio backend.
+    // See https://github.com/algolia/docsearch
+    agentStudio?: boolean;
   };
 
   // DocSearch props that Docusaurus exposes directly through props forwarding

--- a/packages/docusaurus-theme-search-algolia/src/validateThemeConfig.ts
+++ b/packages/docusaurus-theme-search-algolia/src/validateThemeConfig.ts
@@ -9,6 +9,7 @@ import {escapeRegexp} from '@docusaurus/utils';
 import {Joi} from '@docusaurus/utils-validation';
 import {docSearchV3} from './docSearchVersion';
 import type {ThemeConfigValidationContext} from '@docusaurus/types';
+import type {FacetFilters} from 'algoliasearch/lite';
 import type {
   ThemeConfig,
   ThemeConfigAlgolia,
@@ -72,10 +73,11 @@ export const Schema = Joi.object<ThemeConfig>({
           indexName: Joi.string().optional(),
           apiKey: Joi.string().optional(),
           appId: Joi.string().optional(),
-          searchParameters: Joi.object({
-            facetFilters: FacetFiltersSchema.optional(),
-          }).optional(),
+          // When `agentStudio: true`, searchParameters is keyed by index name,
+          // so we relax validation rather than enforce the flat shape.
+          searchParameters: Joi.object().unknown().optional(),
           suggestedQuestions: Joi.boolean().optional(),
+          agentStudio: Joi.boolean().optional(),
         }),
       )
       .custom(
@@ -108,12 +110,20 @@ export const Schema = Joi.object<ThemeConfig>({
           askAiInput.indexName = askAiInput.indexName ?? algolia.indexName;
           askAiInput.apiKey = askAiInput.apiKey ?? algolia.apiKey;
           askAiInput.appId = askAiInput.appId ?? algolia.appId;
+          // agentStudio uses an index-keyed `searchParameters` shape and
+          // rejects `facetFilters`, so skip the contextual merge for it.
+          const flatSearchParams = askAiInput.searchParameters as
+            | {facetFilters?: FacetFilters}
+            | undefined;
           if (
-            askAiInput.searchParameters?.facetFilters === undefined &&
+            !askAiInput.agentStudio &&
+            flatSearchParams?.facetFilters === undefined &&
             algoliaFacetFilters
           ) {
-            askAiInput.searchParameters = askAiInput.searchParameters ?? {};
-            askAiInput.searchParameters.facetFilters = algoliaFacetFilters;
+            askAiInput.searchParameters = {
+              ...flatSearchParams,
+              facetFilters: algoliaFacetFilters,
+            };
           }
 
           return askAiInput;


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the Contributing Guidelines on pull requests.
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #11950) and the maintainers have approved on my working plan.

## Motivation

Closes #11950.

`@docsearch/react@4.6.x` added an experimental `agentStudio` flag on the `askAi` prop that routes Ask AI through Algolia's Agent Studio backend. Algolia's current integration guide for DocSearch recommends setting it, and it's the documented path for using the new assistant format. However the Docusaurus theme's Joi schema rejects the key:

```
"algolia.askAi.agentStudio" is not allowed
```

Users today have to swizzle `SearchBar` to inject the flag past the schema. This PR makes the flag first-class in `themeConfig.algolia.askAi`.

## Changes

- Add `agentStudio?: boolean` to `AskAiConfig` and the Joi schema.
- Relax `askAi.searchParameters` validation to accept the index-keyed shape that DocSearch expects when `agentStudio: true` (`{ "INDEX_NAME": { distinct: false } }`).
- Skip the automatic contextual `facetFilters` merge when `agentStudio: true` — the Agent Studio endpoint rejects `facetFilters` entirely (`invalid searchParameters for index 'facetFilters'`). Previously this forced users to also set `contextualSearch: false`.

## Test Plan

New tests in `validateThemeConfig.test.ts`:

- accepts `agentStudio: true` alongside `assistantId`
- does not inject `facetFilters` from top-level algolia config into `askAi` when `agentStudio: true`
- accepts the index-keyed `searchParameters` shape when `agentStudio: true`
- rejects non-boolean `agentStudio`

All 30 tests in the file pass:

```
Test Suites: 1 passed, 1 total
Tests:       30 passed, 30 total
```

Verified end-to-end on a downstream site (docs.two.inc preview): Cmd+K opens the DocSearch v4 modal, clicking "Ask AI" returns Agent Studio–backed answers with citation links.

## Related issues/PRs

- Closes #11950