### PR TITLE
feat(website): add agent docs plugin

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -857,9 +857,6 @@ export default async function createConfigAsync() {
                 href: 'https://github.com/facebook/docusaurus',
               },
               {
-                html: '<span aria-label="AI agents can use /llms.txt"><code>/llms.txt</code></span>',
-              },
-              {
                 label: 'X',
                 href: 'https://x.com/docusaurus',
               },

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -315,6 +315,7 @@ export default async function createConfigAsync() {
           },
         };
       },
+      './src/plugins/agent-docs/index.ts',
       isRsdoctor && [
         'rsdoctor',
         {
@@ -854,6 +855,9 @@ export default async function createConfigAsync() {
               {
                 label: 'GitHub',
                 href: 'https://github.com/facebook/docusaurus',
+              },
+              {
+                html: '<span aria-label="AI agents can use /llms.txt"><code>/llms.txt</code></span>',
               },
               {
                 label: 'X',

--- a/website/src/plugins/agent-docs/index.ts
+++ b/website/src/plugins/agent-docs/index.ts
@@ -1,0 +1,413 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import path from 'path';
+import fs from 'fs-extra';
+import {flattenRoutes, parseMarkdownFile} from '@docusaurus/utils';
+import type {ParseFrontMatter, Plugin, RouteConfig} from '@docusaurus/types';
+
+type AgentDocsEntry = {
+  routePath: string;
+  markdownRoutePath: string;
+  markdownUrl: string;
+  sourceFilePath: string;
+  title: string;
+  section: string;
+};
+
+type PreparedMarkdown = {
+  markdown: string;
+  title: string;
+};
+
+const SectionOrder = ['Docs', 'Community', 'Blog', 'Changelog', 'Pages'];
+const SectionOrderSet = new Set(SectionOrder);
+const MarkdownSourcePattern = /\.(?:md|mdx)$/i;
+
+function isSourceBackedRoute(
+  route: RouteConfig,
+): route is RouteConfig & {metadata: {sourceFilePath: string}} {
+  return typeof route.metadata?.sourceFilePath === 'string';
+}
+
+function stripBaseUrl(routePath: string, baseUrl: string): string {
+  if (baseUrl === '/' || baseUrl === '') {
+    return routePath;
+  }
+
+  const normalizedBaseUrl = baseUrl.endsWith('/')
+    ? baseUrl.slice(0, -1)
+    : baseUrl;
+
+  if (!routePath.startsWith(normalizedBaseUrl)) {
+    return routePath;
+  }
+
+  const stripped = routePath.slice(normalizedBaseUrl.length);
+  return stripped === '' ? '/' : stripped;
+}
+
+function getSection(routePath: string, baseUrl: string): string {
+  const routeWithoutBaseUrl = stripBaseUrl(routePath, baseUrl);
+
+  if (
+    routeWithoutBaseUrl === '/docs' ||
+    routeWithoutBaseUrl.startsWith('/docs/')
+  ) {
+    return 'Docs';
+  }
+  if (
+    routeWithoutBaseUrl === '/community' ||
+    routeWithoutBaseUrl.startsWith('/community/')
+  ) {
+    return 'Community';
+  }
+  if (
+    routeWithoutBaseUrl === '/blog' ||
+    routeWithoutBaseUrl.startsWith('/blog/')
+  ) {
+    return 'Blog';
+  }
+  if (
+    routeWithoutBaseUrl === '/changelog' ||
+    routeWithoutBaseUrl.startsWith('/changelog/')
+  ) {
+    return 'Changelog';
+  }
+  return 'Pages';
+}
+
+function toMarkdownRoutePath(routePath: string): string {
+  const normalizedRoutePath =
+    routePath !== '/' && routePath.endsWith('/')
+      ? routePath.slice(0, -1)
+      : routePath;
+
+  return normalizedRoutePath === '/'
+    ? '/index.md'
+    : `${normalizedRoutePath}.md`;
+}
+
+function toOutputFilePath(outDir: string, routePath: string): string {
+  return path.join(outDir, routePath.replace(/^\//, ''));
+}
+
+function toAbsoluteUrl(siteUrl: string, routePath: string): string {
+  return new URL(routePath, siteUrl).toString();
+}
+
+function toBaseUrlPath(baseUrl: string, filename: string): string {
+  const normalizedBaseUrl = baseUrl === '/' ? '' : baseUrl.replace(/\/$/, '');
+  return `${normalizedBaseUrl}/${filename}`.replace(/\/+/g, '/');
+}
+
+function toIndexUrl(
+  siteUrl: string,
+  baseUrl: string,
+  filename: string,
+): string {
+  return toAbsoluteUrl(siteUrl, toBaseUrlPath(baseUrl, filename));
+}
+
+function fallbackTitle(routePath: string): string {
+  if (routePath === '/' || routePath === '') {
+    return 'Home';
+  }
+
+  const segment = routePath
+    .replace(/^\//, '')
+    .replace(/\/$/, '')
+    .split('/')
+    .filter(Boolean)
+    .at(-1);
+
+  return segment ?? 'Page';
+}
+
+async function prepareMarkdownFromSource({
+  filePath,
+  sourceFilePath,
+  routePath,
+  htmlUrl,
+  parseFrontMatter,
+}: {
+  filePath: string;
+  sourceFilePath: string;
+  routePath: string;
+  htmlUrl: string;
+  parseFrontMatter: ParseFrontMatter;
+}): Promise<PreparedMarkdown> {
+  if (!MarkdownSourcePattern.test(sourceFilePath)) {
+    const title = fallbackTitle(routePath);
+    return {
+      title,
+      markdown: [
+        `# ${title}`,
+        '',
+        `Canonical URL: ${htmlUrl}`,
+        '',
+        'This page is implemented as a React page, so there is no source Markdown file to expose directly.',
+        '',
+        `Source file: \`${sourceFilePath}\``,
+        '',
+      ].join('\n'),
+    };
+  }
+
+  const fileContent = await fs.readFile(filePath, 'utf-8');
+  const parsed = await parseMarkdownFile({
+    filePath,
+    fileContent,
+    parseFrontMatter,
+  });
+
+  const title =
+    typeof parsed.frontMatter.title === 'string'
+      ? parsed.frontMatter.title
+      : parsed.contentTitle ?? fallbackTitle(routePath);
+
+  let markdown = parsed.content.trim();
+
+  if (title && !markdown.startsWith('# ')) {
+    markdown = `# ${title}\n\n${markdown}`;
+  }
+
+  return {
+    title,
+    markdown: `${markdown.trim()}\n`,
+  };
+}
+
+function buildGroupedIndex(entries: AgentDocsEntry[]): string[] {
+  const groupedEntries = new Map<string, AgentDocsEntry[]>();
+
+  entries.forEach((entry) => {
+    const existing = groupedEntries.get(entry.section) ?? [];
+    existing.push(entry);
+    groupedEntries.set(entry.section, existing);
+  });
+
+  const orderedSections = [
+    ...SectionOrder.filter((section) => groupedEntries.has(section)),
+    ...[...groupedEntries.keys()].filter(
+      (section) => !SectionOrderSet.has(section),
+    ),
+  ];
+
+  return orderedSections.flatMap((section) => {
+    const sectionEntries = groupedEntries
+      .get(section)!
+      .sort((left, right) => left.routePath.localeCompare(right.routePath));
+
+    return [
+      `## ${section}`,
+      ...sectionEntries.map(
+        (entry) => `- [${entry.title}](${entry.markdownUrl})`,
+      ),
+      '',
+    ];
+  });
+}
+
+function buildSummaryIndex({
+  siteTitle,
+  siteUrl,
+  baseUrl,
+  entries,
+}: {
+  siteTitle: string;
+  siteUrl: string;
+  baseUrl: string;
+  entries: AgentDocsEntry[];
+}): string {
+  const groupedEntries = new Map<string, AgentDocsEntry[]>();
+
+  entries.forEach((entry) => {
+    const existing = groupedEntries.get(entry.section) ?? [];
+    existing.push(entry);
+    groupedEntries.set(entry.section, existing);
+  });
+
+  const sectionFiles = [
+    {section: 'Docs', filename: 'llms-docs.txt'},
+    {section: 'Community', filename: 'llms-community.txt'},
+    {section: 'Blog', filename: 'llms-blog.txt'},
+    {section: 'Changelog', filename: 'llms-changelog.txt'},
+    {section: 'Pages', filename: 'llms-pages.txt'},
+  ].filter((entry) => groupedEntries.has(entry.section));
+
+  const lines = [
+    `# ${siteTitle}`,
+    '',
+    `> Agent-readable index for ${siteTitle}.`,
+    '',
+    'Append `.md` to a canonical page URL to retrieve the markdown form published by this build when it exists.',
+    '',
+    '## Indexes',
+    `- [Full index](${toIndexUrl(siteUrl, baseUrl, 'llms-full.txt')})`,
+    ...sectionFiles.map(
+      ({section, filename}) =>
+        `- [${section}](${toIndexUrl(siteUrl, baseUrl, filename)})`,
+    ),
+    '',
+  ];
+
+  SectionOrder.forEach((section) => {
+    const sectionEntries = groupedEntries.get(section);
+    if (!sectionEntries || sectionEntries.length === 0) {
+      return;
+    }
+
+    lines.push(`## ${section}`);
+    sectionEntries
+      .sort((left, right) => left.routePath.localeCompare(right.routePath))
+      .slice(0, 8)
+      .forEach((entry) => {
+        lines.push(`- [${entry.title}](${entry.markdownUrl})`);
+      });
+    lines.push('');
+  });
+
+  return `${lines.join('\n').trim()}\n`;
+}
+
+function buildSectionIndex({
+  siteTitle,
+  section,
+  entries,
+}: {
+  siteTitle: string;
+  section: string;
+  entries: AgentDocsEntry[];
+}): string {
+  return [
+    `# ${siteTitle} ${section}`,
+    '',
+    `> Agent-readable ${section.toLowerCase()} index for ${siteTitle}.`,
+    '',
+    ...buildGroupedIndex(entries),
+  ]
+    .join('\n')
+    .trim()
+    .concat('\n');
+}
+
+function buildFullIndex({
+  siteTitle,
+  entries,
+}: {
+  siteTitle: string;
+  entries: AgentDocsEntry[];
+}): string {
+  return [
+    `# ${siteTitle} Full Index`,
+    '',
+    `> Agent-readable full index for ${siteTitle}.`,
+    '',
+    ...buildGroupedIndex(entries),
+  ]
+    .join('\n')
+    .trim()
+    .concat('\n');
+}
+
+const AgentDocsPlugin: Plugin = {
+  name: 'agent-docs-plugin',
+
+  async postBuild(props) {
+    const {outDir, routes, routesBuildMetadata, siteDir, siteConfig, baseUrl} =
+      props;
+    const preparedMarkdownBySource = new Map<
+      string,
+      Promise<PreparedMarkdown>
+    >();
+
+    const allRoutes = flattenRoutes(routes)
+      .filter(isSourceBackedRoute)
+      .filter((route) => route.path !== '/404.html')
+      .filter((route) => !routesBuildMetadata[route.path]?.noIndex);
+
+    const entries = await Promise.all(
+      allRoutes.map(async (route) => {
+        const sourceFilePath = route.metadata.sourceFilePath;
+        const absoluteSourceFilePath = path.join(siteDir, sourceFilePath);
+        const markdownRoutePath = toMarkdownRoutePath(route.path);
+        const markdownUrl = toAbsoluteUrl(siteConfig.url, markdownRoutePath);
+        const htmlUrl = toAbsoluteUrl(siteConfig.url, route.path);
+
+        let preparedMarkdown = preparedMarkdownBySource.get(sourceFilePath);
+        if (!preparedMarkdown) {
+          preparedMarkdown = prepareMarkdownFromSource({
+            filePath: absoluteSourceFilePath,
+            sourceFilePath,
+            routePath: route.path,
+            htmlUrl,
+            parseFrontMatter: siteConfig.markdown.parseFrontMatter,
+          });
+          preparedMarkdownBySource.set(sourceFilePath, preparedMarkdown);
+        }
+
+        const prepared = await preparedMarkdown;
+        const outputFilePath = toOutputFilePath(outDir, markdownRoutePath);
+        await fs.ensureDir(path.dirname(outputFilePath));
+        await fs.writeFile(outputFilePath, prepared.markdown);
+
+        return {
+          routePath: route.path,
+          markdownRoutePath,
+          markdownUrl,
+          sourceFilePath,
+          title: prepared.title,
+          section: getSection(route.path, baseUrl),
+        } satisfies AgentDocsEntry;
+      }),
+    );
+
+    const sortedEntries = entries.sort((left, right) =>
+      left.routePath.localeCompare(right.routePath),
+    );
+
+    const groupedEntries = new Map<string, AgentDocsEntry[]>();
+    sortedEntries.forEach((entry) => {
+      const existing = groupedEntries.get(entry.section) ?? [];
+      existing.push(entry);
+      groupedEntries.set(entry.section, existing);
+    });
+
+    await fs.writeFile(
+      path.join(outDir, 'llms.txt'),
+      buildSummaryIndex({
+        siteTitle: siteConfig.title,
+        siteUrl: siteConfig.url,
+        baseUrl,
+        entries: sortedEntries,
+      }),
+    );
+
+    await fs.writeFile(
+      path.join(outDir, 'llms-full.txt'),
+      buildFullIndex({siteTitle: siteConfig.title, entries: sortedEntries}),
+    );
+
+    await Promise.all(
+      [...groupedEntries.entries()].map(async ([section, sectionEntries]) => {
+        await fs.writeFile(
+          path.join(outDir, `llms-${section.toLowerCase()}.txt`),
+          buildSectionIndex({
+            siteTitle: siteConfig.title,
+            section,
+            entries: sectionEntries,
+          }),
+        );
+      }),
+    );
+  },
+};
+
+export default function pluginAgentDocs(): Plugin {
+  return AgentDocsPlugin;
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

This PR adds an agent-readable documentation export to the Docusaurus website build.

It introduces a local website plugin that runs after the site build and emits `/llms.txt`, `/llms-full.txt`, section-specific indexes, and Markdown versions of source-backed routes. This makes the Docusaurus documentation easier for AI agents and other automated tools to discover, index, and consume in a Markdown-oriented format.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

- Verified the change through the repository pre-commit hook.
- `lint-staged` completed successfully.
- `eslint --fix` completed successfully on the staged TypeScript files.
- `prettier --ignore-unknown --write` completed successfully on the staged files.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

Once the deploy preview is available, the relevant links should be:

- https://deploy-preview-_____--docusaurus-2.netlify.app/llms.txt
- https://deploy-preview-_____--docusaurus-2.netlify.app/llms-full.txt
- https://deploy-preview-_____--docusaurus-2.netlify.app/llms-docs.txt
- https://deploy-preview-_____--docusaurus-2.netlify.app/llms-community.txt
- https://deploy-preview-_____--docusaurus-2.netlify.app/llms-blog.txt
- https://deploy-preview-_____--docusaurus-2.netlify.app/llms-changelog.txt
- https://deploy-preview-_____--docusaurus-2.netlify.app/llms-pages.txt
and any page doc page **.md
- https://deploy-preview-_____--docusaurus-2.netlify.app/docs/installation.md


## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
