### PR TITLE
docs: add security policy (SECURITY.md)

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Docusaurus, please report it responsibly.
+
+**Please do NOT report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them via [GitHub Security Advisories](https://github.com/facebook/docusaurus/security/advisories/new).
+
+You should receive a response within 48 hours. If for some reason you do not, please follow up via email to ensure we received your original message.
+
+Please include as much information as possible to help us understand the nature and scope of the issue:
+
+- Type of issue (e.g., XSS, CSRF, remote code execution)
+- Steps to reproduce
+- Impact of the issue
+- Any potential fixes you've identified


### PR DESCRIPTION
## Changes

docs: add security policy (SECURITY.md)

Add a security policy to guide responsible disclosure
of security vulnerabilities via GitHub Security Advisories.

Signed with GPG.