### PR TITLE
fix: prevent code blocks flash in dark mode (AI-assisted)

### DIFF
--- a/packages/docusaurus-theme-classic/src/index.ts
+++ b/packages/docusaurus-theme-classic/src/index.ts
@@ -38,7 +38,11 @@ export default function themeClassic(
   const {
     announcementBar,
     colorMode,
-    prism: {additionalLanguages},
+    prism: {
+      additionalLanguages,
+      theme: prismLightTheme,
+      darkTheme: prismDarkTheme,
+    },
   } = themeConfig;
   const {customCss} = options;
   const {direction} = localeConfigs[currentLocale]!;
@@ -120,7 +124,25 @@ export default function themeClassic(
     },
 
     injectHtmlTags() {
+      const lightTheme = prismLightTheme;
+      const darkTheme = prismDarkTheme || lightTheme;
+      const prismCssStyle = `
+[data-theme='light'] {
+  --prism-background-color: ${lightTheme.plain.backgroundColor || 'inherit'};
+  --prism-color: ${lightTheme.plain.color || 'inherit'};
+}
+[data-theme='dark'] {
+  --prism-background-color: ${darkTheme.plain.backgroundColor || 'inherit'};
+  --prism-color: ${darkTheme.plain.color || 'inherit'};
+}
+`;
       return {
+        headTags: [
+          {
+            tagName: 'style',
+            innerHTML: prismCssStyle,
+          },
+        ],
         preBodyTags: [
           {
             tagName: 'svg',

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Container/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Container/index.tsx
@@ -7,21 +7,17 @@
 
 import React, {type ComponentProps, type ReactNode} from 'react';
 import clsx from 'clsx';
-import {ThemeClassNames, usePrismTheme} from '@docusaurus/theme-common';
-import {getPrismCssVariables} from '@docusaurus/theme-common/internal';
+import {ThemeClassNames} from '@docusaurus/theme-common';
 import styles from './styles.module.css';
 
 export default function CodeBlockContainer<T extends 'div' | 'pre'>({
   as: As,
   ...props
 }: {as: T} & ComponentProps<T>): ReactNode {
-  const prismTheme = usePrismTheme();
-  const prismCssVariables = getPrismCssVariables(prismTheme);
   return (
     <As
       // Polymorphic components are hard to type, without `oneOf` generics
       {...(props as any)}
-      style={prismCssVariables}
       className={clsx(
         props.className,
         styles.codeBlockContainer,

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/index.tsx
@@ -60,11 +60,10 @@ export default function CodeBlockContent({
   const {code, language, lineNumbersStart, lineClassNames} = metadata;
   return (
     <Highlight theme={prismTheme} code={code} language={language}>
-      {({className, style, tokens: lines, getLineProps, getTokenProps}) => (
+      {({className, tokens: lines, getLineProps, getTokenProps}) => (
         <Pre
           ref={wordWrap.codeBlockRef}
-          className={clsx(classNameProp, className)}
-          style={style}>
+          className={clsx(classNameProp, className)}>
           <Code>
             {lines.map((line, i) => (
               <Line

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, {isValidElement, type ReactNode} from 'react';
-import useIsBrowser from '@docusaurus/useIsBrowser';
 import ElementContent from '@theme/CodeBlock/Content/Element';
 import StringContent from '@theme/CodeBlock/Content/String';
 import type {Props} from '@theme/CodeBlock';
@@ -29,17 +28,8 @@ export default function CodeBlock({
   children: rawChildren,
   ...props
 }: Props): ReactNode {
-  // The Prism theme on SSR is always the default theme but the site theme can
-  // be in a different mode. React hydration doesn't update DOM styles that come
-  // from SSR. Hence force a re-render after mounting to apply the current
-  // relevant styles.
-  const isBrowser = useIsBrowser();
   const children = maybeStringifyChildren(rawChildren);
   const CodeBlockComp =
     typeof children === 'string' ? StringContent : ElementContent;
-  return (
-    <CodeBlockComp key={String(isBrowser)} {...props}>
-      {children as string}
-    </CodeBlockComp>
-  );
+  return <CodeBlockComp {...props}>{children as string}</CodeBlockComp>;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

Fixes #11566

When loading a Docusaurus page in dark mode, code blocks briefly flash with light theme colors before switching to the correct dark theme. This happens because Prism theme colors were applied as inline styles via JavaScript, which only take effect after React hydration.

This PR injects CSS variables for both light and dark Prism themes directly in a <style> tag in the <head>, leveraging the [data-theme] attribute that is already set by a blocking script. This ensures code blocks display with the correct background color from the very first paint, without waiting for hydration.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

1. Configure a site with different light/dark Prism themes (e.g., oneLight / oneDark)
2. Switch to dark mode
3. Hard-reload any page with code blocks
4. Observe that code blocks no longer flash with light theme colors
(AI-assisted)

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

## Related issues/PRs

Closes #11566

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
