### PR TITLE
docs: add docusaurus-plugin-copy-page-button to community plugins

### DIFF
--- a/website/community/2-resources.mdx
+++ b/website/community/2-resources.mdx
@@ -74,6 +74,7 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [docusaurus-plugin-glossary](https://github.com/mcclowes/docusaurus-plugin-glossary) - A docusaurus plugin for helping users understand key terms.
 - [docusaurus-plugin-cookie-consent](https://github.com/mcclowes/docusaurus-plugin-cookie-consent) - A Docusaurus plugin for allowing users to opt in/out of cookies, and accessing those settings in code.
 - [expose-markdown-docusaurus-plugin](https://github.com/FlyNumber/markdown_docusaurus_plugin) - A Docusaurus plugin that exposes your /docs Markdown files as raw .md URLs. (For LLM's and such).
+- [docusaurus-plugin-copy-page-button](https://github.com/portdeveloper/docusaurus-plugin-copy-page-button) - Adds a "Copy page" button that exports doc pages as clean markdown for use with ChatGPT, Claude, and Gemini. Used by Ethereum, Sui, Monad, and Flare docs.
 
 ## Enterprise usage {/* #enterprise-usage */}
 


### PR DESCRIPTION
## Motivation

Adds an entry under Community plugins → Features for [docusaurus-plugin-copy-page-button](https://github.com/portdeveloper/docusaurus-plugin-copy-page-button).

The plugin adds a "Copy page" button to the docs sidebar that exports the current page as clean markdown, with one-click "Open in ChatGPT", "Open in Claude", and "Open in Gemini" actions. Useful for the increasingly common workflow of asking an LLM questions about a docs page.

I placed it adjacent to `expose-markdown-docusaurus-plugin` in the list since both target the LLM/AI use case.

## Why include it

- ~10k installs/month on npm
- Currently shipping in production on:
  - Ethereum execution-apis
  - Sui, Walrus, Seal, SuiNS (Mysten Labs)
  - Monad
  - Flare developer hub
  - Kaia
  - Nillion
  - Chronicle Protocol

## Links

- Repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button
- Live demo: https://portdeveloper.github.io/copy-page-button-showcase/

## Test Plan

This is a docs-only change, no code or tests affected.