### PR TITLE
docs: document loading ambient types for optional plugins

### DIFF
--- a/website/docs/typescript-support.mdx
+++ b/website/docs/typescript-support.mdx
@@ -41,6 +41,33 @@ Docusaurus doesn't use this `tsconfig.json` to compile your project. It is added
 
 Now you can start writing TypeScript theme components.
 
+## Ambient types for optional plugins {/* #ambient-types-for-optional-plugins */}
+
+Some plugins and themes ship their own ambient `.d.ts` files that TypeScript does not load automatically.
+
+For example, importing from `@theme/Playground` (provided by `@docusaurus/theme-live-codeblock`) fails with `TS2307: Cannot find module '@theme/Playground'` until you opt the plugin's types in.
+
+Add a triple-slash reference from a project `.d.ts` file (recommended):
+
+```ts title="src/types.d.ts"
+/// <reference types="@docusaurus/theme-live-codeblock" />
+```
+
+Alternatively, list the package in the `types` compiler option of your `tsconfig.json`. This disables TypeScript's default loading of `@types/*` packages, so list any other type packages you rely on explicitly:
+
+```json title="tsconfig.json"
+{
+  "extends": "@docusaurus/tsconfig",
+  "compilerOptions": {
+    "baseUrl": ".",
+    // highlight-next-line
+    "types": ["@docusaurus/theme-live-codeblock"]
+  }
+}
+```
+
+The same applies to any other optional plugin or theme that ships ambient types.
+
 ## Typing the config file {/* #typing-config */}
 
 It is possible to use a TypeScript config file in Docusaurus.

--- a/website/docs/typescript-support.mdx
+++ b/website/docs/typescript-support.mdx
@@ -47,13 +47,13 @@ Some plugins and themes ship their own ambient `.d.ts` files that TypeScript doe
 
 For example, importing from `@theme/Playground` (provided by `@docusaurus/theme-live-codeblock`) fails with `TS2307: Cannot find module '@theme/Playground'` until you opt the plugin's types in.
 
-Add a triple-slash reference from a project `.d.ts` file (recommended):
+Add a triple-slash reference in a project `.d.ts` file (recommended):
 
 ```ts title="src/types.d.ts"
 /// <reference types="@docusaurus/theme-live-codeblock" />
 ```
 
-Alternatively, list the package in the `types` compiler option of your `tsconfig.json`. This disables TypeScript's default loading of `@types/*` packages, so list any other type packages you rely on explicitly:
+Alternatively, add the package to the `types` compiler option of your `tsconfig.json`. This disables TypeScript's default loading of `@types/*` packages, so include any other type packages you rely on explicitly:
 
 ```json title="tsconfig.json"
 {


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior. _(N/A — docs-only change.)_
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #9368) and the maintainers have approved on my working plan. _(N/A — small docs addition; the closing reference is noted below.)_

## Motivation

Closes #9368.

The current TypeScript Support page covers initial setup but doesn't explain how to make module aliases from optional plugins/themes (e.g. `@theme/Playground` from `@docusaurus/theme-live-codeblock`) resolve. New users hit `TS2307: Cannot find module '@theme/Playground'` and have no in-doc path to a fix.

In the issue thread, @Josh-Cena endorsed adding this guidance to the TypeScript Support page:

> The fix is as easy as adding it to tsconfig or a .d.ts triple slash reference, as you have already pointed out. We should probably add it to TypeScript support.

This PR adds a short subsection between **Setup** and **Typing the config file** that explains both opt-in mechanisms.

## Test Plan

Both documented patterns are dogfooded inside this very repo, which is the strongest empirical signal that they work as described:

- **Triple-slash reference** — `website/src/types.d.ts` already uses this pattern for `@docusaurus/plugin-ideal-image`.
- **`types` compiler option** — `website/tsconfig.json` already uses this pattern with `"types": ["jest"]`.

The technical claim about `types` disabling default `@types/*` auto-loading is per the [TypeScript handbook](https://www.typescriptlang.org/tsconfig/#types); the recommended path (triple-slash) is purely additive and avoids that side effect, which is why it is marked as recommended.

### Test links

Deploy preview: https://deploy-preview-11986--docusaurus-2.netlify.app/docs/typescript-support#ambient-types-for-optional-plugins

## Related issues/PRs

Closes #9368.