### PR TITLE
extract themeConfig from preset

### DIFF
--- a/packages/docusaurus-preset-classic/src/index.ts
+++ b/packages/docusaurus-preset-classic/src/index.ts
@@ -23,10 +23,26 @@ function makePluginConfig(
   return require.resolve(source);
 }
 
+function validatePresetMigrations(themeConfig: Record<string, unknown>): void {
+  if (themeConfig.gtag) {
+    throw new Error(
+      'The "gtag" field in themeConfig should now be specified as option for plugin-google-gtag. For preset-classic, simply move themeConfig.gtag to preset options. More information at https://github.com/facebook/docusaurus/pull/5832.',
+    );
+  }
+  if (themeConfig.googleAnalytics) {
+    throw new Error(
+      'The "googleAnalytics" field in themeConfig should now be specified as option for plugin-google-analytics. For preset-classic, simply move themeConfig.googleAnalytics to preset options. More information at https://github.com/facebook/docusaurus/pull/5832.',
+    );
+  }
+}
+
 export default function preset(
   context: LoadContext,
   opts: Options = {},
 ): Preset {
+  validatePresetMigrations(
+    context.siteConfig.themeConfig as Record<string, unknown>,
+  );
   const {siteConfig} = context;
   const {themeConfig} = siteConfig;
   const {algolia} = themeConfig as Partial<ThemeConfig>;
@@ -49,16 +65,6 @@ export default function preset(
   themes.push(makePluginConfig('@docusaurus/theme-classic', theme));
   if (algolia) {
     themes.push(require.resolve('@docusaurus/theme-search-algolia'));
-  }
-  if ('gtag' in themeConfig) {
-    throw new Error(
-      'The "gtag" field in themeConfig should now be specified as option for plugin-google-gtag. For preset-classic, simply move themeConfig.gtag to preset options. More information at https://github.com/facebook/docusaurus/pull/5832.',
-    );
-  }
-  if ('googleAnalytics' in themeConfig) {
-    throw new Error(
-      'The "googleAnalytics" field in themeConfig should now be specified as option for plugin-google-analytics. For preset-classic, simply move themeConfig.googleAnalytics to preset options. More information at https://github.com/facebook/docusaurus/pull/5832.',
-    );
   }
 
   const plugins: PluginConfig[] = [];


### PR DESCRIPTION
Closes [#70](https://github.com/dpantaleoni/docusaurus/issues/70)

## Summary of changes

preset function was handling two unrelated tasks; checking deprecated themeConfig and registering plugins, mixing migration guards and functionality checks. `gtag` and `googleanalytics` theme configurations have been moved to their own function `validatePresetMigrations`.

## Verification

yarn test passes implemented tests after refactor

## Evidence

<img width="1631" height="790" alt="image" src="https://github.com/user-attachments/assets/a4586542-a9e5-41bc-8e5d-58fd7ecdfedf" />

## Pre-flight checklist

- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
