### PR TITLE
fix(theme-classic): restore color emoji presentation for DocCard category fallback

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocCard/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocCard/index.tsx
@@ -27,7 +27,7 @@ function getFallbackEmojiIcon(
   item: PropSidebarItemLink | PropSidebarItemCategory,
 ): string {
   if (item.type === 'category') {
-    return '🗃';
+    return '🗃️';
   }
   return isInternalUrl(item.href) ? '📄️' : '🔗';
 }


### PR DESCRIPTION
## Summary

Restores color emoji presentation for the DocCard category icon fallback. PR #11734 (v3.10) rewrote the literal as `'🗃'` (just U+1F5C3 — Unicode default presentation is *text*), so on Win11 and many Linux setups it renders monochrome. The sibling `'📄️'` literal two lines below already includes U+FE0F — this PR matches that convention.

One-character fix: append U+FE0F to the literal at `packages/docusaurus-theme-classic/src/theme/DocCard/index.tsx:30`.

## Test plan

- [x] `prettier --check` clean
- [x] Full theme-classic suite passes (no DocCard-specific tests/snapshots exist to update)
- [x] Verified codepoints: `[0x1f5c3, 0xfe0f]` after fix (matches sibling `[0x1f4c4, 0xfe0f]`)
- [x] Other emoji literal in the same function (`'🔗'` U+1F517) checked — has `Emoji_Presentation=True`, doesn't need the fix

Fixes #11962