### PR TITLE
P3/issue 77 mdx options builder

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,7 @@
   },
   "forwardPorts": [3000],
   "containerUser": "vscode",
-  "postCreateCommand": "yarn install",
+  "postCreateCommand": "",
   "waitFor": "postCreateCommand", // otherwise automated jest tests fail
   "features": {
     "node": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,7 @@
   },
   "forwardPorts": [3000],
   "containerUser": "vscode",
-  "postCreateCommand": "",
+  "postCreateCommand": "yarn install",
   "waitFor": "postCreateCommand", // otherwise automated jest tests fail
   "features": {
     "node": {

--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,7 @@ website/rspack-tracing.pftrace
 website/bundler-cpu-profile.json
 website/profile.json.gz
 
-
+# Local Docker dev setup
+Dockerfile
+docker-compose.yml
+.dockerignore

--- a/admin/scripts/formatLighthouseReport.js
+++ b/admin/scripts/formatLighthouseReport.js
@@ -20,8 +20,15 @@ const summaryKeys = {
 /** @param {number} rawScore */
 const scoreEntry = (rawScore) => {
   const score = Math.round(rawScore * 100);
-  // eslint-disable-next-line no-nested-ternary
-  const scoreIcon = score >= 90 ? '🟢' : score >= 50 ? '🟠' : '🔴';
+  let scoreIcon;
+  if (score >= 90) {
+    scoreIcon = '🟢';
+  } else if (score >= 50) {
+    scoreIcon = '🟠';
+  } else {
+    scoreIcon = '🔴';
+  }
+
   return `${scoreIcon} ${score}`;
 };
 

--- a/examples/classic/src/components/HomepageFeatures/index.js
+++ b/examples/classic/src/components/HomepageFeatures/index.js
@@ -1,9 +1,11 @@
 import clsx from 'clsx';
 import Heading from '@theme/Heading';
 import styles from './styles.module.css';
+import PropTypes from 'prop-types';
 
 const FeatureList = [
   {
+    id: 1,
     title: 'Easy to Use',
     Svg: require('@site/static/img/undraw_docusaurus_mountain.svg').default,
     description: (
@@ -14,6 +16,7 @@ const FeatureList = [
     ),
   },
   {
+    id: 2,
     title: 'Focus on What Matters',
     Svg: require('@site/static/img/undraw_docusaurus_tree.svg').default,
     description: (
@@ -24,6 +27,7 @@ const FeatureList = [
     ),
   },
   {
+    id: 3,
     title: 'Powered by React',
     Svg: require('@site/static/img/undraw_docusaurus_react.svg').default,
     description: (
@@ -35,7 +39,7 @@ const FeatureList = [
   },
 ];
 
-function Feature({Svg, title, description}) {
+function Feature({id, Svg, title, description}) {
   return (
     <div className={clsx('col col--4')}>
       <div className="text--center">
@@ -49,13 +53,20 @@ function Feature({Svg, title, description}) {
   );
 }
 
+Feature.propTypes = {
+  id: PropTypes.int.isRequired,
+  Svg: PropTypes.elementType.isRequired,
+  title: PropTypes.string.isRequired,
+  description: PropTypes.node.isRequired,
+};
+
 export default function HomepageFeatures() {
   return (
     <section className={styles.features}>
       <div className="container">
         <div className="row">
-          {FeatureList.map((props, idx) => (
-            <Feature key={idx} {...props} />
+          {FeatureList.map((item) => (
+            <Feature key={item.id} {...item}/>
           ))}
         </div>
       </div>

--- a/packages/create-docusaurus/src/__tests__/cross-spawn.d.ts
+++ b/packages/create-docusaurus/src/__tests__/cross-spawn.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+declare module 'cross-spawn';

--- a/packages/create-docusaurus/src/__tests__/utils.test.ts
+++ b/packages/create-docusaurus/src/__tests__/utils.test.ts
@@ -5,7 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {siteNameToPackageName} from '../utils';
+import {EventEmitter} from 'events';
+import spawn from 'cross-spawn';
+import {siteNameToPackageName, runCommand} from '../utils';
+
+// MY TEST CASE
 
 describe('siteNameToPackageName', () => {
   it('converts simple cases', () => {
@@ -38,5 +42,59 @@ describe('siteNameToPackageName', () => {
 
   it('skips !!!', () => {
     expect(siteNameToPackageName('!!!')).toEqual('!!!');
+  });
+});
+
+jest.mock('cross-spawn', () => {
+  const mockFn = jest.fn();
+  return {
+    default: mockFn,
+    __esModule: true,
+  };
+});
+
+// describe.skip(........) skips my test cases to get coverage before
+describe('runCommand error handling', () => {
+  beforeEach(() => {
+    // set spawn mock to a clean default state
+    jest.mocked(spawn).mockImplementation(() => {
+      const fakeProcess = new EventEmitter();
+      process.nextTick(() => fakeProcess.emit('close', 0));
+      return fakeProcess;
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('verifies error thrown for empty string commands', async () => {
+    await expect(runCommand('')).rejects.toThrow('Invalid command');
+  });
+
+  it('verifies error thrown for white spaces only command', async () => {
+    await expect(runCommand('  ')).rejects.toThrow('Invalid command');
+  });
+
+  it('verifies promise rejects when spawn emits error event', async () => {
+    jest.mocked(spawn).mockImplementation(() => {
+      const fakeProcess = new EventEmitter();
+      process.nextTick(() =>
+        fakeProcess.emit('error', new Error('spawn failed')),
+      );
+      return fakeProcess;
+    });
+    await expect(runCommand('some-command')).rejects.toThrow('spawn failed');
+  });
+
+  it('promise rejects when exit code is null', async () => {
+    jest.mocked(spawn).mockImplementation(() => {
+      const fakeProcess = new EventEmitter();
+      process.nextTick(() => fakeProcess.emit('close', null));
+      return fakeProcess;
+    });
+    await expect(runCommand('some-command')).rejects.toThrow(
+      'No exit code for command',
+    );
   });
 });

--- a/packages/docusaurus-bundler/src/minification.ts
+++ b/packages/docusaurus-bundler/src/minification.ts
@@ -29,9 +29,9 @@ function getTerserParallel() {
     terserParallel = false;
   } else if (
     process.env.TERSER_PARALLEL &&
-    parseInt(process.env.TERSER_PARALLEL, 10) > 0
+    Number.parseInt(process.env.TERSER_PARALLEL, 10) > 0
   ) {
-    terserParallel = parseInt(process.env.TERSER_PARALLEL, 10);
+    terserParallel = Number.parseInt(process.env.TERSER_PARALLEL, 10);
   }
   return terserParallel;
 }

--- a/packages/docusaurus-cssnano-preset/src/remove-overridden-custom-properties/index.ts
+++ b/packages/docusaurus-cssnano-preset/src/remove-overridden-custom-properties/index.ts
@@ -41,7 +41,7 @@ function creator(): Plugin {
         ? sameProperties.filter((p) => !('important' in p))
         : sameProperties.slice(0, -1);
 
-      overriddenProperties.map((p) => p.remove());
+      overriddenProperties.forEach((p) => p.remove());
     },
   };
 }

--- a/packages/docusaurus-mdx-loader/src/__tests__/__snapshots__/optionsBuilder.test.ts.snap
+++ b/packages/docusaurus-mdx-loader/src/__tests__/__snapshots__/optionsBuilder.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`createMDXLoaderOptionsBuilder produces the same options as manual assembly 1`] = `
+{
+  "admonitions": true,
+  "isMDXPartial": [Function],
+  "markdownConfig": {
+    "mermaid": true,
+  },
+  "siteDir": "/mySite",
+  "staticDirs": [
+    "/mySite/static",
+    "/mySite/static2",
+  ],
+  "useCrossCompilerCache": true,
+}
+`;

--- a/packages/docusaurus-mdx-loader/src/__tests__/createMDXLoader.test.ts
+++ b/packages/docusaurus-mdx-loader/src/__tests__/createMDXLoader.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import {createMDXLoaderItem} from '../createMDXLoader';
+
+jest.mock('../processor', () => ({
+  createProcessors: jest.fn().mockResolvedValue({
+    mdxProcessor: {},
+    rehypeProcessor: {},
+  }),
+}));
+
+// describe creates a block that groups several related
+// tests into one test suite
+describe('createMDXLoader caching behavior', () => {
+  const originalEnv = process.env.NODE_ENV;
+  const originalJestWorkerId = process.env.JEST_WORKER_ID;
+
+  // before AND after each test
+  beforeEach(() => {
+    delete process.env.JEST_WORKER_ID;
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+    if (originalJestWorkerId !== undefined) {
+      process.env.JEST_WORKER_ID = originalJestWorkerId;
+    } else {
+      delete process.env.JEST_WORKER_ID;
+    }
+  });
+
+  // 1. caching is enabled in production mode
+  it('enables crossCompileCache when use crossCompilerCache=true and NODE_ENV=production', async () => {
+    // ARRANGE - set up the environment
+    process.env.NODE_ENV = 'production';
+
+    // ACT - call the function with specific options
+    const result = (await createMDXLoaderItem({
+      useCrossCompilerCache: true,
+    } as any)) as any;
+
+    // ASSERT - validate the results
+    // expect lets you validate conditions in tests
+    expect(typeof result).toBe('object');
+    expect(result).not.toBeNull();
+    expect('loader' in result).toBe(true);
+    expect(result.loader).toBe(require.resolve('@docusaurus/mdx-loader'));
+    expect(typeof result.options).toBe('object');
+    expect((result as any).options.crossCompilerCache).toBeInstanceOf(Map);
+  });
+
+  // 2. caching is disabled development mode, would cache old versions
+  it('disables crossCompileCache when crossCompilerCache=true but NODE_ENV=development', async () => {
+    // ARRANGE - set up the environment
+    process.env.NODE_ENV = 'development';
+
+    // ACT - call the function with specific options
+    // await pauses async function until a promise is kept
+    // Promise<RuleSetUseItem> in createMDXLoaderItem
+    const result = (await createMDXLoaderItem({
+      useCrossCompilerCache: true,
+    } as any)) as any;
+
+    // ASSERT - validate the results
+    expect(typeof result).toBe('object');
+    expect((result.options as any).crossCompilerCache).toBeUndefined();
+  });
+
+  // 3. caching is disabled when env is undefined
+  it('disables crossCompilerCache when useCrossCompilerCache=true but NODE_ENV is undefined', async () => {
+    // ARRANGE - set up the environment
+    delete process.env.NODE_ENV;
+
+    // ACT - call function with specific options
+    const result = (await createMDXLoaderItem({
+      useCrossCompilerCache: true,
+    } as any)) as any;
+
+    // ASSERT - validate the results
+    expect(typeof result).toBe('object');
+    expect((result.options as any).crossCompilerCache).toBeUndefined();
+  });
+
+  // 4. caching is disabled when useCrossCompilerCache is false, even in production
+  it('disables crossCompilerCache when useCrossCompilerCache=false in production', async () => {
+    // ARRANGE - set up the environment
+    process.env.NODE_ENV = 'production';
+
+    // ACT - call function with specific options
+    const result = (await createMDXLoaderItem({
+      useCrossCompilerCache: false,
+    } as any)) as any;
+
+    // ASSERT - validate the results
+    expect(typeof result).toBe('object');
+    expect((result.options as any).crossCompilerCache).toBeUndefined();
+  });
+
+  // 5.
+  it('disables crossCompilerCache when useCrossCompilerCache is not provided', async () => {
+    // ARRANGE - set up the environment
+    process.env.NODE_ENV = 'production';
+
+    // ACT - call the function with specific options
+    const result = (await createMDXLoaderItem({} as any)) as any;
+
+    // ASSERT - validate the results
+    expect(typeof result.options).toBe('object');
+    expect((result.options as any).crossCompilerCache).toBeUndefined();
+  });
+});

--- a/packages/docusaurus-mdx-loader/src/__tests__/loader.test.ts
+++ b/packages/docusaurus-mdx-loader/src/__tests__/loader.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// mock `../utils` so we don't execute the real MDX processor (ESM deps).
+jest.mock('../utils', () => ({
+  __esModule: true,
+  compileToJSX: jest.fn(),
+  extractContentTitleData: jest.fn(),
+  createAssetsExportCode: jest.fn(),
+  promiseWithResolvers: jest.fn(),
+}));
+
+// eslint-disable-next-line import/first
+import {loadMDXWithCaching, loadMDX} from '../loader';
+// eslint-disable-next-line import/first
+import {compileToJSX} from '../utils';
+// eslint-disable-next-line import/first
+import type {Options} from '../options';
+// eslint-disable-next-line import/first
+import type {WebpackCompilerName} from '@docusaurus/utils';
+
+const mockCompileToJSX = compileToJSX as jest.MockedFunction<
+  typeof compileToJSX
+>;
+
+describe('loadMDXWithCaching', () => {
+  beforeEach(() => {
+    mockCompileToJSX.mockReset();
+  });
+
+  describe('when crossCompilerCache is undefined or missing', () => {
+    const createMockOptions = (
+      crossCompilerCache?: Options['crossCompilerCache'],
+    ): Options => ({
+      markdownConfig: {
+        parseFrontMatter: jest.fn().mockResolvedValue({frontMatter: {}}),
+        mdx1Compat: {
+          headingIds: false,
+          admonitions: false,
+        },
+      } as unknown as Options['markdownConfig'],
+      staticDirs: [],
+      siteDir: '/test',
+      crossCompilerCache,
+    });
+
+    it('calls loadMDX exactly once with expected arguments', async () => {
+      const fileContent = 'test content';
+      const filePath = '/test/file.mdx';
+      const resource = '/test/file.mdx';
+      const compilerName: WebpackCompilerName = 'client';
+      const options = createMockOptions(undefined);
+      const expectedContent = 'compiled result';
+
+      mockCompileToJSX.mockResolvedValue({
+        content: expectedContent,
+        data: {},
+      });
+
+      const result = await loadMDXWithCaching({
+        resource,
+        fileContent,
+        filePath,
+        options,
+        compilerName,
+      });
+
+      expect(options.markdownConfig.parseFrontMatter).toHaveBeenCalledTimes(1);
+      expect(mockCompileToJSX).toHaveBeenCalledTimes(1);
+      expect(mockCompileToJSX).toHaveBeenCalledWith({
+        filePath,
+        fileContent,
+        frontMatter: {},
+        options,
+        compilerName,
+      });
+      expect(result).toContain(expectedContent);
+    });
+
+    it('returns the same promise/value that loadMDX returns', async () => {
+      const fileContent = 'test content';
+      const filePath = '/test/file.mdx';
+      const resource = '/test/file.mdx';
+      const compilerName: WebpackCompilerName = 'client';
+      const options = createMockOptions(undefined);
+      const expectedContent = 'compiled result';
+
+      mockCompileToJSX.mockResolvedValue({
+        content: expectedContent,
+        data: {},
+      });
+
+      const resultFromWithCaching = await loadMDXWithCaching({
+        resource,
+        fileContent,
+        filePath,
+        options,
+        compilerName,
+      });
+
+      const resultFromLoadMDX = await loadMDX({
+        fileContent,
+        filePath,
+        options,
+        compilerName,
+      });
+
+      expect(resultFromWithCaching).toBe(resultFromLoadMDX);
+    });
+
+    it('works with server compilerName', async () => {
+      const fileContent = 'test content';
+      const filePath = '/test/file.mdx';
+      const resource = '/test/file.mdx';
+      const compilerName: WebpackCompilerName = 'server';
+      const options = createMockOptions(undefined);
+      const expectedContent = 'compiled result';
+
+      mockCompileToJSX.mockResolvedValue({
+        content: expectedContent,
+        data: {},
+      });
+
+      const result = await loadMDXWithCaching({
+        resource,
+        fileContent,
+        filePath,
+        options,
+        compilerName,
+      });
+
+      expect(options.markdownConfig.parseFrontMatter).toHaveBeenCalledTimes(1);
+      expect(mockCompileToJSX).toHaveBeenCalledTimes(1);
+      expect(result).toContain(expectedContent);
+    });
+
+    it('calls loadMDX each time when called multiple times (no deduplication)', async () => {
+      const fileContent = 'test content';
+      const filePath = '/test/file.mdx';
+      const resource = '/test/file.mdx';
+      const compilerName: WebpackCompilerName = 'client';
+      const options = createMockOptions(undefined);
+
+      mockCompileToJSX.mockResolvedValue({
+        content: 'result',
+        data: {},
+      });
+
+      // Call multiple times with same inputs
+      await Promise.all([
+        loadMDXWithCaching({
+          resource,
+          fileContent,
+          filePath,
+          options,
+          compilerName,
+        }),
+        loadMDXWithCaching({
+          resource,
+          fileContent,
+          filePath,
+          options,
+          compilerName,
+        }),
+        loadMDXWithCaching({
+          resource,
+          fileContent,
+          filePath,
+          options,
+          compilerName,
+        }),
+      ]);
+
+      // Should be called 3 times (no deduplication)
+      expect(options.markdownConfig.parseFrontMatter).toHaveBeenCalledTimes(3);
+      expect(mockCompileToJSX).toHaveBeenCalledTimes(3);
+    });
+
+    it('each call is independent (no shared state)', async () => {
+      const fileContent = 'test content';
+      const filePath = '/test/file.mdx';
+      const resource = '/test/file.mdx';
+      const compilerName: WebpackCompilerName = 'client';
+      const options = createMockOptions(undefined);
+
+      let callCount = 0;
+      mockCompileToJSX.mockImplementation(() => {
+        callCount += 1;
+        return Promise.resolve({
+          content: `result-${callCount}`,
+          data: {},
+        });
+      });
+
+      const results = await Promise.all([
+        loadMDXWithCaching({
+          resource,
+          fileContent,
+          filePath,
+          options,
+          compilerName,
+        }),
+        loadMDXWithCaching({
+          resource,
+          fileContent,
+          filePath,
+          options,
+          compilerName,
+        }),
+      ]);
+
+      // Each call should return a different result (no shared state)
+      expect(results[0]).toContain('result-1');
+      expect(results[1]).toContain('result-2');
+      expect(options.markdownConfig.parseFrontMatter).toHaveBeenCalledTimes(2);
+      expect(mockCompileToJSX).toHaveBeenCalledTimes(2);
+    });
+
+    it('handles when crossCompilerCache is missing from options', async () => {
+      const fileContent = 'test content';
+      const filePath = '/test/file.mdx';
+      const resource = '/test/file.mdx';
+      const compilerName: WebpackCompilerName = 'client';
+      const options: Options = {
+        markdownConfig: {
+          parseFrontMatter: jest.fn().mockResolvedValue({frontMatter: {}}),
+          mdx1Compat: {
+            headingIds: false,
+            admonitions: false,
+          },
+        } as unknown as Options['markdownConfig'],
+        staticDirs: [],
+        siteDir: '/test',
+        // crossCompilerCache is intentionally omitted
+      };
+
+      mockCompileToJSX.mockResolvedValue({
+        content: 'result',
+        data: {},
+      });
+
+      const result = await loadMDXWithCaching({
+        resource,
+        fileContent,
+        filePath,
+        options,
+        compilerName,
+      });
+
+      expect(options.markdownConfig.parseFrontMatter).toHaveBeenCalledTimes(1);
+      expect(mockCompileToJSX).toHaveBeenCalledTimes(1);
+      expect(result).toContain('result');
+    });
+
+    it('passes through errors from loadMDX', async () => {
+      const fileContent = 'test content';
+      const filePath = '/test/file.mdx';
+      const resource = '/test/file.mdx';
+      const compilerName: WebpackCompilerName = 'client';
+      const options = createMockOptions(undefined);
+      const error = new Error('compile error');
+
+      mockCompileToJSX.mockRejectedValue(error);
+
+      await expect(
+        loadMDXWithCaching({
+          resource,
+          fileContent,
+          filePath,
+          options,
+          compilerName,
+        }),
+      ).rejects.toThrow('compile error');
+
+      expect(options.markdownConfig.parseFrontMatter).toHaveBeenCalledTimes(1);
+      expect(mockCompileToJSX).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/docusaurus-mdx-loader/src/__tests__/loader.test.ts
+++ b/packages/docusaurus-mdx-loader/src/__tests__/loader.test.ts
@@ -53,7 +53,7 @@ describe('loadMDXWithCaching', () => {
       const filePath = '/test/file.mdx';
       const resource = '/test/file.mdx';
       const compilerName: WebpackCompilerName = 'client';
-      const options = createMockOptions(undefined);
+      const options = createMockOptions();
       const expectedContent = 'compiled result';
 
       mockCompileToJSX.mockResolvedValue({
@@ -86,7 +86,7 @@ describe('loadMDXWithCaching', () => {
       const filePath = '/test/file.mdx';
       const resource = '/test/file.mdx';
       const compilerName: WebpackCompilerName = 'client';
-      const options = createMockOptions(undefined);
+      const options = createMockOptions();
       const expectedContent = 'compiled result';
 
       mockCompileToJSX.mockResolvedValue({
@@ -117,7 +117,7 @@ describe('loadMDXWithCaching', () => {
       const filePath = '/test/file.mdx';
       const resource = '/test/file.mdx';
       const compilerName: WebpackCompilerName = 'server';
-      const options = createMockOptions(undefined);
+      const options = createMockOptions();
       const expectedContent = 'compiled result';
 
       mockCompileToJSX.mockResolvedValue({
@@ -143,7 +143,7 @@ describe('loadMDXWithCaching', () => {
       const filePath = '/test/file.mdx';
       const resource = '/test/file.mdx';
       const compilerName: WebpackCompilerName = 'client';
-      const options = createMockOptions(undefined);
+      const options = createMockOptions();
 
       mockCompileToJSX.mockResolvedValue({
         content: 'result',
@@ -185,7 +185,7 @@ describe('loadMDXWithCaching', () => {
       const filePath = '/test/file.mdx';
       const resource = '/test/file.mdx';
       const compilerName: WebpackCompilerName = 'client';
-      const options = createMockOptions(undefined);
+      const options = createMockOptions();
 
       let callCount = 0;
       mockCompileToJSX.mockImplementation(() => {
@@ -261,7 +261,7 @@ describe('loadMDXWithCaching', () => {
       const filePath = '/test/file.mdx';
       const resource = '/test/file.mdx';
       const compilerName: WebpackCompilerName = 'client';
-      const options = createMockOptions(undefined);
+      const options = createMockOptions();
       const error = new Error('compile error');
 
       mockCompileToJSX.mockRejectedValue(error);

--- a/packages/docusaurus-mdx-loader/src/__tests__/optionsBuilder.test.ts
+++ b/packages/docusaurus-mdx-loader/src/__tests__/optionsBuilder.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import path from 'path';
+import {createMDXLoaderOptionsBuilder} from '../options';
+
+describe('createMDXLoaderOptionsBuilder', () => {
+  it('produces the same options as manual assembly', () => {
+    const siteDir = '/mySite';
+    const siteConfig = {
+      staticDirectories: ['static', 'static2'],
+      markdown: {mermaid: true} as any,
+    };
+
+    const overrides = {
+      admonitions: true,
+      isMDXPartial: () => true,
+    } as const;
+
+    const built = createMDXLoaderOptionsBuilder({
+      siteDir,
+      siteConfig,
+      useCrossCompilerCache: true,
+    }).build(overrides as any);
+
+    const manual = {
+      siteDir,
+      staticDirs: siteConfig.staticDirectories.map((dir) =>
+        path.resolve(siteDir, dir),
+      ),
+      markdownConfig: siteConfig.markdown,
+      useCrossCompilerCache: true,
+      ...overrides,
+    };
+
+    expect(built).toEqual(manual);
+    expect(built).toMatchSnapshot();
+  });
+});

--- a/packages/docusaurus-mdx-loader/src/index.ts
+++ b/packages/docusaurus-mdx-loader/src/index.ts
@@ -42,3 +42,7 @@ export type LoadedMDXContent<FrontMatter, Metadata, Assets = undefined> = {
 export type {MDXPlugin} from './loader';
 export type {MDXOptions} from './processor';
 export type {Options} from './options';
+export {
+  createMDXLoaderOptionsBuilder,
+  type MDXLoaderOptionsBuilderSiteConfig,
+} from './options';

--- a/packages/docusaurus-mdx-loader/src/loader.ts
+++ b/packages/docusaurus-mdx-loader/src/loader.ts
@@ -232,3 +232,6 @@ export async function mdxLoader(
     return callback(error as Error);
   }
 }
+
+// Export for testing purposes
+export {loadMDX, loadMDXWithCaching};

--- a/packages/docusaurus-mdx-loader/src/loader.ts
+++ b/packages/docusaurus-mdx-loader/src/loader.ts
@@ -19,14 +19,10 @@ import {
   extractContentTitleData,
   promiseWithResolvers,
 } from './utils';
+import type {Pluggable} from 'unified';
 import type {WebpackCompilerName} from '@docusaurus/utils';
 import type {Options} from './options';
 import type {LoaderContext} from 'webpack';
-
-// TODO as of April 2023, no way to import/re-export this ESM type easily :/
-// This might change soon, likely after TS 5.2
-// See https://github.com/microsoft/TypeScript/issues/49721#issuecomment-1517839391
-type Pluggable = any; // TODO fix this asap
 
 export type MDXPlugin = Pluggable;
 

--- a/packages/docusaurus-mdx-loader/src/options.ts
+++ b/packages/docusaurus-mdx-loader/src/options.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import path from 'path';
 import type {MDXOptions, SimpleProcessors} from './processor';
 import type {MarkdownConfig} from '@docusaurus/types';
 import type {ResolveMarkdownLink} from './remark/resolveMarkdownLinks';
@@ -32,3 +33,43 @@ export type Options = Partial<MDXOptions> & {
 };
 
 type CrossCompilerCacheEntry = PromiseWithResolvers<string>;
+
+export type MDXLoaderOptionsBuilderSiteConfig = {
+  staticDirectories: string[];
+  markdown: MarkdownConfig;
+};
+
+export function createMDXLoaderOptionsBuilder({
+  siteDir,
+  siteConfig,
+  useCrossCompilerCache,
+}: {
+  siteDir: string;
+  siteConfig: MDXLoaderOptionsBuilderSiteConfig;
+  useCrossCompilerCache?: boolean;
+}): {
+  build: (
+    overrides: Omit<Options, 'siteDir' | 'staticDirs' | 'markdownConfig'>,
+  ) => Options;
+} {
+  const baseOptions: Pick<
+    Options,
+    'siteDir' | 'staticDirs' | 'markdownConfig' | 'useCrossCompilerCache'
+  > = {
+    siteDir,
+    staticDirs: siteConfig.staticDirectories.map((dir) =>
+      path.resolve(siteDir, dir),
+    ),
+    markdownConfig: siteConfig.markdown,
+    useCrossCompilerCache,
+  };
+
+  return {
+    build(overrides) {
+      return {
+        ...baseOptions,
+        ...overrides,
+      };
+    },
+  };
+}

--- a/packages/docusaurus-mdx-loader/src/processor.ts
+++ b/packages/docusaurus-mdx-loader/src/processor.ts
@@ -18,6 +18,7 @@ import transformAdmonitions from './remark/admonitions';
 import unusedDirectivesWarning from './remark/unusedDirectives';
 import codeCompatPlugin from './remark/mdx1Compat/codeCompatPlugin';
 import {getFormat} from './format';
+import type {Pluggable} from 'unified';
 import type {WebpackCompilerName} from '@docusaurus/utils';
 import type {MDXFrontMatter} from './frontMatter';
 import type {Options} from './options';
@@ -26,11 +27,6 @@ import type {PluginOptions as ResolveMarkdownLinksOptions} from './remark/resolv
 import type {PluginOptions as TransformLinksOptions} from './remark/transformLinks';
 import type {PluginOptions as TransformImageOptions} from './remark/transformImage';
 import type {ProcessorOptions} from '@mdx-js/mdx';
-
-// TODO as of April 2023, no way to import/re-export this ESM type easily :/
-// This might change soon, likely after TS 5.2
-// See https://github.com/microsoft/TypeScript/issues/49721#issuecomment-1517839391
-type Pluggable = any; // TODO fix this asap
 
 export type SimpleProcessorResult = {
   content: string;

--- a/packages/docusaurus-plugin-content-blog/src/client/sidebarUtils.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/client/sidebarUtils.test.ts
@@ -5,6 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/**
+ * @jest-environment jsdom
+ */
+
 import * as Router from '@docusaurus/router';
 import {renderHook} from '@testing-library/react';
 import {

--- a/packages/docusaurus-plugin-content-blog/src/client/sidebarUtils.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/client/sidebarUtils.test.ts
@@ -5,10 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/**
- * @jest-environment jsdom
- */
-
 import * as Router from '@docusaurus/router';
 import {renderHook} from '@testing-library/react';
 import {

--- a/packages/docusaurus-plugin-content-blog/src/client/sidebarUtils.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/client/sidebarUtils.test.ts
@@ -5,8 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {groupBlogSidebarItemsByYear} from './sidebarUtils';
+import * as Router from '@docusaurus/router';
+import {renderHook} from '@testing-library/react';
+import {
+  groupBlogSidebarItemsByYear,
+  isVisible,
+  useVisibleBlogSidebarItems,
+} from './sidebarUtils';
 import type {BlogSidebarItem} from '@docusaurus/plugin-content-blog';
+
+jest.mock('@docusaurus/router', () => ({
+  useLocation: jest.fn(),
+}));
 
 describe('groupBlogSidebarItemsByYear', () => {
   const post1: BlogSidebarItem = {
@@ -48,5 +58,81 @@ describe('groupBlogSidebarItemsByYear', () => {
       ['2024', [post1, post2]],
       ['2022', [post3]],
     ]);
+  });
+});
+
+describe('isVisible', () => {
+  const baseItem: BlogSidebarItem = {
+    title: 'post',
+    permalink: '/post',
+    date: '2024-01-01',
+    unlisted: false,
+  };
+
+  it('returns true for listed items', () => {
+    const result = isVisible(baseItem, '/any');
+    expect(result).toBe(true);
+  });
+
+  it('returns false for unlisted item when pathname does not match', () => {
+    const item: BlogSidebarItem = {
+      ...baseItem,
+      unlisted: true,
+    };
+
+    const result = isVisible(item, '/other');
+    expect(result).toBe(false);
+  });
+
+  it('returns true for unlisted item when pathname matches', () => {
+    const item: BlogSidebarItem = {
+      ...baseItem,
+      unlisted: true,
+    };
+
+    const result = isVisible(item, '/post');
+    expect(result).toBe(true);
+  });
+});
+
+describe('useVisibleBlogSidebarItems', () => {
+  const post1: BlogSidebarItem = {
+    title: 'post1',
+    permalink: '/post1',
+    date: '2024-01-01',
+    unlisted: false,
+  };
+
+  const post2: BlogSidebarItem = {
+    title: 'post2',
+    permalink: '/post2',
+    date: '2024-01-02',
+    unlisted: true,
+  };
+
+  const mockedUseLocation = jest.mocked(Router.useLocation);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('filters out unlisted items when pathname does not match', () => {
+    mockedUseLocation.mockReturnValue({pathname: '/other'} as any);
+
+    const {result} = renderHook(() =>
+      useVisibleBlogSidebarItems([post1, post2]),
+    );
+
+    expect(result.current).toEqual([post1]);
+  });
+
+  it('keeps unlisted item when pathname matches permalink', () => {
+    mockedUseLocation.mockReturnValue({pathname: '/post2'} as any);
+
+    const {result} = renderHook(() =>
+      useVisibleBlogSidebarItems([post1, post2]),
+    );
+
+    expect(result.current).toEqual([post1, post2]);
   });
 });

--- a/packages/docusaurus-plugin-content-blog/src/client/sidebarUtils.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/client/sidebarUtils.test.ts
@@ -3,8 +3,12 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment jsdom
  */
 
+// Jest doesn't allow pragma below other comments. https://github.com/facebook/jest/issues/12573
+// eslint-disable-next-line header/header
 import * as Router from '@docusaurus/router';
 import {renderHook} from '@testing-library/react';
 import {

--- a/packages/docusaurus-plugin-content-blog/src/client/sidebarUtils.tsx
+++ b/packages/docusaurus-plugin-content-blog/src/client/sidebarUtils.tsx
@@ -12,7 +12,7 @@ import {groupBy} from '@docusaurus/theme-common';
 import {isSamePath} from '@docusaurus/theme-common/internal';
 import type {BlogSidebarItem} from '@docusaurus/plugin-content-blog';
 
-function isVisible(item: BlogSidebarItem, pathname: string): boolean {
+export function isVisible(item: BlogSidebarItem, pathname: string): boolean {
   if (item.unlisted && !isSamePath(item.permalink, pathname)) {
     return false;
   }

--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -21,7 +21,10 @@ import {
   getLocaleConfig,
 } from '@docusaurus/utils';
 import {getTagsFilePathsToWatch} from '@docusaurus/utils-validation';
-import {createMDXLoaderItem} from '@docusaurus/mdx-loader';
+import {
+  createMDXLoaderItem,
+  createMDXLoaderOptionsBuilder,
+} from '@docusaurus/mdx-loader';
 import {
   getBlogTags,
   shouldBeListed,
@@ -112,56 +115,61 @@ export default async function pluginContentBlog(
 
     const contentDirs = getContentPathList(contentPaths);
 
-    const mdxLoaderItem = await createMDXLoaderItem({
+    const mdxOptionsBuilder = createMDXLoaderOptionsBuilder({
+      siteDir,
+      siteConfig,
       useCrossCompilerCache:
         siteConfig.future.experimental_faster.mdxCrossCompilerCache,
-      admonitions,
-      remarkPlugins,
-      rehypePlugins,
-      recmaPlugins,
-      beforeDefaultRemarkPlugins: [
-        footnoteIDFixer,
-        ...beforeDefaultRemarkPlugins,
-      ],
-      beforeDefaultRehypePlugins,
-      staticDirs: siteConfig.staticDirectories.map((dir) =>
-        path.resolve(siteDir, dir),
-      ),
-      siteDir,
-      isMDXPartial: createAbsoluteFilePathMatcher(options.exclude, contentDirs),
-      metadataPath: (mdxPath: string) => {
-        // Note that metadataPath must be the same/in-sync as
-        // the path from createData for each MDX.
-        const aliasedPath = aliasedSitePath(mdxPath, siteDir);
-        return path.join(dataDir, `${docuHash(aliasedPath)}.json`);
-      },
-      // For blog posts a title in markdown is always removed
-      // Blog posts title are rendered separately
-      removeContentTitle: true,
-      // createAssets converts relative paths to require() calls
-      createAssets: ({filePath}: {filePath: string}): Assets => {
-        const blogPost = contentHelpers.sourceToBlogPost.get(
-          aliasedSitePath(filePath, siteDir),
-        )!;
-        if (!blogPost) {
-          throw new Error(`Blog post not found for  filePath=${filePath}`);
-        }
-        return {
-          image: blogPost.metadata.frontMatter.image as string,
-          authorsImageUrls: blogPost.metadata.authors.map(
-            (author) => author.imageURL,
-          ),
-        };
-      },
-      markdownConfig: siteConfig.markdown,
-      resolveMarkdownLink: ({linkPathname, sourceFilePath}) => {
-        return resolveMarkdownLinkPathname(linkPathname, {
-          sourceFilePath,
-          sourceToPermalink: contentHelpers.sourceToPermalink,
-          siteDir,
-          contentPaths,
-        });
-      },
+    });
+
+    const mdxLoaderItem = await createMDXLoaderItem({
+      ...mdxOptionsBuilder.build({
+        admonitions,
+        remarkPlugins,
+        rehypePlugins,
+        recmaPlugins,
+        beforeDefaultRemarkPlugins: [
+          footnoteIDFixer,
+          ...beforeDefaultRemarkPlugins,
+        ],
+        beforeDefaultRehypePlugins,
+        isMDXPartial: createAbsoluteFilePathMatcher(
+          options.exclude,
+          contentDirs,
+        ),
+        metadataPath: (mdxPath: string) => {
+          // Note that metadataPath must be the same/in-sync as
+          // the path from createData for each MDX.
+          const aliasedPath = aliasedSitePath(mdxPath, siteDir);
+          return path.join(dataDir, `${docuHash(aliasedPath)}.json`);
+        },
+        // For blog posts a title in markdown is always removed
+        // Blog posts title are rendered separately
+        removeContentTitle: true,
+        // createAssets converts relative paths to require() calls
+        createAssets: ({filePath}: {filePath: string}): Assets => {
+          const blogPost = contentHelpers.sourceToBlogPost.get(
+            aliasedSitePath(filePath, siteDir),
+          )!;
+          if (!blogPost) {
+            throw new Error(`Blog post not found for  filePath=${filePath}`);
+          }
+          return {
+            image: blogPost.metadata.frontMatter.image as string,
+            authorsImageUrls: blogPost.metadata.authors.map(
+              (author) => author.imageURL,
+            ),
+          };
+        },
+        resolveMarkdownLink: ({linkPathname, sourceFilePath}) => {
+          return resolveMarkdownLinkPathname(linkPathname, {
+            sourceFilePath,
+            sourceToPermalink: contentHelpers.sourceToPermalink,
+            siteDir,
+            contentPaths,
+          });
+        },
+      }),
     });
 
     function createBlogMarkdownLoader(): RuleSetUseItem {

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
@@ -249,7 +249,9 @@ describe('simple site', () => {
   it('readVersionDocs', async () => {
     const {options, currentVersion} = await loadSite();
     const docs = await readVersionDocs(currentVersion, options);
-    expect(docs.map((doc) => doc.source).sort()).toEqual(
+    expect(
+      docs.map((doc) => doc.source).sort((a, b) => a.localeCompare(b)),
+    ).toEqual(
       [
         'hello.md',
         'ipsum.md',
@@ -273,7 +275,7 @@ describe('simple site', () => {
         'slugs/tryToEscapeSlug.md',
         'unlisted-category/index.md',
         'unlisted-category/unlisted-category-doc.md',
-      ].sort(),
+      ].sort((a, b) => a.localeCompare(b)),
     );
   });
 

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -19,7 +19,10 @@ import {
   DEFAULT_PLUGIN_ID,
 } from '@docusaurus/utils';
 import {getTagsFilePathsToWatch} from '@docusaurus/utils-validation';
-import {createMDXLoaderRule} from '@docusaurus/mdx-loader';
+import {
+  createMDXLoaderOptionsBuilder,
+  createMDXLoaderRule,
+} from '@docusaurus/mdx-loader';
 import {resolveSidebarPathOption} from './sidebars';
 import {CategoryMetadataFilenamePattern} from './sidebars/generator';
 import {type DocEnv} from './docs';
@@ -120,56 +123,57 @@ export default async function pluginContentDocs(
       // Trailing slash is important, see https://github.com/facebook/docusaurus/pull/3970
       .map(addTrailingPathSeparator);
 
+    const mdxOptionsBuilder = createMDXLoaderOptionsBuilder({
+      siteDir,
+      siteConfig,
+      useCrossCompilerCache:
+        siteConfig.future.experimental_faster.mdxCrossCompilerCache,
+    });
+
     return createMDXLoaderRule({
       include: contentDirs,
       options: {
-        dependencies: [
-          await createMdxLoaderDependencyFile({
-            dataDir,
-            options,
-            versionsMetadata,
+        ...mdxOptionsBuilder.build({
+          dependencies: [
+            await createMdxLoaderDependencyFile({
+              dataDir,
+              options,
+              versionsMetadata,
+            }),
+          ].filter((d): d is string => typeof d === 'string'),
+          admonitions: options.admonitions,
+          remarkPlugins,
+          rehypePlugins,
+          recmaPlugins,
+          beforeDefaultRehypePlugins,
+          beforeDefaultRemarkPlugins,
+          isMDXPartial: createAbsoluteFilePathMatcher(
+            options.exclude,
+            contentDirs,
+          ),
+          metadataPath: (mdxPath: string) => {
+            // Note that metadataPath must be the same/in-sync as
+            // the path from createData for each MDX.
+            const aliasedPath = aliasedSitePath(mdxPath, siteDir);
+            return path.join(dataDir, `${docuHash(aliasedPath)}.json`);
+          },
+          // createAssets converts relative paths to require() calls
+          createAssets: ({frontMatter}: {frontMatter: DocFrontMatter}) => ({
+            image: frontMatter.image,
           }),
-        ].filter((d): d is string => typeof d === 'string'),
-
-        useCrossCompilerCache:
-          siteConfig.future.experimental_faster.mdxCrossCompilerCache,
-        admonitions: options.admonitions,
-        remarkPlugins,
-        rehypePlugins,
-        recmaPlugins,
-        beforeDefaultRehypePlugins,
-        beforeDefaultRemarkPlugins,
-        staticDirs: siteConfig.staticDirectories.map((dir) =>
-          path.resolve(siteDir, dir),
-        ),
-        siteDir,
-        isMDXPartial: createAbsoluteFilePathMatcher(
-          options.exclude,
-          contentDirs,
-        ),
-        metadataPath: (mdxPath: string) => {
-          // Note that metadataPath must be the same/in-sync as
-          // the path from createData for each MDX.
-          const aliasedPath = aliasedSitePath(mdxPath, siteDir);
-          return path.join(dataDir, `${docuHash(aliasedPath)}.json`);
-        },
-        // createAssets converts relative paths to require() calls
-        createAssets: ({frontMatter}: {frontMatter: DocFrontMatter}) => ({
-          image: frontMatter.image,
+          resolveMarkdownLink: ({linkPathname, sourceFilePath}) => {
+            const version = getVersionFromSourceFilePath(
+              sourceFilePath,
+              versionsMetadata,
+            );
+            return resolveMarkdownLinkPathname(linkPathname, {
+              sourceFilePath,
+              sourceToPermalink: contentHelpers.sourceToPermalink,
+              siteDir,
+              contentPaths: version,
+            });
+          },
         }),
-        markdownConfig: siteConfig.markdown,
-        resolveMarkdownLink: ({linkPathname, sourceFilePath}) => {
-          const version = getVersionFromSourceFilePath(
-            sourceFilePath,
-            versionsMetadata,
-          );
-          return resolveMarkdownLinkPathname(linkPathname, {
-            sourceFilePath,
-            sourceToPermalink: contentHelpers.sourceToPermalink,
-            siteDir,
-            contentPaths: version,
-          });
-        },
       },
     });
   }

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/utils.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/utils.ts
@@ -181,6 +181,99 @@ export type SidebarsUtils = {
   }) => void;
 };
 
+function emptySidebarNavigation(): SidebarNavigation {
+  return {
+    sidebarName: undefined,
+    previous: undefined,
+    next: undefined,
+  };
+}
+
+// remove in Docusaurus v4
+function getLegacyVersionedPrefix(versionMetadata: VersionMetadata): string {
+  return `version-${versionMetadata.versionName}/`;
+}
+
+// throw a better error message for Docusaurus v3 breaking change
+// this can be removed in Docusaurus v4
+function handleLegacyVersionedDocIds({
+  invalidDocIds,
+  sidebarFilePath,
+  versionMetadata,
+}: {
+  invalidDocIds: string[];
+  sidebarFilePath: string;
+  versionMetadata: VersionMetadata;
+}) {
+  const illegalPrefix = getLegacyVersionedPrefix(versionMetadata);
+
+  // In older v2.0 alpha/betas, versioned docs had a legacy versioned prefix
+  // Example: "version-1.4/my-doc-id"
+  //
+  const legacyVersionedDocIds = invalidDocIds.filter((docId) =>
+    docId.startsWith(illegalPrefix),
+  );
+  if (legacyVersionedDocIds.length > 0) {
+    throw new Error(
+      `Invalid sidebar file at "${toMessageRelativeFilePath(sidebarFilePath)}".
+These legacy versioned document ids are not supported anymore in Docusaurus v3:
+- ${legacyVersionedDocIds.toSorted().join('\n- ')}
+
+The document ids you should now use are:
+- ${legacyVersionedDocIds
+        .toSorted()
+        .map((legacyId) => legacyId.split('/').splice(1).join('/'))
+        .join('\n- ')}
+
+Please remove the "${illegalPrefix}" prefix from your versioned sidebar file.
+This breaking change is documented on Docusaurus v3 release notes: https://docusaurus.io/blog/releases/3.0
+`,
+    );
+  }
+}
+
+function getFirstLink(sidebar: Sidebar):
+  | {
+      type: 'doc';
+      id: string;
+      label: string;
+    }
+  | {
+      type: 'generated-index';
+      permalink: string;
+      label: string;
+    }
+  | undefined {
+  for (const item of sidebar) {
+    if (item.type === 'doc') {
+      return {
+        type: 'doc',
+        id: item.id,
+        label: item.label ?? item.id,
+      };
+    } else if (item.type === 'category') {
+      if (item.link?.type === 'doc') {
+        return {
+          type: 'doc',
+          id: item.link.id,
+          label: item.label,
+        };
+      } else if (item.link?.type === 'generated-index') {
+        return {
+          type: 'generated-index',
+          permalink: item.link.permalink,
+          label: item.label,
+        };
+      }
+      const firstSubItem = getFirstLink(item.items);
+      if (firstSubItem) {
+        return firstSubItem;
+      }
+    }
+  }
+  return undefined;
+}
+
 export function createSidebarsUtils(sidebars: Sidebars): SidebarsUtils {
   const sidebarNameToDocIds = collectSidebarsDocIds(sidebars);
   const sidebarNameToNavigationItems = collectSidebarsNavigations(sidebars);
@@ -198,14 +291,6 @@ export function createSidebarsUtils(sidebars: Sidebars): SidebarsUtils {
 
   function getSidebarNameByDocId(docId: string): string | undefined {
     return docIdToSidebarName[docId];
-  }
-
-  function emptySidebarNavigation(): SidebarNavigation {
-    return {
-      sidebarName: undefined,
-      previous: undefined,
-      next: undefined,
-    };
   }
 
   function getDocNavigation({
@@ -310,15 +395,10 @@ export function createSidebarsUtils(sidebars: Sidebars): SidebarsUtils {
     };
   }
 
-  // TODO remove in Docusaurus v4
-  function getLegacyVersionedPrefix(versionMetadata: VersionMetadata): string {
-    return `version-${versionMetadata.versionName}/`;
-  }
-
   // In early v2, sidebar names used to be versioned
   // example: "version-2.0.0-alpha.66/my-sidebar-name"
   // In v3 it's not the case anymore and we throw an error to explain
-  // TODO remove in Docusaurus v4
+  // remove in Docusaurus v4
   function checkLegacyVersionedSidebarNames({
     versionMetadata,
     sidebarFilePath,
@@ -336,52 +416,12 @@ export function createSidebarsUtils(sidebars: Sidebars): SidebarsUtils {
           sidebarFilePath,
         )}".
 These legacy versioned sidebar names are not supported anymore in Docusaurus v3:
-- ${legacySidebarNames.sort().join('\n- ')}
+- ${legacySidebarNames.toSorted().join('\n- ')}
 
 The sidebar names you should now use are:
 - ${legacySidebarNames
-          .sort()
+          .toSorted()
           .map((legacyName) => legacyName.split('/').splice(1).join('/'))
-          .join('\n- ')}
-
-Please remove the "${illegalPrefix}" prefix from your versioned sidebar file.
-This breaking change is documented on Docusaurus v3 release notes: https://docusaurus.io/blog/releases/3.0
-`,
-      );
-    }
-  }
-
-  // throw a better error message for Docusaurus v3 breaking change
-  // TODO this can be removed in Docusaurus v4
-  function handleLegacyVersionedDocIds({
-    invalidDocIds,
-    sidebarFilePath,
-    versionMetadata,
-  }: {
-    invalidDocIds: string[];
-    sidebarFilePath: string;
-    versionMetadata: VersionMetadata;
-  }) {
-    const illegalPrefix = getLegacyVersionedPrefix(versionMetadata);
-
-    // In older v2.0 alpha/betas, versioned docs had a legacy versioned prefix
-    // Example: "version-1.4/my-doc-id"
-    //
-    const legacyVersionedDocIds = invalidDocIds.filter((docId) =>
-      docId.startsWith(illegalPrefix),
-    );
-    if (legacyVersionedDocIds.length > 0) {
-      throw new Error(
-        `Invalid sidebar file at "${toMessageRelativeFilePath(
-          sidebarFilePath,
-        )}".
-These legacy versioned document ids are not supported anymore in Docusaurus v3:
-- ${legacyVersionedDocIds.sort().join('\n- ')}
-
-The document ids you should now use are:
-- ${legacyVersionedDocIds
-          .sort()
-          .map((legacyId) => legacyId.split('/').splice(1).join('/'))
           .join('\n- ')}
 
 Please remove the "${illegalPrefix}" prefix from your versioned sidebar file.
@@ -414,55 +454,13 @@ This breaking change is documented on Docusaurus v3 release notes: https://docus
           sidebarFilePath,
         )}".
 These sidebar document ids do not exist:
-- ${invalidDocIds.sort().join('\n- ')}
+- ${invalidDocIds.toSorted().join('\n- ')}
 
 Available document ids are:
-- ${_.uniq(allDocIds).sort().join('\n- ')}
+- ${_.uniq(allDocIds).toSorted().join('\n- ')}
 `,
       );
     }
-  }
-
-  function getFirstLink(sidebar: Sidebar):
-    | {
-        type: 'doc';
-        id: string;
-        label: string;
-      }
-    | {
-        type: 'generated-index';
-        permalink: string;
-        label: string;
-      }
-    | undefined {
-    for (const item of sidebar) {
-      if (item.type === 'doc') {
-        return {
-          type: 'doc',
-          id: item.id,
-          label: item.label ?? item.id,
-        };
-      } else if (item.type === 'category') {
-        if (item.link?.type === 'doc') {
-          return {
-            type: 'doc',
-            id: item.link.id,
-            label: item.label,
-          };
-        } else if (item.link?.type === 'generated-index') {
-          return {
-            type: 'generated-index',
-            permalink: item.link.permalink,
-            label: item.label,
-          };
-        }
-        const firstSubItem = getFirstLink(item.items);
-        if (firstSubItem) {
-          return firstSubItem;
-        }
-      }
-    }
-    return undefined;
   }
 
   return {

--- a/packages/docusaurus-plugin-content-pages/src/index.ts
+++ b/packages/docusaurus-plugin-content-pages/src/index.ts
@@ -15,7 +15,10 @@ import {
   getContentPathList,
   resolveMarkdownLinkPathname,
 } from '@docusaurus/utils';
-import {createMDXLoaderRule} from '@docusaurus/mdx-loader';
+import {
+  createMDXLoaderOptionsBuilder,
+  createMDXLoaderRule,
+} from '@docusaurus/mdx-loader';
 import {createAllRoutes} from './routes';
 import {createPagesContentPaths, loadPagesContent} from './content';
 import {createContentHelpers} from './contentHelpers';
@@ -53,46 +56,48 @@ export default async function pluginContentPages(
     } = options;
     const contentDirs = getContentPathList(contentPaths);
 
+    const mdxOptionsBuilder = createMDXLoaderOptionsBuilder({
+      siteDir,
+      siteConfig,
+      useCrossCompilerCache:
+        siteConfig.future.experimental_faster.mdxCrossCompilerCache,
+    });
+
     return createMDXLoaderRule({
       include: contentDirs
         // Trailing slash is important, see https://github.com/facebook/docusaurus/pull/3970
         .map(addTrailingPathSeparator),
       options: {
-        useCrossCompilerCache:
-          siteConfig.future.experimental_faster.mdxCrossCompilerCache,
-        admonitions,
-        remarkPlugins,
-        rehypePlugins,
-        recmaPlugins,
-        beforeDefaultRehypePlugins,
-        beforeDefaultRemarkPlugins,
-        staticDirs: siteConfig.staticDirectories.map((dir) =>
-          path.resolve(siteDir, dir),
-        ),
-        siteDir,
-        isMDXPartial: createAbsoluteFilePathMatcher(
-          options.exclude,
-          contentDirs,
-        ),
-        metadataPath: (mdxPath: string) => {
-          // Note that metadataPath must be the same/in-sync as
-          // the path from createData for each MDX.
-          const aliasedSource = aliasedSitePath(mdxPath, siteDir);
-          return path.join(dataDir, `${docuHash(aliasedSource)}.json`);
-        },
-        // createAssets converts relative paths to require() calls
-        createAssets: ({frontMatter}: {frontMatter: PageFrontMatter}) => ({
-          image: frontMatter.image,
+        ...mdxOptionsBuilder.build({
+          admonitions,
+          remarkPlugins,
+          rehypePlugins,
+          recmaPlugins,
+          beforeDefaultRehypePlugins,
+          beforeDefaultRemarkPlugins,
+          isMDXPartial: createAbsoluteFilePathMatcher(
+            options.exclude,
+            contentDirs,
+          ),
+          metadataPath: (mdxPath: string) => {
+            // Note that metadataPath must be the same/in-sync as
+            // the path from createData for each MDX.
+            const aliasedSource = aliasedSitePath(mdxPath, siteDir);
+            return path.join(dataDir, `${docuHash(aliasedSource)}.json`);
+          },
+          // createAssets converts relative paths to require() calls
+          createAssets: ({frontMatter}: {frontMatter: PageFrontMatter}) => ({
+            image: frontMatter.image,
+          }),
+          resolveMarkdownLink: ({linkPathname, sourceFilePath}) => {
+            return resolveMarkdownLinkPathname(linkPathname, {
+              sourceFilePath,
+              sourceToPermalink: contentHelpers.sourceToPermalink,
+              siteDir,
+              contentPaths,
+            });
+          },
         }),
-        markdownConfig: siteConfig.markdown,
-        resolveMarkdownLink: ({linkPathname, sourceFilePath}) => {
-          return resolveMarkdownLinkPathname(linkPathname, {
-            sourceFilePath,
-            sourceToPermalink: contentHelpers.sourceToPermalink,
-            siteDir,
-            contentPaths,
-          });
-        },
       },
     });
   }

--- a/packages/docusaurus-plugin-google-gtag/src/__tests__/options.test.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/__tests__/options.test.ts
@@ -11,8 +11,13 @@ import {
   type PluginOptions,
   type Options,
   DEFAULT_OPTIONS,
+  validateThemeConfig,
 } from '../options';
-import type {Validate} from '@docusaurus/types';
+import type {
+  ThemeConfig,
+  ThemeConfigValidationContext,
+  Validate,
+} from '@docusaurus/types';
 
 function testValidateOptions(options: Options) {
   return validateOptions({
@@ -31,6 +36,12 @@ function validationResult(options: Options) {
         ? [options.trackingID]
         : options.trackingID,
   };
+}
+
+function testValidateThemeConfig(themeConfig: ThemeConfig) {
+  return validateThemeConfig({
+    themeConfig,
+  } as ThemeConfigValidationContext<ThemeConfig>);
 }
 
 const MinimalConfig: Options = {
@@ -151,6 +162,50 @@ describe('validateOptions', () => {
       testValidateOptions(config),
     ).toThrowErrorMatchingInlineSnapshot(
       `""trackingID" does not match any of the allowed types"`,
+    );
+  });
+});
+
+describe('validateThemeConfig', () => {
+  it('returns themeConfig if no gtag field is present', () => {
+    const config = {
+      navbar: {
+        title: 'My Site',
+      },
+    } as ThemeConfig;
+
+    expect(testValidateThemeConfig(config)).toBe(config);
+  });
+
+  it('returns empty object if no gtag field is present', () => {
+    const config = {} as ThemeConfig;
+
+    expect(testValidateThemeConfig(config)).toBe(config);
+  });
+
+  it('throws if gtag field is present', () => {
+    const config = {
+      gtag: {
+        trackingID: 'G-XYZ12345',
+      },
+    } as ThemeConfig;
+
+    expect(() =>
+      testValidateThemeConfig(config),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"The "gtag" field in themeConfig should now be specified as option for plugin-google-gtag. More information at https://github.com/facebook/docusaurus/pull/5832."`,
+    );
+  });
+
+  it('throws even if gtag is undefined', () => {
+    const config = {
+      gtag: undefined,
+    } as ThemeConfig;
+
+    expect(() =>
+      testValidateThemeConfig(config),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"The "gtag" field in themeConfig should now be specified as option for plugin-google-gtag. More information at https://github.com/facebook/docusaurus/pull/5832."`,
     );
   });
 });

--- a/packages/docusaurus-plugin-ideal-image/src/theme/IdealImageLegacy/__tests__/helpers.js
+++ b/packages/docusaurus-plugin-ideal-image/src/theme/IdealImageLegacy/__tests__/helpers.js
@@ -2,7 +2,6 @@ import {
   // guessMaxImageWidth,
   bytesToSize,
   selectSrc,
-  fallbackParams,
 } from '../components/helpers';
 
 /*
@@ -168,18 +167,3 @@ describe('selectSrc', () => {
     expect(result).toEqual(expected);
   });
 });
-
-/*
-describe('fallbackParams', () => {
-  it('Should return an empty object when run in the browser environment', () => {
-    const result = fallbackParams({
-      srcSet: [
-        {
-          format: 'webp',
-        },
-      ],
-    });
-    expect(result).toEqual({});
-  });
-});
- */

--- a/packages/docusaurus-plugin-ideal-image/src/theme/IdealImageLegacy/components/IdealImage/index.js
+++ b/packages/docusaurus-plugin-ideal-image/src/theme/IdealImageLegacy/components/IdealImage/index.js
@@ -51,11 +51,7 @@ const defaultGetMessage = (icon, state) => {
       const {pickedSrc} = state;
       const {size} = pickedSrc;
       if (size) {
-        return [
-          'Click to load (',
-          <nobr key="nb">{bytesToSize(size)}</nobr>,
-          ')',
-        ];
+        return `Click to load (${bytesToSize(size)})`;
       } else {
         return 'Click to load';
       }

--- a/packages/docusaurus-plugin-ideal-image/src/theme/IdealImageLegacy/components/unfetch.js
+++ b/packages/docusaurus-plugin-ideal-image/src/theme/IdealImageLegacy/components/unfetch.js
@@ -54,7 +54,7 @@ export const unfetch = (url, options) => {
 
       return {
         // eslint-disable-next-line no-bitwise
-        ok: ((request.status / 100) | 0) === 2, // 200-299
+        ok: Math.trunc(request.status / 100) === 2, // 200-299
         status: request.status,
         statusText: request.statusText,
         url: request.responseURL,

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.tsx
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.tsx
@@ -238,7 +238,7 @@ function getSearchPageTitle(searchQuery: string | undefined): string {
       });
 }
 
-function SearchPageContent(): ReactNode {
+function useAlgoliaSearchPage() {
   const {
     i18n: {currentLocale},
   } = useDocusaurusContext();
@@ -246,7 +246,6 @@ function SearchPageContent(): ReactNode {
     algolia: {appId, apiKey, indexName, contextualSearch},
   } = useAlgoliaThemeConfig();
   const processSearchResultUrl = useSearchResultUrlProcessor();
-  const documentsFoundPlural = useDocumentsFoundPlural();
 
   const docsSearchVersionsHelpers = useDocsSearchVersionsHelpers();
   const [searchQuery, setSearchQuery] = useSearchQueryString();
@@ -438,6 +437,29 @@ function SearchPageContent(): ReactNode {
 
     makeSearch(searchResultState.lastPage);
   }, [makeSearch, searchResultState.lastPage]);
+
+  return {
+    searchQuery,
+    setSearchQuery,
+    searchResultState,
+    setLoaderRef,
+    docsSearchVersionsHelpers,
+    pageTitle,
+    contextualSearch,
+  };
+}
+
+function SearchPageContent(): ReactNode {
+  const documentsFoundPlural = useDocumentsFoundPlural();
+  const {
+    searchQuery,
+    setSearchQuery,
+    searchResultState,
+    setLoaderRef,
+    docsSearchVersionsHelpers,
+    pageTitle,
+    contextualSearch,
+  } = useAlgoliaSearchPage();
 
   return (
     <Layout>

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.tsx
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.tsx
@@ -238,6 +238,58 @@ function getSearchPageTitle(searchQuery: string | undefined): string {
       });
 }
 
+function useInfiniteScroll(
+  onLoadMore: () => void,
+): (node: HTMLDivElement | null) => void {
+  const [loaderRef, setLoaderRef] = useState<HTMLDivElement | null>(null);
+  const prevY = useRef(0);
+  const onLoadMoreRef = useRef(onLoadMore);
+
+  useEffect(() => {
+    onLoadMoreRef.current = onLoadMore;
+  }, [onLoadMore]);
+
+  const observer = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    if (!ExecutionEnvironment.canUseIntersectionObserver) {
+      return undefined;
+    }
+
+    observer.current = new IntersectionObserver(
+      (entries) => {
+        const {
+          isIntersecting,
+          boundingClientRect: {y: currentY},
+        } = entries[0]!;
+
+        if (isIntersecting && prevY.current > currentY) {
+          onLoadMoreRef.current();
+        }
+
+        prevY.current = currentY;
+      },
+      {threshold: 1},
+    );
+
+    return () => {
+      observer.current?.disconnect();
+      observer.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const currentObserver = observer.current;
+    if (!loaderRef || !currentObserver) {
+      return undefined;
+    }
+    currentObserver.observe(loaderRef);
+    return () => currentObserver.unobserve(loaderRef);
+  }, [loaderRef]);
+
+  return setLoaderRef;
+}
+
 function useAlgoliaSearchPage() {
   const {
     i18n: {currentLocale},
@@ -365,28 +417,9 @@ function useAlgoliaSearchPage() {
     },
   );
 
-  const [loaderRef, setLoaderRef] = useState<HTMLDivElement | null>(null);
-  const prevY = useRef(0);
-  const observer = useRef(
-    ExecutionEnvironment.canUseIntersectionObserver &&
-      new IntersectionObserver(
-        // TODO need to fix this React Compiler lint error
-        // eslint-disable-next-line react-compiler/react-compiler
-        (entries) => {
-          const {
-            isIntersecting,
-            boundingClientRect: {y: currentY},
-          } = entries[0]!;
-
-          if (isIntersecting && prevY.current > currentY) {
-            searchResultStateDispatcher({type: 'advance'});
-          }
-
-          prevY.current = currentY;
-        },
-        {threshold: 1},
-      ),
-  );
+  const setLoaderRef = useInfiniteScroll(() => {
+    searchResultStateDispatcher({type: 'advance'});
+  });
 
   const makeSearch = useEvent((page: number = 0) => {
     if (contextualSearch) {
@@ -405,18 +438,6 @@ function useAlgoliaSearchPage() {
 
     algoliaHelper.setQuery(searchQuery).setPage(page).search();
   });
-
-  useEffect(() => {
-    if (!loaderRef) {
-      return undefined;
-    }
-    const currentObserver = observer.current;
-    if (currentObserver) {
-      currentObserver.observe(loaderRef);
-      return () => currentObserver.unobserve(loaderRef);
-    }
-    return () => true;
-  }, [loaderRef]);
 
   useEffect(() => {
     searchResultStateDispatcher({type: 'reset'});
@@ -442,7 +463,7 @@ function useAlgoliaSearchPage() {
     searchQuery,
     setSearchQuery,
     searchResultState,
-    setLoaderRef,
+    setLoaderRef, // the useState setter used as a callback ref
     docsSearchVersionsHelpers,
     pageTitle,
     contextualSearch,

--- a/packages/docusaurus-utils/src/i18nUtils.ts
+++ b/packages/docusaurus-utils/src/i18nUtils.ts
@@ -54,7 +54,7 @@ export function getPluginI18nPath({
 }: {
   localizationDir: string;
   pluginName: string;
-  pluginId?: string | undefined;
+  pluginId?: string;
   subPaths?: string[];
 }): string {
   return path.join(

--- a/packages/docusaurus-utils/src/markdownUtils.ts
+++ b/packages/docusaurus-utils/src/markdownUtils.ts
@@ -105,13 +105,23 @@ export function admonitionTitleToDirectiveLabel(
     'gm',
   );
 
-  return content.replaceAll(regexp, (substring, ...args: any[]) => {
-    const groups = args.at(-1);
+  type AdmonitionTitleGroups = {
+    quote: string | undefined;
+    indentation: string | undefined;
+    directive: string;
+    title: string;
+  };
 
-    return `${groups.quote ?? ''}${groups.indentation ?? ''}${
-      groups.directive
-    }[${groups.title}]`;
-  });
+  return content.replaceAll(
+    regexp,
+    (_substring: string, ..._args: unknown[]) => {
+      const groups = _args.at(-1) as AdmonitionTitleGroups;
+
+      return `${groups.quote ?? ''}${groups.indentation ?? ''}${
+        groups.directive
+      }[${groups.title}]`;
+    },
+  );
 }
 
 // TODO: Find a better way to do so, possibly by compiling the Markdown content,

--- a/packages/docusaurus-utils/src/markdownUtils.ts
+++ b/packages/docusaurus-utils/src/markdownUtils.ts
@@ -74,9 +74,14 @@ export function unwrapMdxCodeBlocks(content: string): string {
   const regexp4 =
     /(?<begin>^|\r?\n)(?<indentStart>\x20*)````(?<spaces>\x20*)mdx-code-block\r?\n(?<children>.*?)\r?\n(?<indentEnd>\x20*)````(?<end>\r?\n|$)/gs;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const replacer = (substring: string, ...args: any[]) => {
-    const groups = args.at(-1);
+  type MdxCodeBlockGroups = {
+    begin: string;
+    children: string;
+    end: string;
+  };
+
+  const replacer = (_substring: string, ..._args: unknown[]): string => {
+    const groups = _args.at(-1) as MdxCodeBlockGroups;
     return `${groups.begin}${groups.children}${groups.end}`;
   };
 

--- a/packages/docusaurus-utils/src/vcs/gitUtils.ts
+++ b/packages/docusaurus-utils/src/vcs/gitUtils.ts
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import path from 'node:path';
 import fs from 'fs-extra';
-import os from 'os';
+import os from 'node:os';
 import _ from 'lodash';
 import execa from 'execa';
 import PQueue from 'p-queue';
@@ -16,13 +16,13 @@ import logger from '@docusaurus/logger';
 // Quite high/conservative concurrency value (it was previously "Infinity")
 // See https://github.com/facebook/docusaurus/pull/10915
 const DefaultGitCommandConcurrency =
-  // TODO Docusaurus v4: bump node, availableParallelism() now always exists
+  // Task for Docusaurus v4: bump node, availableParallelism() now always exists
   (typeof os.availableParallelism === 'function'
     ? os.availableParallelism()
     : os.cpus().length) * 4;
 
 const GitCommandConcurrencyEnv = process.env.DOCUSAURUS_GIT_COMMAND_CONCURRENCY
-  ? parseInt(process.env.DOCUSAURUS_GIT_COMMAND_CONCURRENCY, 10)
+  ? Number.parseInt(process.env.DOCUSAURUS_GIT_COMMAND_CONCURRENCY, 10)
   : undefined;
 
 const GitCommandConcurrency =
@@ -38,9 +38,10 @@ const GitCommandQueue = new PQueue({
 
 const realHasGitFn = () => {
   try {
-    return execa.sync('git', ['--version']).exitCode === 0;
+    const result = execa.sync('git', ['--version'], {stdio: 'pipe'});
+    return {hasGit: result.exitCode === 0, error: null};
   } catch (error) {
-    return false;
+    return {hasGit: false, error};
   }
 };
 
@@ -49,12 +50,12 @@ const realHasGitFn = () => {
 const hasGit =
   process.env.NODE_ENV === 'test' ? realHasGitFn : _.memoize(realHasGitFn);
 
-// TODO Docusaurus v4: remove this
+// task: Docusaurus v4: remove this
 //  Exceptions are not made for control flow logic
 /** Custom error thrown when git is not found in `PATH`. */
 export class GitNotFoundError extends Error {}
 
-// TODO Docusaurus v4: remove this, only kept for retro-compatibility
+// task: Docusaurus v4: remove this, only kept for retro-compatibility
 //  Exceptions are not made for control flow logic
 /** Custom error thrown when the current file is not tracked by git. */
 export class FileNotTrackedError extends Error {}
@@ -83,7 +84,7 @@ export async function getFileCommitDate(
   },
 ): Promise<{
   /** Relevant commit date. */
-  date: Date; // TODO duplicate data, not really useful?
+  date: Date; // duplicate data, not really useful?
   /** Timestamp returned from git, converted to **milliseconds**. */
   timestamp: number;
 }>;
@@ -227,7 +228,7 @@ async function getGitCommitInfo(
     });
     return {timestamp: result.timestamp, author: result.author};
   } catch (err) {
-    // TODO legacy perf issue: do not use exceptions for control flow!
+    // Task: legacy perf issue: do not use exceptions for control flow!
     if (err instanceof GitNotFoundError) {
       if (!showedGitRequirementError) {
         logger.warn('Sorry, the last update options require Git.');
@@ -451,7 +452,7 @@ export async function getGitRepositoryFilesInfo(
     {
       cwd,
       encoding: 'utf-8',
-      // TODO use streaming to avoid a large buffer
+      // Task: use streaming to avoid a large buffer
       // See https://github.com/withastro/starlight/issues/3154
       maxBuffer: 20 * 1024 * 1024,
     },
@@ -468,7 +469,7 @@ The command exited with code ${result.exitCode}: ${result.stderr}`,
 
   const now = Date.now();
 
-  // TODO not fail-fast
+  // Task: not fail-fast
   let runningDate = now;
   let runningAuthor = 'N/A';
   const runningMap: GitFileInfoMap = new Map();
@@ -484,7 +485,7 @@ The command exited with code ${result.exitCode}: ${result.stderr}`,
       runningAuthor = author;
     }
 
-    // TODO the code below doesn't handle delete/move/rename operations properly
+    // Task: the code below doesn't handle delete/move/rename operations properly
     //  it returns files that no longer exist in the repo (deleted/moved)
 
     // - Added files take the format `A\t<file>`

--- a/packages/docusaurus/src/commands/__tests__/cli.test.ts
+++ b/packages/docusaurus/src/commands/__tests__/cli.test.ts
@@ -7,7 +7,7 @@
 
 import path from 'path';
 import {Command, type CommanderStatic} from 'commander';
-import {createCLIProgram} from '../cli';
+import {createCLIProgram, isInternalCommand, normalizePollValue} from '../cli';
 
 const ExitOverrideError = new Error('exitOverride');
 
@@ -222,6 +222,78 @@ describe('CLI', () => {
         ",
         }
       `);
+    });
+  });
+
+  describe('isInternalCommand', () => {
+    const validCommands = [
+      'start',
+      'build',
+      'swizzle',
+      'deploy',
+      'serve',
+      'clear',
+      'write-translations',
+      'write-heading-ids',
+    ];
+
+    const invalidCommands = [
+      'random',
+      ' ',
+      'undefined',
+      '123',
+      'build ',
+      'START',
+    ];
+
+    describe('valid internal commands', () => {
+      it.each(validCommands)('docusaurus %s', (command) => {
+        const result = isInternalCommand(command);
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('invalid internal commands', () => {
+      it.each(invalidCommands)('docusaurus %s', (command) => {
+        const result = isInternalCommand(command);
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('normalizePollValue', () => {
+    describe('empty or undefined values', () => {
+      it('returns false when value is undefined', () => {
+        expect(normalizePollValue(undefined)).toBe(false);
+      });
+
+      it('returns false when value is empty string', () => {
+        expect(normalizePollValue('')).toBe(false);
+      });
+    });
+
+    describe('numeric values', () => {
+      it('parses integer string correctly', () => {
+        expect(normalizePollValue('42')).toBe(42);
+      });
+
+      it('parses integer with leading zeros', () => {
+        expect(normalizePollValue('007')).toBe(7);
+      });
+
+      it('parses negative integers', () => {
+        expect(normalizePollValue('-10')).toBe(-10);
+      });
+    });
+
+    describe('boolean values', () => {
+      it('returns true when value is "true"', () => {
+        expect(normalizePollValue('true')).toBe(true);
+      });
+
+      it('returns false when value is "false"', () => {
+        expect(normalizePollValue('false')).toBe(false);
+      });
     });
   });
 });

--- a/packages/docusaurus/src/commands/cli.ts
+++ b/packages/docusaurus/src/commands/cli.ts
@@ -23,7 +23,18 @@ function concatLocaleOptions(locale: string, locales: string[] = []): string[] {
   return locales.concat(locale);
 }
 
-function isInternalCommand(command: string | undefined) {
+export function normalizePollValue(value?: string) {
+  if (value === undefined || value === '') {
+    return false;
+  }
+  const parsedIntValue = Number.parseInt(value, 10);
+  if (!Number.isNaN(parsedIntValue)) {
+    return parsedIntValue;
+  }
+  return value === 'true';
+}
+
+export function isInternalCommand(command: string | undefined) {
   return (
     command &&
     [
@@ -167,17 +178,6 @@ export async function createCLIProgram({
       'path to the target directory to deploy to (default: `.`)',
     )
     .action(deploy);
-
-  function normalizePollValue(value?: string) {
-    if (value === undefined || value === '') {
-      return false;
-    }
-    const parsedIntValue = Number.parseInt(value, 10);
-    if (!Number.isNaN(parsedIntValue)) {
-      return parsedIntValue;
-    }
-    return value === 'true';
-  }
 
   cli
     .command('start [siteDir]')

--- a/packages/docusaurus/src/commands/swizzle/__tests__/common.test.ts
+++ b/packages/docusaurus/src/commands/swizzle/__tests__/common.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {findStringIgnoringCase, findClosestValue} from '../common';
+
+describe('findStringIgnoringCase', () => {
+  it('exact match', () => {
+    const matches = findStringIgnoringCase('foo', ['foo', 'bar']);
+    expect(matches).toBe('foo');
+  });
+
+  it('different case match', () => {
+    const matches = findStringIgnoringCase('Foo', ['foo', 'bar']);
+    expect(matches).toBe('foo');
+  });
+
+  it('close but not a match', () => {
+    const matches = findStringIgnoringCase('fo', ['foo', 'bar']);
+    expect(matches).toBe(undefined);
+  });
+
+  it('empty string', () => {
+    const matches = findStringIgnoringCase('', ['foo', 'bar']);
+    expect(matches).toBe(undefined);
+  });
+
+  it('empty values', () => {
+    const matches = findStringIgnoringCase('foo', []);
+    expect(matches).toBe(undefined);
+  });
+
+  it('special characters', () => {
+    const matches = findStringIgnoringCase('this#test', ['this#test', 'bar']);
+    expect(matches).toBe('this#test');
+  });
+
+  it('escape sequence', () => {
+    const matches = findStringIgnoringCase('test\n', ['test\n', 'bar']);
+    expect(matches).toBe('test\n');
+  });
+
+  it('numbers', () => {
+    const matches = findStringIgnoringCase('cloud9', ['cloud9', 'bar']);
+    expect(matches).toBe('cloud9');
+  });
+
+  it('large string', () => {
+    const matches = findStringIgnoringCase(
+      'this is a large string test test test test test test test',
+      ['this is a large string test test test test test test test', 'bar'],
+    );
+    expect(matches).toBe(
+      'this is a large string test test test test test test test',
+    );
+  });
+
+  it('multiple case variants picks first occurrence', () => {
+    const matches = findStringIgnoringCase('foo', ['FOO', 'Foo', 'foo', 'bar']);
+    expect(matches).toBe('FOO');
+  });
+});
+
+describe('findClosestValue', () => {
+  // maxLevenshtein is 3 by default
+  it('exact match', () => {
+    const matches = findClosestValue('fooz', ['fooz', 'barz']);
+    expect(matches).toBe('fooz');
+  });
+
+  it('different case match', () => {
+    const matches = findClosestValue('Fooz', ['fooz', 'barz']);
+    expect(matches).toBe('fooz');
+  });
+
+  it('a match but missing > 3 characters', () => {
+    const matches = findClosestValue('f', ['foozy', 'barzy']);
+    expect(matches).toBe(undefined);
+  });
+
+  it('a match but missing 3 characters', () => {
+    const matches = findClosestValue('fo', ['foozy', 'barz']);
+    expect(matches).toBe('foozy');
+  });
+
+  it('a match but missing < 3 characters', () => {
+    const matches = findClosestValue('fooz', ['foozy', 'barz']);
+    expect(matches).toBe('foozy');
+  });
+
+  it('a match but 1 inner insertion needed', () => {
+    const matches = findClosestValue('fooy', ['foozy', 'barz']);
+    expect(matches).toBe('foozy');
+  });
+
+  it('a match but 3 inner insertions needed', () => {
+    const matches = findClosestValue('fooybrbz', ['foozybarbaz', 'barz']);
+    expect(matches).toBe('foozybarbaz');
+  });
+
+  it('5 inner insertions needed to match', () => {
+    const matches = findClosestValue('fooybz', ['foozybarbaz', 'barz']);
+    expect(matches).toBe(undefined);
+  });
+
+  it('5 inner deletions needed to match', () => {
+    const matches = findClosestValue('foozybarbaz', ['fooybz', 'barz']);
+    expect(matches).toBe(undefined);
+  });
+
+  it('a match but 3 inner deletions needed', () => {
+    const matches = findClosestValue('foozybarbaz', ['fooybrbrz', 'barz']);
+    expect(matches).toBe('fooybrbrz');
+  });
+
+  it('a match but 1 inner deletion needed', () => {
+    const matches = findClosestValue('foozy', ['fooy', 'barz']);
+    expect(matches).toBe('fooy');
+  });
+
+  it('empty string but smallest value length is 3 or less', () => {
+    const matches = findClosestValue('', ['foo', 'barz']);
+    expect(matches).toBe('foo');
+  });
+
+  it('empty string but smallest value length is greater than 3', () => {
+    const matches = findClosestValue('', ['foozy', 'barzy']);
+    expect(matches).toBe(undefined);
+  });
+
+  it('returns first match when multiple candidates have same distance', () => {
+    const matches = findClosestValue('fooz', ['foaz', 'fozz', 'barz']);
+    expect(matches).toBe('foaz');
+  });
+});

--- a/packages/docusaurus/src/commands/swizzle/config.ts
+++ b/packages/docusaurus/src/commands/swizzle/config.ts
@@ -12,7 +12,7 @@ import {getPluginByThemeName} from './themes';
 import type {SwizzleComponentConfig, SwizzleConfig} from '@docusaurus/types';
 import type {SwizzlePlugin} from './common';
 
-function getModuleSwizzleConfig(
+export function getModuleSwizzleConfig(
   swizzlePlugin: SwizzlePlugin,
 ): SwizzleConfig | undefined {
   const getSwizzleConfig =
@@ -79,6 +79,11 @@ export function normalizeSwizzleConfig(
 
   // Ensure all components always declare all actions
   Object.values(swizzleConfig.components).forEach((componentConfig) => {
+    if (!componentConfig.actions) {
+      // SET ACTIONS TO A DEFAULT VALUE WHEN NOT PRESENT
+      componentConfig.actions = {} as SwizzleComponentConfig['actions'];
+    }
+
     SwizzleActions.forEach((action) => {
       if (!componentConfig.actions[action]) {
         componentConfig.actions[action] = 'unsafe';

--- a/packages/docusaurus/src/server/plugins/synthetic.ts
+++ b/packages/docusaurus/src/server/plugins/synthetic.ts
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import {createMDXLoaderItem} from '@docusaurus/mdx-loader';
+import {
+  createMDXLoaderItem,
+  createMDXLoaderOptionsBuilder,
+} from '@docusaurus/mdx-loader';
 import type {RuleSetRule} from 'webpack';
 import type {
   HtmlTagObject,
@@ -79,19 +81,21 @@ export async function createMDXFallbackPlugin({
   siteDir,
   siteConfig,
 }: LoadContext): Promise<InitializedPlugin> {
-  const mdxLoaderItem = await createMDXLoaderItem({
+  const mdxOptionsBuilder = createMDXLoaderOptionsBuilder({
+    siteDir,
+    siteConfig,
     useCrossCompilerCache:
       siteConfig.future.experimental_faster.mdxCrossCompilerCache,
-    admonitions: true,
-    staticDirs: siteConfig.staticDirectories.map((dir) =>
-      path.resolve(siteDir, dir),
-    ),
-    siteDir,
-    // External MDX files are always meant to be imported as partials
-    isMDXPartial: () => true,
-    // External MDX files might have front matter, just disable the warning
-    isMDXPartialFrontMatterWarningDisabled: true,
-    markdownConfig: siteConfig.markdown,
+  });
+
+  const mdxLoaderItem = await createMDXLoaderItem({
+    ...mdxOptionsBuilder.build({
+      admonitions: true,
+      // External MDX files are always meant to be imported as partials
+      isMDXPartial: () => true,
+      // External MDX files might have front matter, just disable the warning
+      isMDXPartialFrontMatterWarningDisabled: true,
+    }),
   });
 
   return {

--- a/project-words.txt
+++ b/project-words.txt
@@ -21,6 +21,8 @@ autogenerating
 autohide
 Autolinks
 Bartosz
+barz
+barzy
 beforeinstallprompt
 Bhatt
 Blockquotes
@@ -87,8 +89,18 @@ Fienny
 flac
 Flightcontrol
 Flightcontrol's
+foaz
+fooy
+fooybrbrz
+fooybrbz
+fooybz
+Fooz
+fooz
+foozy
+foozybarbaz
 forwardable
 FOUC
+fozz
 Français
 froms
 gabrielcsapo


### PR DESCRIPTION
## Problem
Multiple content plugins (docs/blog/pages) plus the synthetic MDX fallback plugin each re-assembled the same MDX loader "base" options (`siteDir`, `staticDirs`, `markdownConfig`, `useCrossCompilerCache`). This created shotgun surgery when changing common MDX loader setup.
## Approach
- Added a minimal `createMDXLoaderOptionsBuilder()` in `@docusaurus/mdx-loader` that centralizes the shared base options and returns a `build(overrides)` merge result.
- Kept plugin-specific one-offs (matchers, `metadataPath`, `createAssets`, `resolveMarkdownLink`, plugin-specific remark/rehype/recma configuration, etc.) at each call site via the override object.
- Migrated call sites mechanically to use the builder:
  - docs/content-docs webpack MDX rule
  - blog MDX loader item setup
  - pages/content-pages webpack MDX rule
  - synthetic MDX fallback plugin loader item
## Evidence
- Added snapshot/equivalence test for builder output shape: `packages/docusaurus-mdx-loader/src/__tests__/optionsBuilder.test.ts`
- Existing MDX loader tests remain green: `packages/docusaurus-mdx-loader/src/__tests__/createMDXLoader.test.ts`
- Verified locally:
  `npm test -- --runTestsByPath packages/docusaurus-mdx-loader/src/__tests__/createMDXLoader.test.ts packages/docusaurus-mdx-loader/src/__tests__/optionsBuilder.test.ts`

Closes #77