### PR TITLE
fix(ci): fix pnpm e2e tests - pin to pnpm 11 + migrate env variable name

### DIFF
--- a/.github/workflows/security-supply-chain.yml
+++ b/.github/workflows/security-supply-chain.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           rm -rf node_modules
 
-          npm install -g pnpm@10.33.0
+          npm install -g pnpm@11.0.8
 
           cat > pnpm-workspace.yaml <<'YAML'
 

--- a/.github/workflows/security-supply-chain.yml
+++ b/.github/workflows/security-supply-chain.yml
@@ -68,20 +68,15 @@ jobs:
           npm install -g pnpm@11.0.8
 
           cat > pnpm-workspace.yaml <<'YAML'
-
           blockExoticSubdeps: true
-
           strictDepBuilds: true
           allowBuilds:
             '@swc/core': true
-            core-js-pure: true
             core-js: true
-
           trustPolicy: no-downgrade
           trustPolicyExclude:
             - 'detect-port@1.6.1'
             - 'semver@6.3.1'
-
           YAML
 
           sfw pnpm install || sfw pnpm install || sfw pnpm install

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -250,6 +250,14 @@ jobs:
       - name: Install test-website project with pnpm
         run: |
           npm install -g pnpm
+
+          cat > pnpm-workspace.yaml <<'YAML'
+          strictDepBuilds: true
+          allowBuilds:
+            '@swc/core': true
+            core-js: true
+          YAML
+
           pnpm install
         working-directory: ../test-website
         env:

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -249,7 +249,7 @@ jobs:
         run: yarn test:build:website -st
       - name: Install test-website project with pnpm
         run: |
-          npm install -g pnpm@11.0.8
+          npm install -g pnpm
           pnpm install
         working-directory: ../test-website
         env:

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -249,11 +249,11 @@ jobs:
         run: yarn test:build:website -st
       - name: Install test-website project with pnpm
         run: |
-          npm install -g pnpm
+          npm install -g pnpm@11.0.8
           pnpm install
         working-directory: ../test-website
         env:
-          npm_config_registry: http://localhost:4873
+          pnpm_config_registry: http://localhost:4873
       - name: TypeCheck website
         working-directory: ../test-website
         run: yarn typecheck


### PR DESCRIPTION


## Motivation

In pnpm v11, released recently, `npm_config_` env variables are not read anymore, which made our CI fail

See https://pnpm.io/blog/releases/11.0#npmrc-is-authregistry-only

## Test Plan

CI


