### PR TITLE
docs: fix siteConfig.url link in i18n tutorial

### DIFF
--- a/website/docs/i18n/i18n-tutorial.mdx
+++ b/website/docs/i18n/i18n-tutorial.mdx
@@ -541,7 +541,7 @@ This helps [search engines like Google know about localized versions of your pag
 
 This also permits Docusaurus themes to redirect users to the appropriate URL when they switch locale, usually through the [Navbar locale dropdown](../api/themes/theme-configuration.mdx#navbar-locale-dropdown).
 
-Read more on the [`siteConfig.url`](../api/docusaurus.config.js.mdx#baseUrl) and [`siteConfig.baseUrl`](../api/docusaurus.config.js.mdx#baseUrl) docs.
+Read more on the [`siteConfig.url`](../api/docusaurus.config.js.mdx#url) and [`siteConfig.baseUrl`](../api/docusaurus.config.js.mdx#baseUrl) docs.
 
 :::
 


### PR DESCRIPTION
## Summary

Fixes an incorrect internal docs link in the i18n tutorial.

The multi-domain deployment section links both `siteConfig.url` and `siteConfig.baseUrl` to the `#baseUrl` anchor. This updates the `siteConfig.url` link to point to the existing `#url` anchor instead.

## Test Plan

- Ran `yarn.cmd workspace website typecheck`