### PR TITLE
fix(client-redirects): preserve external redirect targets trailing slash

### DIFF
--- a/packages/docusaurus-plugin-client-redirects/src/__tests__/collectRedirects.test.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/__tests__/collectRedirects.test.ts
@@ -232,6 +232,30 @@ describe('collectRedirects', () => {
     ]);
   });
 
+  it('preserves external redirect targets with trailingSlash=true', () => {
+    expect(
+      collectRedirects(
+        createTestPluginContext(
+          {
+            redirects: [
+              {
+                from: '/someLegacyPath',
+                to: 'https://example.com/somePath?a=1#x',
+              },
+            ],
+          },
+          ['/'],
+        ),
+        true,
+      ),
+    ).toEqual([
+      {
+        from: '/someLegacyPath',
+        to: 'https://example.com/somePath?a=1#x',
+      },
+    ]);
+  });
+
   it('collects redirects from plugin option redirects with trailingSlash=false', () => {
     expect(
       collectRedirects(
@@ -264,6 +288,30 @@ describe('collectRedirects', () => {
       {
         from: '/someLegacyPathArray2',
         to: '/',
+      },
+    ]);
+  });
+
+  it('preserves external redirect targets with trailingSlash=false', () => {
+    expect(
+      collectRedirects(
+        createTestPluginContext(
+          {
+            redirects: [
+              {
+                from: '/someLegacyPath',
+                to: 'https://example.com/somePath/?a=1#x',
+              },
+            ],
+          },
+          ['/'],
+        ),
+        false,
+      ),
+    ).toEqual([
+      {
+        from: '/someLegacyPath',
+        to: 'https://example.com/somePath/?a=1#x',
       },
     ]);
   });

--- a/packages/docusaurus-plugin-client-redirects/src/collectRedirects.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/collectRedirects.ts
@@ -24,6 +24,15 @@ export default function collectRedirects(
   pluginContext: PluginContext,
   trailingSlash: boolean | undefined,
 ): RedirectItem[] {
+  function normalizeRedirectTo(to: string) {
+    return to.startsWith('/')
+      ? applyTrailingSlash(to, {
+          trailingSlash,
+          baseUrl: pluginContext.baseUrl,
+        })
+      : to;
+  }
+
   // For each plugin config option, create the appropriate redirects
   const redirects = [
     ...createFromExtensionsRedirects(
@@ -50,10 +59,7 @@ export default function collectRedirects(
     //
     // It should be easy to toggle `trailingSlash` option without having to
     // change other configs
-    to: applyTrailingSlash(redirect.to, {
-      trailingSlash,
-      baseUrl: pluginContext.baseUrl,
-    }),
+    to: normalizeRedirectTo(redirect.to),
   }));
 
   validateCollectedRedirects(redirects, pluginContext);

--- a/website/docs/i18n/i18n-tutorial.mdx
+++ b/website/docs/i18n/i18n-tutorial.mdx
@@ -541,7 +541,7 @@ This helps [search engines like Google know about localized versions of your pag
 
 This also permits Docusaurus themes to redirect users to the appropriate URL when they switch locale, usually through the [Navbar locale dropdown](../api/themes/theme-configuration.mdx#navbar-locale-dropdown).
 
-Read more on the [`siteConfig.url`](../api/docusaurus.config.js.mdx#baseUrl) and [`siteConfig.baseUrl`](../api/docusaurus.config.js.mdx#baseUrl) docs.
+Read more on the [`siteConfig.url`](../api/docusaurus.config.js.mdx#url) and [`siteConfig.baseUrl`](../api/docusaurus.config.js.mdx#baseUrl) docs.
 
 :::
 


### PR DESCRIPTION
## Summary

Fixes `@docusaurus/plugin-client-redirects` so absolute external redirect targets are not normalized by the site `trailingSlash` setting.

Previously, external `to` URLs could be modified during redirect collection. For example, with `trailingSlash: true`, `https://example.com/somePath?a=1#x` could become `https://example.com/somePath/?a=1#x`.

This keeps trailing-slash normalization for local redirect targets while preserving external URLs exactly.

## Test Plan

- Ran `yarn.cmd jest packages/docusaurus-plugin-client-redirects/src/__tests__/collectRedirects.test.ts --runInBand`