### PR TITLE
fix(theme-common): report recoverable storage errors via reportError() (AI-assisted)

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/__tests__/errorUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/errorUtils.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {reportRecoverableError} from '../errorUtils';
+
+describe('reportRecoverableError', () => {
+  const originalReportError = globalThis.reportError;
+
+  afterEach(() => {
+    globalThis.reportError = originalReportError;
+    vi.restoreAllMocks();
+  });
+
+  it('forwards the error to globalThis.reportError when available', () => {
+    const reportErrorMock = vi.fn();
+    globalThis.reportError = reportErrorMock;
+    const consoleErrorMock = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const error = new Error('boom');
+    reportRecoverableError(error);
+
+    expect(reportErrorMock).toHaveBeenCalledTimes(1);
+    expect(reportErrorMock).toHaveBeenCalledWith(error);
+    expect(consoleErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to console.error when globalThis.reportError is missing', () => {
+    // @ts-expect-error: simulating an environment without reportError
+    delete globalThis.reportError;
+    const consoleErrorMock = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const error = new Error('boom');
+    reportRecoverableError(error);
+
+    expect(consoleErrorMock).toHaveBeenCalledTimes(1);
+    expect(consoleErrorMock).toHaveBeenCalledWith(error);
+  });
+});

--- a/packages/docusaurus-theme-common/src/utils/errorUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/errorUtils.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Reports a recoverable client-side error.
+ *
+ * Uses the standard `reportError()` API when available so host-page error
+ * listeners (e.g. `window.onerror`, Sentry's global handler) can capture it.
+ * Falls back to `console.error` in environments where `reportError` does not
+ * exist (older browsers, some test runners).
+ *
+ * See https://github.com/facebook/docusaurus/issues/6747
+ */
+export function reportRecoverableError(error: unknown): void {
+  if (typeof globalThis.reportError === 'function') {
+    globalThis.reportError(error);
+  } else {
+    console.error(error);
+  }
+}

--- a/packages/docusaurus-theme-common/src/utils/storageUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/storageUtils.ts
@@ -7,6 +7,7 @@
 
 import {useCallback, useState, useSyncExternalStore} from 'react';
 import SiteStorage from '@generated/site-storage';
+import {reportRecoverableError} from './errorUtils';
 
 export type StorageType = (typeof SiteStorage)['type'] | 'none';
 
@@ -153,7 +154,11 @@ export function createStorageSlot(
       try {
         return storage.getItem(key);
       } catch (err) {
-        console.error(`Docusaurus storage error, can't get key=${key}`, err);
+        reportRecoverableError(
+          new Error(`Docusaurus storage error, can't get key=${key}`, {
+            cause: err,
+          }),
+        );
         return null;
       }
     },
@@ -168,9 +173,10 @@ export function createStorageSlot(
           storage,
         });
       } catch (err) {
-        console.error(
-          `Docusaurus storage error, can't set ${key}=${newValue}`,
-          err,
+        reportRecoverableError(
+          new Error(`Docusaurus storage error, can't set ${key}=${newValue}`, {
+            cause: err,
+          }),
         );
       }
     },
@@ -180,7 +186,11 @@ export function createStorageSlot(
         storage.removeItem(key);
         dispatchChangeEvent({key, oldValue, newValue: null, storage});
       } catch (err) {
-        console.error(`Docusaurus storage error, can't delete key=${key}`, err);
+        reportRecoverableError(
+          new Error(`Docusaurus storage error, can't delete key=${key}`, {
+            cause: err,
+          }),
+        );
       }
     },
     listen: (onChange) => {
@@ -193,9 +203,11 @@ export function createStorageSlot(
         window.addEventListener('storage', listener);
         return () => window.removeEventListener('storage', listener);
       } catch (err) {
-        console.error(
-          `Docusaurus storage error, can't listen for changes of key=${key}`,
-          err,
+        reportRecoverableError(
+          new Error(
+            `Docusaurus storage error, can't listen for changes of key=${key}`,
+            {cause: err},
+          ),
         );
         return () => {};
       }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist
- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

Closes #6747.

Today, when Docusaurus's `createStorageSlot` (used for color mode, announcement bar dismissal, etc.) hits a failing `localStorage`/`sessionStorage` operation — for example in an iframe, an incognito session, or under strict browser privacy settings — it logs to `console.error` and continues. Site owners using `window.onerror`, `window.addEventListener('error', ...)`, or third-party error reporting may not see these failures today, even though they can be useful diagnostics for real browser/runtime conditions.

The HTML spec's `reportError()` API (Baseline since 2022) is purpose-built for this: it dispatches an `ErrorEvent` to global listeners just like an uncaught exception would, without actually throwing. This makes the error observable to host-page tooling while keeping the recovery path unchanged.

## What this PR does

- Adds a tiny `reportRecoverableError(error)` helper in `@docusaurus/theme-common` that prefers `globalThis.reportError` and falls back to `console.error` when it's unavailable (older browsers, some test runners).
- Migrates the four `console.error` call sites inside `createStorageSlot` (`get` / `set` / `del` / `listen`) to use the helper. Original messages are preserved as the new `Error`'s message; the underlying browser exception is preserved via `Error.cause` (a pattern already used elsewhere in the repo — see `vitest.config.ts`'s `snapshotErrorCause.ts` serializer).
- Leaves intentional `console.error` calls untouched: deprecation warnings in `colorMode.tsx`, locale diagnostics in `usePluralForm.ts`, and CLI/server logging. Those are not recoverable runtime errors.

Scope was kept deliberately small so the helper and approach can be reviewed in isolation; follow-up PRs can migrate additional call sites incrementally if maintainers are happy with the pattern.

## Test plan

- [x] `yarn test packages/docusaurus-theme-common/src/utils/__tests__/errorUtils.test.ts` — 2/2 pass, covers both the `reportError`-present and fallback paths.
- [x] `yarn test packages/docusaurus-theme-common` — 108/108 pass, no regressions in existing storage / color mode behavior.
- [x] `yarn tsc --noEmit` in `packages/docusaurus-theme-common` — clean.
- [x] `yarn lint:js` — no new errors or warnings on the changed files.

## Notes

This change is AI-assisted, per `AGENTS.md`. The fallback to `console.error` preserves the existing behavior for older browsers and test environments without `reportError`.