### PR TITLE
Fix links to local directories with dots

### DIFF
--- a/packages/docusaurus-mdx-loader/src/remark/transformLinks/__tests__/index.test.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/transformLinks/__tests__/index.test.ts
@@ -79,6 +79,16 @@ describe('transformLinks plugin', () => {
     expect(result).toMatchInlineSnapshot(`"[file](dir/file.zip)"`);
   });
 
+  // Regression test for https://github.com/facebook/docusaurus/issues/11940
+  // A relative link to an existing directory whose name contains a dot
+  // (e.g. `../directory-with.dot/`) should be left as a plain link.
+  // Previously it was misclassified as an asset and passed to
+  // toAssetRequireNode(), which produced a webpack "Module not found" error.
+  it('accepts relative link to an existing directory with a dot in its name', async () => {
+    const result = await processContent(`[dir](../directory-with.dot/)`);
+    expect(result).toMatchInlineSnapshot(`"[dir](../directory-with.dot/)"`);
+  });
+
   describe('onBrokenMarkdownLinks', () => {
     const fixtures = {
       urlEmpty: `[empty]()`,

--- a/packages/docusaurus-mdx-loader/src/remark/transformLinks/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/transformLinks/index.ts
@@ -197,6 +197,15 @@ async function getLocalFileAbsolutePath(
   return null;
 }
 
+async function isExistingDirectory(absolutePath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(absolutePath);
+    return stat.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 async function processLinkNode(target: Target, context: Context) {
   const [node] = target;
   if (!node.url) {
@@ -229,6 +238,13 @@ async function processLinkNode(target: Target, context: Context) {
   );
 
   if (localFilePath) {
+    // A path like `../some.dir/` has `path.extname() === ".dot"` and trips the
+    // asset-like heuristic above, but it points to a directory, not a file.
+    // Don't try to require() a directory — leave the link as a plain link.
+    // See https://github.com/facebook/docusaurus/issues/11940
+    if (await isExistingDirectory(localFilePath)) {
+      return;
+    }
     await toAssetRequireNode(target, localFilePath, context);
   } else {
     // The @site alias is the only way to believe that the user wants an asset.


### PR DESCRIPTION
## Summary

Fixes local Markdown links to existing directories whose names contain dots, such as:

```md
[dir](../directory-with.dot/)
```

Previously, this path was treated as asset-like because `path.extname('../directory-with.dot/')` returns `.dot`. Since the directory exists, the MDX link transform attempted to emit an asset `require()` for the directory, which caused the Docusaurus build to fail.

This change keeps existing asset behavior intact while treating existing local directories as links instead of assets.

Fixes #11940.

## Test Plan

```bash
npx vitest run packages/docusaurus-mdx-loader/src/remark/transformLinks
npx vitest run packages/docusaurus-mdx-loader
```

Both pass. Formatting (`oxfmt`) is clean.