### PR TITLE
break(eslint-plugin): Add ESLint flag configs, require ESLint `>= 8.57`

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -18,17 +18,20 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "watch": "tsc --watch"
   },
   "dependencies": {
-    "@typescript-eslint/utils": "^5.62.0",
+    "@typescript-eslint/utils": "^8.59.3",
+    "@typescript-eslint/types": "^8.59.3",
     "tslib": "^2.6.0"
   },
   "devDependencies": {
-    "eslint-plugin-eslint-plugin": "^5.1.0"
+    "@typescript-eslint/rule-tester": "^8.59.3",
+    "eslint-plugin-eslint-plugin": "^6.5.0"
   },
   "peerDependencies": {
-    "eslint": ">=6"
+    "eslint": ">=8.57.0"
   },
   "engines": {
     "node": ">=24.14"

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -5,28 +5,57 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {name, version} from '../package.json';
+
 import rules from './rules';
 
-// @ts-expect-error: TODO try to remove later
-export = {
+const plugin = {
+  meta: {name, version, namespace: '@docusaurus'},
   rules,
+};
+
+const rulesRecommended = {
+  '@docusaurus/string-literal-i18n-messages': 'error',
+  '@docusaurus/no-html-links': 'warn',
+  '@docusaurus/prefer-docusaurus-heading': 'warn',
+};
+
+const rulesAll = {
+  '@docusaurus/string-literal-i18n-messages': 'error',
+  '@docusaurus/no-untranslated-text': 'warn',
+  '@docusaurus/no-html-links': 'warn',
+  '@docusaurus/prefer-docusaurus-heading': 'warn',
+};
+
+// Supports both legacy/flat configs:
+// https://eslint.org/docs/latest/extend/plugins#backwards-compatibility-for-legacy-configs
+const compatPlugin = {
+  ...plugin,
   configs: {
     recommended: {
       plugins: ['@docusaurus'],
-      rules: {
-        '@docusaurus/string-literal-i18n-messages': 'error',
-        '@docusaurus/no-html-links': 'warn',
-        '@docusaurus/prefer-docusaurus-heading': 'warn',
-      },
+      rules: rulesRecommended,
     },
     all: {
       plugins: ['@docusaurus'],
-      rules: {
-        '@docusaurus/string-literal-i18n-messages': 'error',
-        '@docusaurus/no-untranslated-text': 'warn',
-        '@docusaurus/no-html-links': 'warn',
-        '@docusaurus/prefer-docusaurus-heading': 'warn',
+      rules: rulesAll,
+    },
+    flat: {
+      recommended: {
+        plugins: {
+          '@docusaurus': plugin,
+        },
+        rules: rulesRecommended,
+      },
+      all: {
+        plugins: {
+          '@docusaurus': plugin,
+        },
+        rules: rulesAll,
       },
     },
   },
 };
+
+// @ts-expect-error: TODO try to remove later
+export = compatPlugin;

--- a/packages/eslint-plugin/src/rules/__tests__/no-html-links.test.ts
+++ b/packages/eslint-plugin/src/rules/__tests__/no-html-links.test.ts
@@ -6,18 +6,9 @@
  */
 
 import rule from '../no-html-links';
-import {RuleTester} from './testUtils';
+import {ruleTester} from './testUtils';
 
 const errorsJSX = [{messageId: 'link'}] as const;
-
-const ruleTester = new RuleTester({
-  parser: '@typescript-eslint/parser',
-  parserOptions: {
-    ecmaFeatures: {
-      jsx: true,
-    },
-  },
-});
 
 ruleTester.run('prefer-docusaurus-link', rule, {
   valid: [

--- a/packages/eslint-plugin/src/rules/__tests__/no-untranslated-text.test.ts
+++ b/packages/eslint-plugin/src/rules/__tests__/no-untranslated-text.test.ts
@@ -6,18 +6,9 @@
  */
 
 import rule from '../no-untranslated-text';
-import {getCommonValidTests, RuleTester} from './testUtils';
+import {getCommonValidTests, ruleTester} from './testUtils';
 
 const errorsJSX = [{messageId: 'translateChildren'}] as const;
-
-const ruleTester = new RuleTester({
-  parser: '@typescript-eslint/parser',
-  parserOptions: {
-    ecmaFeatures: {
-      jsx: true,
-    },
-  },
-});
 
 ruleTester.run('no-untranslated-text', rule, {
   valid: [

--- a/packages/eslint-plugin/src/rules/__tests__/prefer-docusaurus-heading.test.ts
+++ b/packages/eslint-plugin/src/rules/__tests__/prefer-docusaurus-heading.test.ts
@@ -6,18 +6,9 @@
  */
 
 import rule from '../prefer-docusaurus-heading';
-import {RuleTester} from './testUtils';
+import {ruleTester} from './testUtils';
 
 const errorsJSX = [{messageId: 'headings'}] as const;
-
-const ruleTester = new RuleTester({
-  parser: '@typescript-eslint/parser',
-  parserOptions: {
-    ecmaFeatures: {
-      jsx: true,
-    },
-  },
-});
 
 ruleTester.run('prefer-docusaurus-heading', rule, {
   valid: [

--- a/packages/eslint-plugin/src/rules/__tests__/string-literal-i18n-messages.test.ts
+++ b/packages/eslint-plugin/src/rules/__tests__/string-literal-i18n-messages.test.ts
@@ -6,19 +6,10 @@
  */
 
 import rule from '../string-literal-i18n-messages';
-import {getCommonValidTests, RuleTester} from './testUtils';
+import {getCommonValidTests, ruleTester} from './testUtils';
 
 const errorsJSX = [{messageId: 'translateChildren'}] as const;
 const errorsFunc = [{messageId: 'translateArg'}] as const;
-
-const ruleTester = new RuleTester({
-  parser: '@typescript-eslint/parser',
-  parserOptions: {
-    ecmaFeatures: {
-      jsx: true,
-    },
-  },
-});
 
 ruleTester.run('string-literal-i18n-messages', rule, {
   valid: [...getCommonValidTests()],

--- a/packages/eslint-plugin/src/rules/__tests__/testUtils.ts
+++ b/packages/eslint-plugin/src/rules/__tests__/testUtils.ts
@@ -6,9 +6,7 @@
  */
 
 import {afterAll, describe, it} from 'vitest';
-import {ESLintUtils} from '@typescript-eslint/utils';
-
-const {RuleTester} = ESLintUtils;
+import {RuleTester} from '@typescript-eslint/rule-tester';
 
 // `RuleTester` defers to globals when these are unset; we run with
 // `globals: false`, so wire it to Vitest's test-framework functions instead.
@@ -17,7 +15,15 @@ RuleTester.describe = describe;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
 
-export {RuleTester};
+export const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
 
 export const getCommonValidTests = (): {code: string}[] => [
   {

--- a/packages/eslint-plugin/src/rules/no-html-links.ts
+++ b/packages/eslint-plugin/src/rules/no-html-links.ts
@@ -6,7 +6,7 @@
  */
 
 import {createRule} from '../util';
-import type {TSESTree} from '@typescript-eslint/types/dist/ts-estree';
+import type {TSESTree} from '@typescript-eslint/types';
 
 const docsUrl = 'https://docusaurus.io/docs/docusaurus-core#link';
 

--- a/packages/eslint-plugin/src/rules/no-untranslated-text.ts
+++ b/packages/eslint-plugin/src/rules/no-untranslated-text.ts
@@ -6,7 +6,7 @@
  */
 
 import {isTextLabelChild, createRule} from '../util';
-import type {TSESTree} from '@typescript-eslint/types/dist/ts-estree';
+import type {TSESTree} from '@typescript-eslint/types';
 
 type Options = [
   {

--- a/packages/eslint-plugin/src/rules/prefer-docusaurus-heading.ts
+++ b/packages/eslint-plugin/src/rules/prefer-docusaurus-heading.ts
@@ -6,7 +6,7 @@
  */
 
 import {createRule} from '../util';
-import type {TSESTree} from '@typescript-eslint/types/dist/ts-estree';
+import type {TSESTree} from '@typescript-eslint/types';
 
 type Options = [];
 type MessageIds = 'headings';

--- a/packages/eslint-plugin/src/rules/string-literal-i18n-messages.ts
+++ b/packages/eslint-plugin/src/rules/string-literal-i18n-messages.ts
@@ -10,7 +10,7 @@ import {
   isStringWithoutExpressions,
   createRule,
 } from '../util';
-import type {TSESTree} from '@typescript-eslint/types/dist/ts-estree';
+import type {TSESTree} from '@typescript-eslint/types';
 
 type Options = [];
 type MessageIds = 'translateChildren' | 'translateArg';

--- a/packages/eslint-plugin/src/util.ts
+++ b/packages/eslint-plugin/src/util.ts
@@ -5,8 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {ESLintUtils} from '@typescript-eslint/utils';
-import type {TSESTree} from '@typescript-eslint/types/dist/ts-estree';
+import {ESLintUtils, type TSESTree} from '@typescript-eslint/utils';
 
 type CheckTranslateChildOptions = {
   ignoredStrings?: string[];
@@ -61,7 +60,14 @@ export function isTextLabelChild(
   }
 }
 
-export const createRule = ESLintUtils.RuleCreator(
+// Not sure if we really need this
+// See https://typescript-eslint.io/blog/announcing-typescript-eslint-v8/#custom-rule-metadocs-types
+// See https://github.com/typescript-eslint/typescript-eslint/pull/9025
+export interface PluginDocs {
+  recommended: boolean | 'error';
+}
+
+export const createRule = ESLintUtils.RuleCreator<PluginDocs>(
   (name) =>
     `https://docusaurus.io/docs/api/misc/@docusaurus/eslint-plugin/${name}`,
 );

--- a/website/docs/api/misc/eslint-plugin/README.mdx
+++ b/website/docs/api/misc/eslint-plugin/README.mdx
@@ -37,44 +37,42 @@ Both built-in configs exist in flat and legacy variants:
 
 ### Recommended config {/* #recommended-config-flat */}
 
-Add `plugin:@docusaurus/recommended` to the `extends` section of your `.eslintrc` configuration file:
+Import `@docusaurus/eslint-plugin` and add `docusaurus.configs.flat.recommended` to your flat config array:
 
-```json title=".eslintrc"
-{
-  "extends": ["plugin:@docusaurus/recommended"]
-}
+```js title="eslint.config.js"
+import {defineConfig} from 'eslint/config';
+// highlight-next-line
+import docusaurus from '@docusaurus/eslint-plugin';
+
+export default defineConfig(
+  // highlight-next-line
+  docusaurus.configs.flat.recommended,
+  {
+    // Other config
+  },
+);
 ```
 
-This will enable the `@docusaurus` eslint plugin and use the `recommended` config. See [Supported rules](#supported-rules) below for a list of rules that this will enable.
+This will enable the `@docusaurus` eslint plugin and use the `recommended` config. See [Supported rules](#supported-rules) above for a list of rules that this will enable.
 
 ### Manual config {/* #manual-config-flat */}
 
 For more fine-grained control, you can also enable the plugin manually and configure the rules you want to use directly:
 
-```json title=".eslintrc"
-{
-  "plugins": ["@docusaurus"],
-  "rules": {
-    "@docusaurus/string-literal-i18n-messages": "error",
-    "@docusaurus/no-untranslated-text": "warn"
-  }
-}
-```
+```js title="eslint.config.js"
+import {defineConfig} from 'eslint/config';
+// highlight-next-line
+import docusaurus from '@docusaurus/eslint-plugin';
 
-## Example configuration {/* #example-configuration-flat */}
-
-Here's an example configuration:
-
-```js title=".eslintrc.js"
-module.exports = {
-  extends: ['plugin:@docusaurus/recommended'],
+export default defineConfig({
+  // highlight-start
+  plugins: {docusaurus},
   rules: {
-    '@docusaurus/no-untranslated-text': [
-      'warn',
-      {ignoredStrings: ['·', '—', '×']},
-    ],
+    '@docusaurus/string-literal-i18n-messages': 'error',
+    '@docusaurus/no-untranslated-text': 'warn',
   },
-};
+  // highlight-end
+});
 ```
 
 ## Usage - Legacy {/* #usage-legacy */}
@@ -89,7 +87,7 @@ Add `plugin:@docusaurus/recommended` to the `extends` section of your `.eslintrc
 }
 ```
 
-This will enable the `@docusaurus` eslint plugin and use the `recommended` config. See [Supported rules](#supported-rules) below for a list of rules that this will enable.
+This will enable the `@docusaurus` eslint plugin and use the `recommended` config. See [Supported rules](#supported-rules) above for a list of rules that this will enable.
 
 ### Manual config {/* #manual-config-legacy */}
 
@@ -103,20 +101,4 @@ For more fine-grained control, you can also enable the plugin manually and confi
     "@docusaurus/no-untranslated-text": "warn"
   }
 }
-```
-
-## Example configuration {/* #example-configuration-legacy */}
-
-Here's an example configuration:
-
-```js title=".eslintrc.js"
-module.exports = {
-  extends: ['plugin:@docusaurus/recommended'],
-  rules: {
-    '@docusaurus/no-untranslated-text': [
-      'warn',
-      {ignoredStrings: ['·', '—', '×']},
-    ],
-  },
-};
 ```

--- a/website/docs/api/misc/eslint-plugin/README.mdx
+++ b/website/docs/api/misc/eslint-plugin/README.mdx
@@ -7,41 +7,17 @@ slug: /api/misc/@docusaurus/eslint-plugin
 
 [ESLint](https://eslint.org/) is a tool that statically analyzes your code and reports problems or suggests best practices through editor hints and command line. Docusaurus provides an ESLint plugin to enforce best Docusaurus practices.
 
+This ESLint plugin supports ESLint `>= 8.57.0`, flat configs and legacy configs.
+
 ## Installation {/* #installation */}
 
 ```bash npm2yarn
 npm install --save-dev @docusaurus/eslint-plugin
 ```
 
-## Usage {/* #usage */}
-
-### Recommended config {/* #recommended-config */}
-
-Add `plugin:@docusaurus/recommended` to the `extends` section of your `.eslintrc` configuration file:
-
-```json title=".eslintrc"
-{
-  "extends": ["plugin:@docusaurus/recommended"]
-}
-```
-
-This will enable the `@docusaurus` eslint plugin and use the `recommended` config. See [Supported rules](#supported-rules) below for a list of rules that this will enable.
-
-### Manual config {/* #manual-config */}
-
-For more fine-grained control, you can also enable the plugin manually and configure the rules you want to use directly:
-
-```json title=".eslintrc"
-{
-  "plugins": ["@docusaurus"],
-  "rules": {
-    "@docusaurus/string-literal-i18n-messages": "error",
-    "@docusaurus/no-untranslated-text": "warn"
-  }
-}
-```
-
 ## Supported configs {/* #supported-configs */}
+
+Both built-in configs exist in flat and legacy variants:
 
 - Recommended: recommended rule set for most Docusaurus sites that should be extended from.
 - All: **all** rules enabled. This will change between minor versions, so you should not use this if you want to avoid unexpected breaking changes.
@@ -57,7 +33,79 @@ For more fine-grained control, you can also enable the plugin manually and confi
 
 ✅ = recommended
 
-## Example configuration {/* #example-configuration */}
+## Usage - Flat {/* #usage-flat */}
+
+### Recommended config {/* #recommended-config-flat */}
+
+Add `plugin:@docusaurus/recommended` to the `extends` section of your `.eslintrc` configuration file:
+
+```json title=".eslintrc"
+{
+  "extends": ["plugin:@docusaurus/recommended"]
+}
+```
+
+This will enable the `@docusaurus` eslint plugin and use the `recommended` config. See [Supported rules](#supported-rules) below for a list of rules that this will enable.
+
+### Manual config {/* #manual-config-flat */}
+
+For more fine-grained control, you can also enable the plugin manually and configure the rules you want to use directly:
+
+```json title=".eslintrc"
+{
+  "plugins": ["@docusaurus"],
+  "rules": {
+    "@docusaurus/string-literal-i18n-messages": "error",
+    "@docusaurus/no-untranslated-text": "warn"
+  }
+}
+```
+
+## Example configuration {/* #example-configuration-flat */}
+
+Here's an example configuration:
+
+```js title=".eslintrc.js"
+module.exports = {
+  extends: ['plugin:@docusaurus/recommended'],
+  rules: {
+    '@docusaurus/no-untranslated-text': [
+      'warn',
+      {ignoredStrings: ['·', '—', '×']},
+    ],
+  },
+};
+```
+
+## Usage - Legacy {/* #usage-legacy */}
+
+### Recommended config {/* #recommended-config-legacy */}
+
+Add `plugin:@docusaurus/recommended` to the `extends` section of your `.eslintrc` configuration file:
+
+```json title=".eslintrc"
+{
+  "extends": ["plugin:@docusaurus/recommended"]
+}
+```
+
+This will enable the `@docusaurus` eslint plugin and use the `recommended` config. See [Supported rules](#supported-rules) below for a list of rules that this will enable.
+
+### Manual config {/* #manual-config-legacy */}
+
+For more fine-grained control, you can also enable the plugin manually and configure the rules you want to use directly:
+
+```json title=".eslintrc"
+{
+  "plugins": ["@docusaurus"],
+  "rules": {
+    "@docusaurus/string-literal-i18n-messages": "error",
+    "@docusaurus/no-untranslated-text": "warn"
+  }
+}
+```
+
+## Example configuration {/* #example-configuration-legacy */}
 
 Here's an example configuration:
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2215,7 +2215,7 @@
   resolved "https://registry.yarnpkg.com/@epic-web/invariant/-/invariant-1.0.0.tgz#1073e5dee6dd540410784990eb73e4acd25c9813"
   integrity sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==
 
-"@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.9.1":
+"@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0", "@eslint-community/eslint-utils@^4.9.1":
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz#4e90af67bc51ddee6cdef5284edf572ec376b595"
   integrity sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==
@@ -5346,6 +5346,17 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
+"@typescript-eslint/parser@8.59.3":
+  version "8.59.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.59.3.tgz#f46cbc70ae0a25119ef94eac9ecd46714788e1a1"
+  integrity sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==
+  dependencies:
+    "@typescript-eslint/scope-manager" "8.59.3"
+    "@typescript-eslint/types" "8.59.3"
+    "@typescript-eslint/typescript-estree" "8.59.3"
+    "@typescript-eslint/visitor-keys" "8.59.3"
+    debug "^4.4.3"
+
 "@typescript-eslint/parser@^5.62.0":
   version "5.62.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.62.0.tgz#1b63d082d849a2fcae8a569248fbe2ee1b8a56c7"
@@ -5356,14 +5367,27 @@
     "@typescript-eslint/typescript-estree" "5.62.0"
     debug "^4.3.4"
 
-"@typescript-eslint/project-service@8.59.2":
-  version "8.59.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.59.2.tgz#f8b8cbf8692e3a51c2c394acf8cf6900f7e755af"
-  integrity sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==
+"@typescript-eslint/project-service@8.59.3":
+  version "8.59.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.59.3.tgz#1be5ae152aad987a156c9a1a9b4256e75cfbbe0c"
+  integrity sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==
   dependencies:
-    "@typescript-eslint/tsconfig-utils" "^8.59.2"
-    "@typescript-eslint/types" "^8.59.2"
+    "@typescript-eslint/tsconfig-utils" "^8.59.3"
+    "@typescript-eslint/types" "^8.59.3"
     debug "^4.4.3"
+
+"@typescript-eslint/rule-tester@^8.59.3":
+  version "8.59.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/rule-tester/-/rule-tester-8.59.3.tgz#f5fc6092b756da7a8bfb4b0db7231a61a12ba4b4"
+  integrity sha512-GH5g42Dt0IvM/G4ojD4JoOJaZCmogsQBGTSNExRa1ND+sDLI1SVppzYX66+xLIX/jFhcJRpYhiBOhHJEpLtgkA==
+  dependencies:
+    "@typescript-eslint/parser" "8.59.3"
+    "@typescript-eslint/typescript-estree" "8.59.3"
+    "@typescript-eslint/utils" "8.59.3"
+    ajv "^6.12.6"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    lodash.merge "4.6.2"
+    semver "^7.7.3"
 
 "@typescript-eslint/scope-manager@5.62.0":
   version "5.62.0"
@@ -5373,18 +5397,18 @@
     "@typescript-eslint/types" "5.62.0"
     "@typescript-eslint/visitor-keys" "5.62.0"
 
-"@typescript-eslint/scope-manager@8.59.2", "@typescript-eslint/scope-manager@^8.58.0":
-  version "8.59.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz#63cbd0af2e3180949d6be81122cc555bc71e736d"
-  integrity sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==
+"@typescript-eslint/scope-manager@8.59.3", "@typescript-eslint/scope-manager@^8.58.0":
+  version "8.59.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz#91a60f66803fe9dae0696fbab2451f5723f119d2"
+  integrity sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==
   dependencies:
-    "@typescript-eslint/types" "8.59.2"
-    "@typescript-eslint/visitor-keys" "8.59.2"
+    "@typescript-eslint/types" "8.59.3"
+    "@typescript-eslint/visitor-keys" "8.59.3"
 
-"@typescript-eslint/tsconfig-utils@8.59.2", "@typescript-eslint/tsconfig-utils@^8.59.2":
-  version "8.59.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz#6e92bc412083753185a79c9f1431e78169d9232f"
-  integrity sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==
+"@typescript-eslint/tsconfig-utils@8.59.3", "@typescript-eslint/tsconfig-utils@^8.59.3":
+  version "8.59.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz#88ca9036b42ccdd1e630cfdafd2e042c2ca6a835"
+  integrity sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==
 
 "@typescript-eslint/type-utils@5.62.0":
   version "5.62.0"
@@ -5401,10 +5425,10 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.62.0.tgz#258607e60effa309f067608931c3df6fed41fd2f"
   integrity sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==
 
-"@typescript-eslint/types@8.59.2", "@typescript-eslint/types@^8.59.2":
-  version "8.59.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.59.2.tgz#01caabcd7e4715c33ad5e11cab260829714d6b9c"
-  integrity sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==
+"@typescript-eslint/types@8.59.3", "@typescript-eslint/types@^8.59.3":
+  version "8.59.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.59.3.tgz#b7ca539c5e302fdde9a7cadb73caed107ef8f2cd"
+  integrity sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==
 
 "@typescript-eslint/typescript-estree@5.62.0":
   version "5.62.0"
@@ -5419,22 +5443,22 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/typescript-estree@8.59.2":
-  version "8.59.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz#6a217ef65b18dbd12c718fc86a675d1d7a1414cc"
-  integrity sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==
+"@typescript-eslint/typescript-estree@8.59.3":
+  version "8.59.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz#e6bb1408e00b47e431427a40268db4e86cb121ab"
+  integrity sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==
   dependencies:
-    "@typescript-eslint/project-service" "8.59.2"
-    "@typescript-eslint/tsconfig-utils" "8.59.2"
-    "@typescript-eslint/types" "8.59.2"
-    "@typescript-eslint/visitor-keys" "8.59.2"
+    "@typescript-eslint/project-service" "8.59.3"
+    "@typescript-eslint/tsconfig-utils" "8.59.3"
+    "@typescript-eslint/types" "8.59.3"
+    "@typescript-eslint/visitor-keys" "8.59.3"
     debug "^4.4.3"
     minimatch "^10.2.2"
     semver "^7.7.3"
     tinyglobby "^0.2.15"
     ts-api-utils "^2.5.0"
 
-"@typescript-eslint/utils@5.62.0", "@typescript-eslint/utils@^5.62.0":
+"@typescript-eslint/utils@5.62.0":
   version "5.62.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.62.0.tgz#141e809c71636e4a75daa39faed2fb5f4b10df86"
   integrity sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==
@@ -5448,15 +5472,15 @@
     eslint-scope "^5.1.1"
     semver "^7.3.7"
 
-"@typescript-eslint/utils@^8.58.0":
-  version "8.59.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.59.2.tgz#ff619a6a3075f4017fa91b8610b752a8ca3366aa"
-  integrity sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==
+"@typescript-eslint/utils@8.59.3", "@typescript-eslint/utils@^8.58.0", "@typescript-eslint/utils@^8.59.3":
+  version "8.59.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.59.3.tgz#f693f979deb4dc3994de03ff8b23976d625c36c5"
+  integrity sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==
   dependencies:
     "@eslint-community/eslint-utils" "^4.9.1"
-    "@typescript-eslint/scope-manager" "8.59.2"
-    "@typescript-eslint/types" "8.59.2"
-    "@typescript-eslint/typescript-estree" "8.59.2"
+    "@typescript-eslint/scope-manager" "8.59.3"
+    "@typescript-eslint/types" "8.59.3"
+    "@typescript-eslint/typescript-estree" "8.59.3"
 
 "@typescript-eslint/visitor-keys@5.62.0":
   version "5.62.0"
@@ -5466,12 +5490,12 @@
     "@typescript-eslint/types" "5.62.0"
     eslint-visitor-keys "^3.3.0"
 
-"@typescript-eslint/visitor-keys@8.59.2":
-  version "8.59.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz#5ccc486913cd347883d69158836b1189a660bfe6"
-  integrity sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==
+"@typescript-eslint/visitor-keys@8.59.3":
+  version "8.59.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz#820843b1b5ca4290009cf189382abcf6fe00dfa6"
+  integrity sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==
   dependencies:
-    "@typescript-eslint/types" "8.59.2"
+    "@typescript-eslint/types" "8.59.3"
     eslint-visitor-keys "^5.0.0"
 
 "@ungap/structured-clone@^1.0.0", "@ungap/structured-clone@^1.2.0", "@ungap/structured-clone@^1.3.0":
@@ -5867,10 +5891,10 @@ ajv-keywords@^5.1.0:
   dependencies:
     fast-deep-equal "^3.1.3"
 
-ajv@^6.12.4, ajv@^6.12.5:
-  version "6.12.6"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
-  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+ajv@^6.12.4, ajv@^6.12.5, ajv@^6.12.6:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.15.0.tgz#07e982c74626167aa7a2495c53817892d7139492"
+  integrity sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -8998,12 +9022,12 @@ eslint-module-utils@^2.12.0:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-eslint-plugin@^5.1.0:
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-5.5.1.tgz#ff54b5d0a5881e6150183ad025c5a7ee554b6545"
-  integrity sha512-9AmfZzcQ7QHwpzfAQpZ7xdtwHYViylmlnruCH0aV64/tuoH3igGXg91vr0e6ShLf/mrAYGqLw5LZ/gOxJeRXnw==
+eslint-plugin-eslint-plugin@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-6.5.0.tgz#f0a099aac5af5237ae09ef7df1932c05b9577d97"
+  integrity sha512-DT8YpcXDtMBcBZN39JlkHGurHKU8eYFLavTrnowQLeNwqe/diRUsllsftgD/7dZ2/ItabNLLF2/EYapE1H+G7Q==
   dependencies:
-    eslint-utils "^3.0.0"
+    "@eslint-community/eslint-utils" "^4.4.0"
     estraverse "^5.3.0"
 
 eslint-plugin-header@^3.1.1:
@@ -9128,18 +9152,6 @@ eslint-scope@^7.2.2:
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
-
-eslint-utils@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
-  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
-  dependencies:
-    eslint-visitor-keys "^2.0.0"
-
-eslint-visitor-keys@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
-  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
 eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
   version "3.4.3"
@@ -12156,7 +12168,7 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
 
-lodash.merge@^4.6.2:
+lodash.merge@4.6.2, lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==


### PR DESCRIPTION

## Breaking change

Our ESLint plugin now requires ESLint `>= 8.57.0`

## Motivation

This adds support for ESLint flat config to our ESLint plugin, while preserving the legacy configs and compatibility with ESLint 8. 

We'll drop legacy configs and ESLint 8 support in the future, so it's better to migrate to this new format and upgrade to ESLint 9/10+.

Extracted from a larger PR (https://github.com/facebook/docusaurus/pull/12024) so that we can document it separately as a feature + breaking change.


## Test Plan

Unfortunately, we don't have a CI setup to test against multiple versions of ESLint atm.

Our monorepo still uses ESLint 8 on this PR, and CI passes, so this shows the compatibility with ESLint 8 is maintained. 

The plugin code is the same in the ESLint 9 + flat config upgrade (https://github.com/facebook/docusaurus/pull/12024) which shows the same code works with both ESLint 8/9.


## Test link

Docs updated: https://deploy-preview-12025--docusaurus-2.netlify.app/docs/api/misc/@docusaurus/eslint-plugin/
