### PR TITLE
docs: clarify where to add custom CSS files

### DIFF
--- a/website/docs/styling-layout.mdx
+++ b/website/docs/styling-layout.mdx
@@ -24,12 +24,15 @@ This is the most traditional way of styling that most developers (including non-
 If you're using `@docusaurus/preset-classic`, you can create your own CSS files (e.g. `/src/css/custom.css`) and import them globally by passing them as an option of the classic theme.
 
 Your project structure should look like this:
+
+```
 my-website/
 ├── src/
 │   └── css/
 │       └── custom.css   ← add your custom styles here
 ├── docusaurus.config.js
 └── package.json
+```
 
 ```js title="docusaurus.config.js"
 export default {

--- a/website/docs/styling-layout.mdx
+++ b/website/docs/styling-layout.mdx
@@ -23,6 +23,14 @@ This is the most traditional way of styling that most developers (including non-
 
 If you're using `@docusaurus/preset-classic`, you can create your own CSS files (e.g. `/src/css/custom.css`) and import them globally by passing them as an option of the classic theme.
 
+Your project structure should look like this:
+my-website/
+├── src/
+│   └── css/
+│       └── custom.css   ← add your custom styles here
+├── docusaurus.config.js
+└── package.json
+
 ```js title="docusaurus.config.js"
 export default {
   // ...


### PR DESCRIPTION
## Pre-flight checklist
- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation
This change addresses #12031.

Beginner users often struggle to find where to place custom CSS files when customizing a Docusaurus site. Added a project folder structure example under the Global Styles section to make this clearer.

## Test Plan
This is a documentation-only change. No code was modified.

Verified that the added folder structure renders correctly in the MDX file.

### Test links
Deploy preview: https://deploy-preview-12032--docusaurus-2.netlify.app/docs/styling-layout

## Related issues/PRs
Closes #12031

### Screenshot
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/731b658c-3715-4797-bdc7-d91286d09ed2" />
