### PR TITLE
docs: add AI / Agents community plugins sub-section

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -143,6 +143,8 @@ lifecycles
 lightningcss
 Linkify
 linkify
+llms
+llmstxt
 longlonglonglonglonglonglonglonglonglonglonglong
 Lorber
 lorber

--- a/website/community/2-resources.mdx
+++ b/website/community/2-resources.mdx
@@ -52,6 +52,13 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [docusaurus-plugin-moesif](https://github.com/Moesif/docusaurus-plugin-moesif) - Adds [Moesif API Analytics](https://www.moesif.com/) to track user behavior and pinpoint where developers drop off in your activation funnel.
 - [docusaurus-plugin-yandex-metrica](https://github.com/sgromkov/docusaurus-plugin-yandex-metrica) - Adds [Yandex Metrika](https://metrika.yandex.ru/) counter for evaluating site traffic and analyzing user behavior.
 
+### AI / Agents {/* #ai-agents */}
+
+- [docusaurus-plugin-copy-page-button](https://github.com/portdeveloper/docusaurus-plugin-copy-page-button) - Adds a "Copy page" button that exports doc pages as clean Markdown for use with ChatGPT, Claude, and Gemini. Used by Ethereum, Sui, Monad, and Flare docs.
+- [docusaurus-plugin-llms](https://github.com/rachfop/docusaurus-plugin-llms) - Generates `llms.txt` and `llms-full.txt` files from your docs, following the [llmstxt.org](https://llmstxt.org/) standard.
+- [docusaurus-plugin-llms-txt](https://github.com/din0s/docusaurus-plugin-llms-txt) - Generates a concatenated Markdown `llms.txt` file from your documentation.
+- [expose-markdown-docusaurus-plugin](https://github.com/FlyNumber/markdown_docusaurus_plugin) - Exposes your /docs Markdown files as raw `.md` URLs (for LLM consumption).
+
 ### Features {/* #features */}
 
 - [docusaurus-theme-github-codeblock](https://github.com/saucelabs/docusaurus-theme-github-codeblock). A Docusaurus plugin that supports referencing code examples from public GitHub repositories
@@ -73,8 +80,6 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [docusaurus-i18n](https://github.com/moonrailgun/docusaurus-i18n) - Auto-translate docusaurus documents with openai.
 - [docusaurus-plugin-glossary](https://github.com/mcclowes/docusaurus-plugin-glossary) - A docusaurus plugin for helping users understand key terms.
 - [docusaurus-plugin-cookie-consent](https://github.com/mcclowes/docusaurus-plugin-cookie-consent) - A Docusaurus plugin for allowing users to opt in/out of cookies, and accessing those settings in code.
-- [expose-markdown-docusaurus-plugin](https://github.com/FlyNumber/markdown_docusaurus_plugin) - A Docusaurus plugin that exposes your /docs Markdown files as raw .md URLs. (For LLM's and such).
-- [docusaurus-plugin-copy-page-button](https://github.com/portdeveloper/docusaurus-plugin-copy-page-button) - Adds a "Copy page" button that exports doc pages as clean markdown for use with ChatGPT, Claude, and Gemini. Used by Ethereum, Sui, Monad, and Flare docs.
 
 ## Enterprise usage {/* #enterprise-usage */}
 


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

> Docs-only change (no code, no API), so the unit-test and RFC-issue boxes are checked as "not applicable."

## Motivation

Adds an `AI / Agents` sub-section under `## Community plugins` in `website/community/2-resources.mdx` so users can find the growing set of plugins that make Docusaurus sites consumable by LLM agents without digging through GitHub issues.

Today these plugins are scattered — two live at the bottom of `### Features` (alongside unrelated bullets like image-zoom and PDF generation), the others aren't listed at all. Given the volume of community work in this space (multiple plugins, multiple production sites shipping their own implementations, the active proposal in #10899, and the recently merged #11972 adding the Copy Page Button), grouping them feels overdue.

The new sub-section contains four plugins:

- **`docusaurus-plugin-copy-page-button`** — moved up from `### Features`. Used by Ethereum, Sui, Monad, and Flare docs.
- **`docusaurus-plugin-llms`** (rachfop) — new. 125⭐, generates `llms.txt` + `llms-full.txt` per [llmstxt.org](https://llmstxt.org).
- **`docusaurus-plugin-llms-txt`** (din0s) — new. Concatenated-Markdown llms.txt generator.
- **`expose-markdown-docusaurus-plugin`** — moved up from `### Features`. Raw `.md` URLs for LLM consumption.

Happy to drop the moves and append the two new plugins to `### Features` instead if you'd rather not regroup — let me know.

## Test Plan

- `yarn install && yarn workspace website start`
- Open `http://localhost:3000/community/resources#ai-agents`
- Verify the new sub-section renders between Integrations and Features
- Verify all four GitHub links resolve

`oxfmt --check website/community/2-resources.mdx` passes (and runs automatically via lint-staged on commit).

### Test links

Deploy preview: will edit with the Netlify preview link once posted, anchor `#ai-agents` on `/community/resources`.

## Related issues/PRs

- #10899 — open proposal for an official `docusaurus-plugin-llms-txt` in core; this PR is complementary, surfacing the community options that exist today.
- #11333 — Copy Page Button feature request; this PR groups the existing community implementation alongside the llms.txt plugins.
- #11972 — recent PR adding \`docusaurus-plugin-copy-page-button\` to the community plugins list; this PR follows the same shape and regroups it.

---

_Assisted-by: Claude (claude-opus-4-7) — full PR is AI-assisted; commits include an \`Assisted-by:\` trailer for transparency, consistent with recent AI-assisted PRs in this repo (#12022, #12021)._