### PR TITLE
fix(mdx-loader): skip asset transformation for directory links with dots

### DIFF
--- a/packages/docusaurus-mdx-loader/src/remark/transformLinks/__tests__/__fixtures__/directory-with.dot/index.md
+++ b/packages/docusaurus-mdx-loader/src/remark/transformLinks/__tests__/__fixtures__/directory-with.dot/index.md
@@ -1,0 +1,4 @@
+# Placeholder
+
+This is a dummy file inside a directory with a dot in its name.
+It exists to test that directory links with dots are not treated as file assets.

--- a/packages/docusaurus-mdx-loader/src/remark/transformLinks/__tests__/index.test.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/transformLinks/__tests__/index.test.ts
@@ -267,4 +267,22 @@ describe('transformLinks plugin', () => {
       });
     });
   });
+
+  it('does not transform link to a directory with a dot in its name', async () => {
+    const result = await processContent(
+      `[link](../directory-with.dot/)`,
+    );
+    expect(result).toMatchInlineSnapshot(
+      `"[link](../directory-with.dot/)"`,
+    );
+  });
+
+  it('does not transform link to a directory with a dot (no trailing slash)', async () => {
+    const result = await processContent(
+      `[link](../directory-with.dot)`,
+    );
+    expect(result).toMatchInlineSnapshot(
+      `"[link](../directory-with.dot)"`,
+    );
+  });
 });

--- a/packages/docusaurus-mdx-loader/src/remark/transformLinks/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/transformLinks/index.ts
@@ -229,6 +229,13 @@ async function processLinkNode(target: Target, context: Context) {
   );
 
   if (localFilePath) {
+    // Skip asset transformation for directories (e.g., "directory-with.dot/")
+    // A directory path with a dot can match hasAssetLikeExtension, but it
+    // should not be treated as a file asset — it's a valid link target.
+    const stats = await fs.stat(localFilePath);
+    if (stats.isDirectory()) {
+      return;
+    }
     await toAssetRequireNode(target, localFilePath, context);
   } else {
     // The @site alias is the only way to believe that the user wants an asset.


### PR DESCRIPTION
## Summary

Fixes a build error when a Markdown link points to a local directory that has a dot in its name (e.g., `[link](../directory-with.dot/)`).

Resolves #11940

## Problem

`path.extname("directory-with.dot/")` returns `".dot"`, which is truthy. The `transformLinks` remark plugin interprets this as a file with an asset-like extension and calls `toAssetRequireNode()`. Since the target is actually a directory (not a file), Webpack's `require()` fails with:

```
Module not found: Error: Can't resolve './../directory-with.dot'
```

## Fix

After `getLocalFileAbsolutePath` resolves the target path, I added a check using `fs.stat()` to see if the path is a directory. If it is, the asset transformation is skipped entirely and the link is left unchanged — which is the correct behavior for directory links.

### Changes

- **`packages/docusaurus-mdx-loader/src/remark/transformLinks/index.ts`** — Added `fs.stat()` directory check before `toAssetRequireNode()`
- **`packages/docusaurus-mdx-loader/src/remark/transformLinks/__tests__/index.test.ts`** — Added two test cases covering directory links with dots (with and without trailing slash)
- **`__fixtures__/directory-with.dot/index.md`** — Test fixture directory

### Test Results

```
 ✓ packages/docusaurus-mdx-loader/src/remark/transformLinks/__tests__/index.test.ts (12 tests) 169ms

 Test Files  1 passed (1)
      Tests  12 passed (12)
```

Let me know if any changes are needed!
