### PR TITLE
docs(cli): document missing `--javascript` option for `docusaurus swizzle`

### DIFF
--- a/website/docs/cli.mdx
+++ b/website/docs/cli.mdx
@@ -125,6 +125,7 @@ The swizzle CLI is interactive and will guide you through the whole [swizzle pro
 | `--wrap` | [Wrap](./swizzling.mdx#wrapping) the theme component |
 | `--danger` | Allow immediate swizzling of unsafe components |
 | `--typescript` | Swizzle the TypeScript variant component |
+| `--javascript` | Swizzle the JavaScript variant component |
 | `--config` | Path to docusaurus config file, default to `[siteDir]/docusaurus.config.js` |
 
 :::warning


### PR DESCRIPTION
Fixes #12036.

The `docusaurus swizzle` options table in `website/docs/cli.mdx` listed `--typescript` but not `--javascript`, even though both flags have existed in the CLI since #9681. The companion `swizzling.mdx` page also has no mention of `--javascript`/`-j`, so users had no way to discover the flag short of running `docusaurus swizzle --help`.

This PR adds a single row to the table.

```diff
 | `--typescript` | Swizzle the TypeScript variant component |
+| `--javascript` | Swizzle the JavaScript variant component |
 | `--config` | Path to docusaurus config file, default to `[siteDir]/docusaurus.config.js` |
```