### PR TITLE
feat(core): upgrade Jiti to v2

### DIFF
--- a/.syncpackrc.ts
+++ b/.syncpackrc.ts
@@ -30,12 +30,6 @@ export default {
   ],
 
   versionGroups: [
-    // TODO temporary, need to upgrade jiti deps
-    {
-      dependencies: ['jiti'],
-      isIgnored: true,
-    },
-
     {
       label: 'Ignore * deps in type-alias packages',
       packages: [

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/index.ts
@@ -88,7 +88,7 @@ async function loadSidebarsFileUnsafe(
   }
 
   // We don't want sidebars to be cached because of hot reloading.
-  const module = await loadFreshModule(sidebarFilePath);
+  const module = await loadFreshModule(sidebarFilePath, {default: true});
 
   // TODO unsafe, need to refactor and improve validation
   return module as SidebarsConfig;

--- a/packages/docusaurus-remark-plugin-npm2yarn/src/index.ts
+++ b/packages/docusaurus-remark-plugin-npm2yarn/src/index.ts
@@ -206,7 +206,4 @@ const plugin: Plugin<[PluginOptions?]> = (options = {}): Transformer => {
   };
 };
 
-// To continue supporting `require('npm2yarn')` without the `.default` ㄟ(▔,▔)ㄏ
-// TODO change to export default after migrating to ESM
-// @ts-expect-error: Docusaurus v4: remove
-export = plugin;
+export default plugin;

--- a/packages/docusaurus-utils/package.json
+++ b/packages/docusaurus-utils/package.json
@@ -28,7 +28,7 @@
     "github-slugger": "^1.5.0",
     "globby": "^11.1.0",
     "gray-matter": "^4.0.3",
-    "jiti": "^1.20.0",
+    "jiti": "^2.7.0",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "micromatch": "^4.0.5",

--- a/packages/docusaurus-utils/src/__tests__/__fixtures__/moduleUtils/user/user.cjs
+++ b/packages/docusaurus-utils/src/__tests__/__fixtures__/moduleUtils/user/user.cjs
@@ -1,7 +1,9 @@
 exports.someNamedExport = 42;
 
+
 module.exports = {
   firstName: 'Sebastien',
   lastName: 'Lorber',
   birthYear: 1986,
 };
+

--- a/packages/docusaurus-utils/src/__tests__/moduleUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/moduleUtils.test.ts
@@ -31,16 +31,33 @@ async function moduleGraphHelpers() {
     return {
       filePath,
       write: (content: string) => fs.outputFile(filePath, content),
-      load: () => loadFreshModule(filePath),
+      load: (withDefault: boolean) => loadModule(filePath, withDefault),
     };
   }
 
   return {fileHelper};
 }
 
-async function loadFixtureModule(fixtureName: string) {
-  return loadFreshModule(
+async function loadModule(modulePath: string, withDefault: boolean) {
+  const result = (await loadFreshModule(
+    modulePath,
+    withDefault ? {default: true} : undefined,
+  )) as object;
+
+  // Because Jiti uses an internal proxy for interopDefault
+  // Spreading converts the proxy to an object compatible with test matchers
+  const obj = {...result};
+  // console.log(modulePath, obj);
+  return obj;
+}
+
+async function loadFixtureModule(
+  fixtureName: string,
+  withDefault: boolean,
+): Promise<{default?: unknown; [key: string]: unknown}> {
+  return loadModule(
     path.resolve(__dirname, '__fixtures__/moduleUtils', fixtureName),
+    withDefault,
   );
 }
 
@@ -48,12 +65,27 @@ describe('loadFreshModule', () => {
   describe('can load CJS user module', () => {
     async function testUserFixture(fixtureName: string) {
       const userFixturePath = `user/${fixtureName}`;
-      const userModule = await loadFixtureModule(userFixturePath);
-      expect(userModule).toEqual({
+
+      await expect(loadFixtureModule(userFixturePath, true)).resolves.toEqual({
         birthYear: 1986,
         firstName: 'Sebastien',
         lastName: 'Lorber',
       });
+
+      // Note: Jiti 2+ doesn't seem to behave exactly the same as Jiti 1 on our
+      // fancy CJS module fixtures mixing "module.exports" + exports.named
+      // I doubt this is a problem in practice, but we'll see
+      // Maybe we'll drop support for CJS config modules in the future?
+      // See https://github.com/facebook/docusaurus/pull/12045
+      /*
+      await expect(loadFixtureModule(userFixturePath, false)).resolves.toEqual({
+        default: {
+          birthYear: 1986,
+          firstName: 'Sebastien',
+          lastName: 'Lorber',
+        },
+      });
+       */
     }
 
     it('for .cjs.js', async () => {
@@ -72,11 +104,19 @@ describe('loadFreshModule', () => {
   describe('can load ESM user module', () => {
     async function testUserFixture(fixtureName: string) {
       const userFixturePath = `user/${fixtureName}`;
-      const userModule = await loadFixtureModule(userFixturePath);
-      expect(userModule).toEqual({
+
+      await expect(loadFixtureModule(userFixturePath, true)).resolves.toEqual({
         birthYear: 1986,
         firstName: 'Sebastien',
         lastName: 'Lorber',
+      });
+
+      await expect(loadFixtureModule(userFixturePath, false)).resolves.toEqual({
+        default: {
+          birthYear: 1986,
+          firstName: 'Sebastien',
+          lastName: 'Lorber',
+        },
         someNamedExport: 42,
       });
     }
@@ -112,7 +152,9 @@ describe('loadFreshModule', () => {
         'dependency2.ts',
         /* language=ts */
         dedent`
-          export default {dep2Val: "dep2 val"} satisfies {dep2Val: string}
+          export const dep2Export = "dep2 val1";
+
+          export default {dep2Val: "dep2 val2"} satisfies {dep2Val: string}
         `,
       );
 
@@ -121,7 +163,7 @@ describe('loadFreshModule', () => {
         /* language=js */
         dedent`
         import dependency1 from "./dependency1";
-        import dependency2 from "./dependency2";
+        import * as dependency2 from "./dependency2";
 
         export default {
           someEntryValue: "entryVal",
@@ -132,22 +174,54 @@ describe('loadFreshModule', () => {
       );
 
       // Should be able to read the initial module graph
-      await expect(entryFile.load()).resolves.toEqual({
+      await expect(entryFile.load(true)).resolves.toEqual({
         someEntryValue: 'entryVal',
         dependency1: {
-          dep1Export: 'dep1 val1',
           dep1Val: 'dep1 val2',
         },
         dependency2: {
-          dep2Val: 'dep2 val',
+          dep2Export: 'dep2 val1',
+          default: {
+            dep2Val: 'dep2 val2',
+          },
         },
       });
-      await expect(dependency1.load()).resolves.toEqual({
-        dep1Export: 'dep1 val1',
+      await expect(entryFile.load(false)).resolves.toEqual({
+        default: {
+          someEntryValue: 'entryVal',
+          dependency1: {
+            // dep1Export: 'dep1 val1', // Expected: not using "* as"
+            dep1Val: 'dep1 val2',
+          },
+          dependency2: {
+            dep2Export: 'dep2 val1',
+
+            default: {
+              dep2Val: 'dep2 val2',
+            },
+          },
+        },
+      });
+
+      await expect(dependency1.load(true)).resolves.toEqual({
         dep1Val: 'dep1 val2',
       });
-      await expect(dependency2.load()).resolves.toEqual({
-        dep2Val: 'dep2 val',
+
+      await expect(dependency1.load(false)).resolves.toEqual({
+        dep1Export: 'dep1 val1',
+        default: {
+          dep1Val: 'dep1 val2',
+        },
+      });
+
+      await expect(dependency2.load(true)).resolves.toEqual({
+        dep2Val: 'dep2 val2',
+      });
+      await expect(dependency2.load(false)).resolves.toEqual({
+        dep2Export: 'dep2 val1',
+        default: {
+          dep2Val: 'dep2 val2',
+        },
       });
 
       // Should be able to read the module graph again after updates
@@ -159,54 +233,121 @@ describe('loadFreshModule', () => {
           export default {dep1Val: "dep1 val2 updated"}
         `,
       );
-      await expect(entryFile.load()).resolves.toEqual({
+
+      await expect(entryFile.load(true)).resolves.toEqual({
         someEntryValue: 'entryVal',
         dependency1: {
-          dep1Export: 'dep1 val1 updated',
+          // dep1Export: 'dep1 val1 updated', // Expected: not using "* as"
           dep1Val: 'dep1 val2 updated',
         },
         dependency2: {
-          dep2Val: 'dep2 val',
+          dep2Export: 'dep2 val1',
+          default: {
+            dep2Val: 'dep2 val2',
+          },
         },
       });
-      await expect(dependency1.load()).resolves.toEqual({
-        dep1Export: 'dep1 val1 updated',
+      await expect(entryFile.load(false)).resolves.toEqual({
+        default: {
+          someEntryValue: 'entryVal',
+          dependency1: {
+            // dep1Export: 'dep1 val1 updated', // Expected: not using "* as"
+            dep1Val: 'dep1 val2 updated',
+          },
+          dependency2: {
+            dep2Export: 'dep2 val1',
+            default: {
+              dep2Val: 'dep2 val2',
+            },
+          },
+        },
+      });
+
+      await expect(dependency1.load(true)).resolves.toEqual({
         dep1Val: 'dep1 val2 updated',
       });
-      await expect(dependency2.load()).resolves.toEqual({
-        dep2Val: 'dep2 val',
+      await expect(dependency1.load(false)).resolves.toEqual({
+        dep1Export: 'dep1 val1 updated',
+        default: {
+          dep1Val: 'dep1 val2 updated',
+        },
+      });
+
+      await expect(dependency2.load(true)).resolves.toEqual({
+        dep2Val: 'dep2 val2',
+      });
+      await expect(dependency2.load(false)).resolves.toEqual({
+        dep2Export: 'dep2 val1',
+        default: {
+          dep2Val: 'dep2 val2',
+        },
       });
 
       // Should be able to read the module graph again after updates
       await dependency2.write(
         /* language=ts */
         dedent`
-          export default {dep2Val: "dep2 val updated"} satisfies {dep2Val: string}
+          export const dep2Export = "dep2 val1 updated";
+
+          export default {dep2Val: "dep2 val2 updated"} satisfies {dep2Val: string}
         `,
       );
-      await expect(entryFile.load()).resolves.toEqual({
+
+      await expect(entryFile.load(true)).resolves.toEqual({
         someEntryValue: 'entryVal',
         dependency1: {
-          dep1Export: 'dep1 val1 updated',
+          // dep1Export: 'dep1 val1 updated', // Expected: not using "* as"
           dep1Val: 'dep1 val2 updated',
         },
         dependency2: {
-          dep2Val: 'dep2 val updated',
+          dep2Export: 'dep2 val1 updated',
+          default: {
+            dep2Val: 'dep2 val2 updated',
+          },
         },
       });
-      await expect(dependency1.load()).resolves.toEqual({
-        dep1Export: 'dep1 val1 updated',
-        dep1Val: 'dep1 val2 updated',
-      });
-      await expect(dependency2.load()).resolves.toEqual({
-        dep2Val: 'dep2 val updated',
+      await expect(entryFile.load(false)).resolves.toEqual({
+        default: {
+          someEntryValue: 'entryVal',
+          dependency1: {
+            // dep1Export: 'dep1 val1 updated', // Expected: not using "* as"
+            dep1Val: 'dep1 val2 updated',
+          },
+          dependency2: {
+            dep2Export: 'dep2 val1 updated',
+            default: {
+              dep2Val: 'dep2 val2 updated',
+            },
+          },
+        },
       });
 
-      // Should be able to read the module graph again after updates
+      await expect(dependency1.load(true)).resolves.toEqual({
+        // dep1Export: 'dep1 val1 updated', // Expected: not using "* as"
+        dep1Val: 'dep1 val2 updated',
+      });
+      await expect(dependency1.load(false)).resolves.toEqual({
+        dep1Export: 'dep1 val1 updated',
+        default: {
+          dep1Val: 'dep1 val2 updated',
+        },
+      });
+
+      await expect(dependency2.load(true)).resolves.toEqual({
+        dep2Val: 'dep2 val2 updated',
+      });
+      await expect(dependency2.load(false)).resolves.toEqual({
+        dep2Export: 'dep2 val1 updated',
+        default: {
+          dep2Val: 'dep2 val2 updated',
+        },
+      });
+
+      // Should be able to read the module graph again after entry updates
       await entryFile.write(
         /* language=js */
         dedent`
-        import dependency1 from "./dependency1";
+        import * as dependency1 from "./dependency1";
         import dependency2 from "./dependency2";
 
         export default {
@@ -217,23 +358,54 @@ describe('loadFreshModule', () => {
         }
         `,
       );
-      await expect(entryFile.load()).resolves.toEqual({
+
+      await expect(entryFile.load(true)).resolves.toEqual({
         someEntryValue: 'entryVal updated',
         newAttribute: 'is there',
         dependency1: {
           dep1Export: 'dep1 val1 updated',
-          dep1Val: 'dep1 val2 updated',
+          default: {
+            dep1Val: 'dep1 val2 updated',
+          },
         },
         dependency2: {
-          dep2Val: 'dep2 val updated',
+          dep2Val: 'dep2 val2 updated',
         },
       });
-      await expect(dependency1.load()).resolves.toEqual({
-        dep1Export: 'dep1 val1 updated',
+      await expect(entryFile.load(false)).resolves.toEqual({
+        default: {
+          someEntryValue: 'entryVal updated',
+          newAttribute: 'is there',
+          dependency1: {
+            dep1Export: 'dep1 val1 updated',
+            default: {
+              dep1Val: 'dep1 val2 updated',
+            },
+          },
+          dependency2: {
+            dep2Val: 'dep2 val2 updated',
+          },
+        },
+      });
+
+      await expect(dependency1.load(true)).resolves.toEqual({
         dep1Val: 'dep1 val2 updated',
       });
-      await expect(dependency2.load()).resolves.toEqual({
-        dep2Val: 'dep2 val updated',
+      await expect(dependency1.load(false)).resolves.toEqual({
+        dep1Export: 'dep1 val1 updated',
+        default: {
+          dep1Val: 'dep1 val2 updated',
+        },
+      });
+
+      await expect(dependency2.load(true)).resolves.toEqual({
+        dep2Val: 'dep2 val2 updated',
+      });
+      await expect(dependency2.load(false)).resolves.toEqual({
+        dep2Export: 'dep2 val1 updated',
+        default: {
+          dep2Val: 'dep2 val2 updated',
+        },
       });
     });
   });

--- a/packages/docusaurus-utils/src/moduleUtils.ts
+++ b/packages/docusaurus-utils/src/moduleUtils.ts
@@ -8,7 +8,7 @@
 import logger from '@docusaurus/logger';
 import {createJiti} from 'jiti';
 
-const DEBUG = true;
+const DEBUG = false;
 
 const jiti = createJiti(__filename, {
   // Transpilation cache, can be safely enabled
@@ -40,12 +40,15 @@ export async function loadFreshModule(
     });
 
     if (DEBUG) {
-      console.log(modulePath, {
+      console.log('Jiti module loaded', {
+        modulePath,
+        options,
         type: typeof module,
         keys:
           module && typeof module === 'object'
             ? Object.keys(module)
             : undefined,
+        module,
       });
     }
 

--- a/packages/docusaurus-utils/src/moduleUtils.ts
+++ b/packages/docusaurus-utils/src/moduleUtils.ts
@@ -5,33 +5,51 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import jiti from 'jiti';
 import logger from '@docusaurus/logger';
+import {createJiti} from 'jiti';
+
+const DEBUG = true;
+
+const jiti = createJiti(__filename, {
+  // Transpilation cache, can be safely enabled
+  fsCache: true,
+  // Bypass Node.js runtime require cache for hot reloads
+  moduleCache: false,
+
+  interopDefault: true,
+  debug: DEBUG,
+});
 
 /*
 jiti is able to load ESM, CJS, JSON, TS modules
  */
-export async function loadFreshModule(modulePath: string): Promise<unknown> {
+export async function loadFreshModule(
+  modulePath: string,
+  options?: {
+    default?: true; // Use this when only the default export matters
+  },
+): Promise<unknown> {
   if (typeof modulePath !== 'string') {
     throw new Error(
       logger.interpolate`Invalid module path of type "name=${typeof modulePath}" with value "name=${modulePath}"`,
     );
   }
   try {
-    const load = jiti(__filename, {
-      // Transpilation cache, can be safely enabled
-      cache: true,
-      // Bypass Node.js runtime require cache
-      // Same as "import-fresh" package we used previously
-      requireCache: false,
-      // Only take into consideration the default export
-      // For now we don't need named exports
-      // This also helps normalize return value for both CJS/ESM/TS modules
-      interopDefault: true,
-      // debug: true,
+    const module = await jiti.import(modulePath, {
+      default: options?.default,
     });
 
-    return load(modulePath);
+    if (DEBUG) {
+      console.log(modulePath, {
+        type: typeof module,
+        keys:
+          module && typeof module === 'object'
+            ? Object.keys(module)
+            : undefined,
+      });
+    }
+
+    return module;
   } catch (error) {
     throw new Error(
       logger.interpolate`Docusaurus could not load module at path path=${modulePath}`,

--- a/packages/docusaurus/src/server/config.ts
+++ b/packages/docusaurus/src/server/config.ts
@@ -50,7 +50,7 @@ export async function loadSiteConfig({
     throw new Error(`Config file at "${siteConfigPath}" not found.`);
   }
 
-  const importedConfig = await loadFreshModule(siteConfigPath);
+  const importedConfig = await loadFreshModule(siteConfigPath, {default: true});
 
   const loadedConfig: unknown =
     typeof importedConfig === 'function'

--- a/yarn.lock
+++ b/yarn.lock
@@ -11498,11 +11498,6 @@ jest-worker@^30.0.5:
     merge-stream "^2.0.0"
     supports-color "^8.1.1"
 
-jiti@^1.20.0:
-  version "1.21.6"
-  resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.6.tgz#6c7f7398dd4b3142767f9a168af2f317a428d268"
-  integrity sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==
-
 jiti@^2.5.1, jiti@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.7.0.tgz#974228f2f4ca2bc21885a1797b45fea68e950c64"


### PR DESCRIPTION
## Breaking change

This upgrade might affect how config files such as `docusaurus.config.js`, `sidebars.js`, plugins/presets/theme in subtle ways.

Most users shouldn't see any difference, but if you do, please tell us and send us a repro: this will help us document that case in our release notes to help other users upgrading to Docusaurus v4.

## Motivation

Upgrade Jiti module loader to v2, handling breaking changes.

For now, I tried to be conservative and kept options similar to what we had before. 

We may want to turn on additional Jiti features in the future, so this is the base minimal PR to set the stage.



## Test Plan

CI

### Test links

https://deploy-preview-_____--docusaurus-2.netlify.app/


