### PR TITLE
chore(ci): Opt out of Yarn 4 security for our internal packages on e2e CI tests

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -144,6 +144,7 @@ jobs:
           yarn config set npmRegistryServer http://localhost:4873
           yarn config set unsafeHttpWhitelist --json '["localhost"]'
           yarn config set enableGlobalCache true
+          yarn config set npmPreapprovedPackages --json '["@docusaurus/*"]'
 
           # Make PnP as strict as possible
           # https://yarnpkg.com/features/pnp#fallback-mode


### PR DESCRIPTION


## Motivation

Our Yarn Berry tests are failing on CI: https://github.com/facebook/docusaurus/actions/runs/26219679740/job/77151106100?pr=12045

Yarn recently added `npmMinimalAgeGate: 1d` by default: 
- https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.15.0
- https://github.com/yarnpkg/berry/pull/7135

```bash
➤ YN0000: Yarn detected that the current workflow is executed from a public pull request. For safety the hardened mode has been enabled.
➤ YN0000: It will prevent malicious lockfile manipulations, in exchange for a slower install time. You can opt-out if necessary; check our documentation for more details.

➤ YN0000: · Yarn 4.15.0
➤ YN0000: ┌ Resolution step
Resolution step
➤ YN0016: @docusaurus/core@npm:3.10.1-NEW-5590: All versions satisfying "3.10.1-NEW-5590" are quarantined
```

Our own packages are safe and do not need to be quarantined when downloaded from our e2e test Verdaccio repository.

Related:
- https://yarnpkg.com/configuration/yarnrc#enableHardenedMode
- https://yarnpkg.com/configuration/yarnrc#npmPreapprovedPackages


## Test Plan

CI

