### PR TITLE
chore(ci): Fix Node `ERR_INTERNAL_ASSERTION` error under Yarn PnP 

### DIFF
--- a/packages/docusaurus/src/server/site.ts
+++ b/packages/docusaurus/src/server/site.ts
@@ -18,7 +18,7 @@ import {loadSiteConfig} from './config';
 import {getAllClientModules} from './clientModules';
 import {loadPlugins, reloadPlugin} from './plugins/plugins';
 import {loadHtmlTags} from './htmlTags';
-import {createSiteMetadata, loadSiteVersion} from './siteMetadata';
+import {createSiteMetadata, tryLoadSitePackageJson} from './siteMetadata';
 import {loadI18n} from './i18n';
 import {
   loadSiteCodeTranslations,
@@ -94,7 +94,7 @@ export async function loadContext(
     siteVersion,
     loadSiteConfig: {siteConfig: initialSiteConfig, siteConfigPath},
   } = await combinePromises({
-    siteVersion: loadSiteVersion(siteDir),
+    siteVersion: tryLoadSitePackageJson(siteDir).then((pkg) => pkg?.version),
     loadSiteConfig: loadSiteConfig({
       siteDir,
       customConfigFilePath,

--- a/packages/docusaurus/src/server/siteMetadata.ts
+++ b/packages/docusaurus/src/server/siteMetadata.ts
@@ -14,27 +14,30 @@ import type {
   SiteMetadata,
 } from '@docusaurus/types';
 
-async function loadPackageJsonVersion(
+type PackageJson = {
+  name?: string;
+  version?: string;
+};
+
+async function tryLoadPackageJson(
   packageJsonPath: string,
-): Promise<string | undefined> {
+): Promise<PackageJson | undefined> {
   if (await fs.pathExists(packageJsonPath)) {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    return (require(packageJsonPath) as {version?: string}).version;
+    try {
+      return (await fs.readJSON(packageJsonPath)) as PackageJson;
+    } catch (error) {
+      throw new Error(`Couldn't load package.json file at ${packageJsonPath}`, {
+        cause: error,
+      });
+    }
   }
   return undefined;
 }
 
-async function loadPackageJsonName(
-  packageJsonPath: string,
-): Promise<string | undefined> {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  return (require(packageJsonPath) as {name?: string}).name;
-}
-
-export async function loadSiteVersion(
+export async function tryLoadSitePackageJson(
   siteDir: string,
-): Promise<string | undefined> {
-  return loadPackageJsonVersion(path.join(siteDir, 'package.json'));
+): Promise<PackageJson | undefined> {
+  return tryLoadPackageJson(path.join(siteDir, 'package.json'));
 }
 
 export async function loadPluginVersion(
@@ -56,10 +59,11 @@ export async function loadPluginVersion(
         // as local plugin.
         return {type: 'project'};
       }
+      const packageJson = await tryLoadPackageJson(packageJsonPath);
       return {
         type: 'package',
-        name: await loadPackageJsonName(packageJsonPath),
-        version: await loadPackageJsonVersion(packageJsonPath),
+        name: packageJson?.name,
+        version: packageJson?.version,
       };
     }
     potentialPluginPackageJsonDirectory = path.dirname(


### PR DESCRIPTION

## Motivation

https://github.com/facebook/docusaurus/actions/runs/26220488585/job/77153903680?pr=12046

For unknown reasons, we started getting these weird errors under Yarn PnP on our CI. 

I don't know if it's related to a Yarn or Node release, and even if it makes sense to report those, given I don't really have a clear minimal repro apart from our full monorepo setup + e2e test suite.

I'm just going to try rewriting a bit the code until this pass.

--- 



<img width="3764" height="1704" alt="CleanShot 2026-05-21 at 13 03 25@2x" src="https://github.com/user-attachments/assets/384fdd11-7891-4a76-8a5e-8f5c16db280c" />


```bash
Error:  Error [ERR_INTERNAL_ASSERTION]: Imported CJS module file:///home/runner/work/docusaurus/test-website/.yarn/__virtual__/@docusaurus-core-virtual-9ff4f0f12d/4/.yarn/berry/cache/@docusaurus-core-npm-3.10.1-NEW-25814-f6a31d56e6-10c0.zip/node_modules/@docusaurus/core/lib/server/siteMetadata.js failed to load module file:///home/runner/work/docusaurus/test-website/package.json using require() due to missed cache
This is caused by either a bug in Node.js or incorrect usage of Node.js internals.
Please open an issue with this stack trace at [https://github.com/nodejs/node/issues](https://github.com/nodejs/node/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen+)

    at assert (node:internal/assert:11:11)
    at require (node:internal/modules/esm/translators:150:7)
    at loadPackageJsonVersion (file:///home/runner/work/docusaurus/test-website/.yarn/__virtual__/@docusaurus-core-virtual-9ff4f0f12d/4/.yarn/berry/cache/@docusaurus-core-npm-3.10.1-NEW-25814-f6a31d56e6-10c0.zip/node_modules/@docusaurus/core/lib/server/siteMetadata.js:19:16)
    at async Promise.all (index 0)
    at async loadContext (file:///home/runner/work/docusaurus/test-website/.yarn/__virtual__/@docusaurus-core-virtual-9ff4f0f12d/4/.yarn/berry/cache/@docusaurus-core-npm-3.10.1-NEW-25814-f6a31d56e6-10c0.zip/node_modules/@docusaurus/core/lib/server/site.js:39:97)
    at async loadSite (file:///home/runner/work/docusaurus/test-website/.yarn/__virtual__/@docusaurus-core-virtual-9ff4f0f12d/4/.yarn/berry/cache/@docusaurus-core-npm-3.10.1-NEW-25814-f6a31d56e6-10c0.zip/node_modules/@docusaurus/core/lib/server/site.js:162:21)
    at async createReloadableSite (file:///home/runner/work/docusaurus/test-website/.yarn/__virtual__/@docusaurus-core-virtual-9ff4f0f12d/4/.yarn/berry/cache/@docusaurus-core-npm-3.10.1-NEW-25814-f6a31d56e6-10c0.zip/node_modules/@docusaurus/core/lib/commands/start/utils.js:62:16)
    at async doStart (file:///home/runner/work/docusaurus/test-website/.yarn/__virtual__/@docusaurus-core-virtual-9ff4f0f12d/4/.yarn/berry/cache/@docusaurus-core-npm-3.10.1-NEW-25814-f6a31d56e6-10c0.zip/node_modules/@docusaurus/core/lib/commands/start/start.js:22:28)
    at async Promise.all (index 0)
    at async runCLI (file:///home/runner/work/docusaurus/test-website/.yarn/__virtual__/@docusaurus-core-virtual-9ff4f0f12d/4/.yarn/berry/cache/@docusaurus-core-npm-3.10.1-NEW-25814-f6a31d56e6-10c0.zip/node_modules/@docusaurus/core/lib/commands/cli.js:56:5) {
  code: 'ERR_INTERNAL_ASSERTION'
}
```
## Test Plan

CI

### Test links

https://deploy-preview-12048--docusaurus-2.netlify.app/

