### PR TITLE
refactor(create-docusaurus): simplify/refactor/split create-docusaurus internal logic

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -20,6 +20,8 @@
     "packages/docusaurus-*/lib/*",
 
     "packages/create-docusaurus/lib/*",
+    "!packages/create-docusaurus/src/**",
+
     "!packages/docusaurus-*/lib/theme/**",
 
     "packages/create-docusaurus/templates/*/docusaurus.config.js",

--- a/packages/create-docusaurus/src/commands.ts
+++ b/packages/create-docusaurus/src/commands.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// We use cross-spawn instead of spawn because of Windows compatibility issues.
+// For example, "yarn" doesn't work on Windows, it requires "yarn.cmd"
+// Tools like execa() use cross-spawn under the hood, and "resolve" the command
+import crossSpawn from 'cross-spawn';
+import supportsColor from 'supports-color';
+import {
+  PackageManagers,
+  type PackageManager,
+  type GitCloneStrategy,
+  type Source,
+} from './constants.js';
+import {askForCustomGitCloneCommand} from './prompts.js';
+
+// This is the same as node's child_process.SpawnOptions type, but extract from
+// cross-spawn directly to ensure direct compatibility.
+type SpawnOptions = NonNullable<Parameters<typeof crossSpawn>[2]>;
+
+/**
+ * Run a command, similar to execa(cmd,args) but simpler
+ * @param command
+ * @param args
+ * @param options
+ * @returns the command exit code
+ */
+async function runCommand(
+  command: string,
+  args: string[] = [],
+  options: SpawnOptions = {},
+): Promise<number> {
+  // This does something similar to execa.command()
+  // we split a string command (with optional args) into command+args
+  // this way it's compatible with spawn()
+  const [realCommand, ...baseArgs] = command.split(' ');
+  const allArgs = [...baseArgs, ...args];
+  if (!realCommand) {
+    throw new Error(`Invalid command: ${command}`);
+  }
+
+  return new Promise<number>((resolve, reject) => {
+    const p = crossSpawn(realCommand, allArgs, {stdio: 'ignore', ...options});
+    p.on('error', reject);
+    p.on('close', (exitCode) =>
+      exitCode !== null
+        ? resolve(exitCode)
+        : reject(new Error(`No exit code for command ${command}`)),
+    );
+  });
+}
+
+async function hasPackageManager(
+  packageManager: PackageManager,
+): Promise<boolean> {
+  return (await runCommand(packageManager, ['--version'])) === 0;
+}
+
+export async function getAvailablePackageManagers(): Promise<PackageManager[]> {
+  const list = await Promise.all(
+    PackageManagers.map(async (name) => {
+      return (await hasPackageManager(name)) ? name : null;
+    }),
+  );
+  return list.filter((item) => item !== null);
+}
+
+export async function runPackageManagerInstallCommand(
+  pkgManager: PackageManager,
+): Promise<boolean> {
+  const installCommand =
+    pkgManager === 'yarn'
+      ? 'yarn'
+      : pkgManager === 'bun'
+        ? 'bun install'
+        : `${pkgManager} install --color always`;
+
+  return (
+    (await runCommand(installCommand, [], {
+      env: {
+        ...process.env,
+        // Force coloring the output
+        ...(supportsColor.stdout ? {FORCE_COLOR: '1'} : {}),
+      },
+    })) === 0
+  );
+}
+
+async function getGitCloneCommand(
+  gitStrategy: GitCloneStrategy,
+): Promise<string> {
+  switch (gitStrategy) {
+    case 'shallow':
+    case 'copy':
+      return 'git clone --recursive --depth 1';
+    case 'custom': {
+      return askForCustomGitCloneCommand();
+    }
+    case 'deep':
+    default:
+      return 'git clone';
+  }
+}
+
+export async function runGitCloneCommand(
+  source: Source & {type: 'git'},
+  dest: string,
+): Promise<boolean> {
+  const gitCommand = await getGitCloneCommand(source.strategy);
+  return (await runCommand(gitCommand, [source.url, dest])) === 0;
+}

--- a/packages/create-docusaurus/src/constants.ts
+++ b/packages/create-docusaurus/src/constants.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Only used in the rare, rare case of running globally installed create +
+// using --skip-install. We need a default name to show the tip text
+export const DefaultPackageManager = 'npm';
+
+// Order matters
+export const LockfileNames = {
+  npm: 'package-lock.json',
+  yarn: 'yarn.lock',
+  pnpm: 'pnpm-lock.yaml',
+  bun: 'bun.lockb',
+};
+
+export type PackageManager = keyof typeof LockfileNames;
+
+export const PackageManagers = Object.keys(LockfileNames) as PackageManager[];
+
+export const GitCloneStrategies = [
+  'deep',
+  'shallow',
+  'copy',
+  'custom',
+] as const;
+
+export type GitCloneStrategy = (typeof GitCloneStrategies)[number];
+
+export type Template = {
+  name: string;
+  path: string;
+  tsVariantPath: string | undefined;
+};
+
+export type Source =
+  | {
+      type: 'template';
+      template: Template;
+      language: 'javascript' | 'typescript';
+    }
+  | {
+      type: 'git';
+      url: string;
+      strategy: GitCloneStrategy;
+    }
+  | {
+      type: 'local';
+      path: string;
+    };

--- a/packages/create-docusaurus/src/index.ts
+++ b/packages/create-docusaurus/src/index.ts
@@ -15,9 +15,27 @@ import path from 'node:path';
 // TODO try to remove these third-party dependencies if possible
 import {logger} from '@docusaurus/logger';
 import prompts, {type Choice} from 'prompts';
-import supportsColor from 'supports-color';
-
-import {runCommand, siteNameToPackageName} from './utils.js';
+import {
+  LockfileNames,
+  PackageManagers,
+  DefaultPackageManager,
+  GitCloneStrategies,
+  type PackageManager,
+  type GitCloneStrategy,
+  type Source,
+  type Template,
+} from './constants.js';
+import {
+  getAvailablePackageManagers,
+  runGitCloneCommand,
+  runPackageManagerInstallCommand,
+} from './commands.js';
+import {
+  siteNameToPackageName,
+  updatePkg,
+  pathExists,
+  printPackageManagerHelp,
+} from './utils.js';
 import {askPreferredLanguage} from './prompts.js';
 
 type LanguagesOptions = {
@@ -28,7 +46,7 @@ type LanguagesOptions = {
 type CLIOptions = LanguagesOptions & {
   packageManager?: PackageManager;
   skipInstall?: boolean;
-  gitStrategy?: GitStrategy;
+  gitStrategy?: GitCloneStrategy;
 };
 
 async function getLanguage(options: LanguagesOptions) {
@@ -41,32 +59,11 @@ async function getLanguage(options: LanguagesOptions) {
   return askPreferredLanguage();
 }
 
-// Only used in the rare, rare case of running globally installed create +
-// using --skip-install. We need a default name to show the tip text
-const defaultPackageManager = 'npm';
-
-const lockfileNames = {
-  npm: 'package-lock.json',
-  yarn: 'yarn.lock',
-  pnpm: 'pnpm-lock.yaml',
-  bun: 'bun.lockb',
-};
-
-type PackageManager = keyof typeof lockfileNames;
-
-const packageManagers = Object.keys(lockfileNames) as PackageManager[];
-
-function pathExists(filePath: string): Promise<boolean> {
-  return fs
-    .access(filePath, fs.constants.F_OK)
-    .then(() => true)
-    .catch(() => false);
-}
 async function findPackageManagerFromLockFile(
   rootDir: string,
 ): Promise<PackageManager | undefined> {
-  for (const packageManager of packageManagers) {
-    const lockFilePath = path.join(rootDir, lockfileNames[packageManager]);
+  for (const packageManager of PackageManagers) {
+    const lockFilePath = path.join(rootDir, LockfileNames[packageManager]);
     if (await pathExists(lockFilePath)) {
       return packageManager;
     }
@@ -75,23 +72,22 @@ async function findPackageManagerFromLockFile(
 }
 
 function findPackageManagerFromUserAgent(): PackageManager | undefined {
-  return packageManagers.find((packageManager) =>
+  return PackageManagers.find((packageManager) =>
     process.env.npm_config_user_agent?.startsWith(packageManager),
   );
 }
 
 async function askForPackageManagerChoice(): Promise<PackageManager> {
-  const hasYarn = (await runCommand('yarn --version')) === 0;
-  const hasPnpm = (await runCommand('pnpm --version')) === 0;
-  const hasBun = (await runCommand('bun --version')) === 0;
-
-  if (!hasYarn && !hasPnpm && !hasBun) {
-    return 'npm';
+  const packageManagers = await getAvailablePackageManagers();
+  if (packageManagers.length === 0) {
+    logger.warn`No package maintainer available? Trying with name=${DefaultPackageManager}`;
+    return DefaultPackageManager;
   }
-  const choices = ['npm', hasYarn && 'yarn', hasPnpm && 'pnpm', hasBun && 'bun']
-    .filter((p): p is string => Boolean(p))
-    .map((p) => ({title: p, value: p}));
+  if (packageManagers.length === 1) {
+    return packageManagers[0]!;
+  }
 
+  const choices = packageManagers.map((p) => ({title: p, value: p}));
   return (
     (
       (await prompts(
@@ -103,11 +99,11 @@ async function askForPackageManagerChoice(): Promise<PackageManager> {
         },
         {
           onCancel() {
-            logger.info`Falling back to name=${defaultPackageManager}`;
+            logger.info`Falling back to name=${DefaultPackageManager}`;
           },
         },
       )) as {packageManager?: PackageManager}
-    ).packageManager ?? defaultPackageManager
+    ).packageManager ?? DefaultPackageManager
   );
 }
 
@@ -115,9 +111,9 @@ async function getPackageManager(
   dest: string,
   {packageManager, skipInstall}: CLIOptions,
 ): Promise<PackageManager> {
-  if (packageManager && !packageManagers.includes(packageManager)) {
+  if (packageManager && !PackageManagers.includes(packageManager)) {
     throw new Error(
-      `Invalid package manager choice ${packageManager}. Must be one of ${packageManagers.join(
+      `Invalid package manager choice ${packageManager}. Must be one of ${PackageManagers.join(
         ', ',
       )}`,
     );
@@ -131,19 +127,13 @@ async function getPackageManager(
     (await findPackageManagerFromLockFile('.')) ??
     findPackageManagerFromUserAgent() ??
     // This only happens if the user has a global installation in PATH
-    (skipInstall ? defaultPackageManager : askForPackageManagerChoice())
+    (skipInstall ? DefaultPackageManager : await askForPackageManagerChoice())
   );
 }
 
 const recommendedTemplate = 'classic';
 const typeScriptTemplateSuffix = '-typescript';
 const templatesDir = fileURLToPath(new URL('../templates', import.meta.url));
-
-type Template = {
-  name: string;
-  path: string;
-  tsVariantPath: string | undefined;
-};
 
 async function readTemplates(): Promise<Template[]> {
   const dirContents = await fs.readdir(templatesDir);
@@ -253,36 +243,6 @@ function isValidGitRepoUrl(gitRepoUrl: string): boolean {
   return ['https://', 'git@'].some((item) => gitRepoUrl.startsWith(item));
 }
 
-const gitStrategies = ['deep', 'shallow', 'copy', 'custom'] as const;
-type GitStrategy = (typeof gitStrategies)[number];
-
-async function getGitCommand(gitStrategy: GitStrategy): Promise<string> {
-  switch (gitStrategy) {
-    case 'shallow':
-    case 'copy':
-      return 'git clone --recursive --depth 1';
-    case 'custom': {
-      const {command} = (await prompts(
-        {
-          type: 'text',
-          name: 'command',
-          message:
-            'Write your own git clone command. The repository URL and destination directory will be supplied. E.g. "git clone --depth 10"',
-        },
-        {
-          onCancel() {
-            logger.info`Falling back to code=${'git clone'}`;
-          },
-        },
-      )) as {command?: string};
-      return command ?? 'git clone';
-    }
-    case 'deep':
-    default:
-      return 'git clone';
-  }
-}
-
 async function getSiteName(
   reqName: string | undefined,
   rootDir: string,
@@ -324,22 +284,6 @@ async function getSiteName(
   )) as {siteName: string};
   return siteName;
 }
-
-type Source =
-  | {
-      type: 'template';
-      template: Template;
-      language: 'javascript' | 'typescript';
-    }
-  | {
-      type: 'git';
-      url: string;
-      strategy: GitStrategy;
-    }
-  | {
-      type: 'local';
-      path: string;
-    };
 
 async function createTemplateSource({
   template,
@@ -390,11 +334,11 @@ async function getUserProvidedSource({
   if (isValidGitRepoUrl(reqTemplate)) {
     if (
       cliOptions.gitStrategy &&
-      !gitStrategies.includes(cliOptions.gitStrategy)
+      !GitCloneStrategies.includes(cliOptions.gitStrategy)
     ) {
       logger.error`Invalid git strategy: name=${
         cliOptions.gitStrategy
-      }. Value must be one of ${gitStrategies.join(', ')}.`;
+      }. Value must be one of ${GitCloneStrategies.join(', ')}.`;
       process.exit(1);
     }
     return {
@@ -466,7 +410,7 @@ async function askGitRepositorySource({
           logger.info`Falling back to name=${'deep'}`;
         },
       },
-    )) as {strategy?: GitStrategy});
+    )) as {strategy?: GitCloneStrategy});
   }
   return {
     type: 'git',
@@ -530,16 +474,6 @@ async function getSource(
   });
 }
 
-async function updatePkg(pkgPath: string, obj: {[key: string]: unknown}) {
-  const pkg = JSON.parse(await fs.readFile(pkgPath, 'utf8')) as {
-    [key: string]: unknown;
-  };
-  const newPkg = Object.assign(pkg, obj);
-
-  await fs.mkdir(path.dirname(pkgPath), {recursive: true});
-  await fs.writeFile(pkgPath, `${JSON.stringify(newPkg, null, 2)}\n`);
-}
-
 export default async function init(
   rootDir: string,
   reqName?: string,
@@ -557,8 +491,7 @@ export default async function init(
   logger.info('Creating new Docusaurus project...');
 
   if (source.type === 'git') {
-    const gitCommand = await getGitCommand(source.strategy);
-    if ((await runCommand(gitCommand, [source.url, dest])) !== 0) {
+    if (!(await runGitCloneCommand(source, dest))) {
       logger.error`Cloning Git template failed!`;
       process.exit(1);
     }
@@ -621,23 +554,7 @@ export default async function init(
     logger.info`Installing dependencies with name=${pkgManager}...`;
     // ...
 
-    if (
-      (await runCommand(
-        pkgManager === 'yarn'
-          ? 'yarn'
-          : pkgManager === 'bun'
-            ? 'bun install'
-            : `${pkgManager} install --color always`,
-        [],
-        {
-          env: {
-            ...process.env,
-            // Force coloring the output
-            ...(supportsColor.stdout ? {FORCE_COLOR: '1'} : {}),
-          },
-        },
-      )) !== 0
-    ) {
+    if (!(await runPackageManagerInstallCommand(pkgManager))) {
       logger.error('Dependency installation failed.');
       logger.info`The site directory has already been created, and you can retry by typing:
 
@@ -647,29 +564,5 @@ export default async function init(
     }
   }
 
-  const useNpm = pkgManager === 'npm';
-  const useBun = pkgManager === 'bun';
-  const useRunCommand = useNpm || useBun;
-  logger.success`Created name=${cdpath}.`;
-  logger.info`Inside that directory, you can run several commands:
-
-  code=${`${pkgManager} start`}
-    Starts the development server.
-
-  code=${`${pkgManager} ${useRunCommand ? 'run ' : ''}build`}
-    Bundles your website into static files for production.
-
-  code=${`${pkgManager} ${useRunCommand ? 'run ' : ''}serve`}
-    Serves the built website locally.
-
-  code=${`${pkgManager} ${useRunCommand ? 'run ' : ''}deploy`}
-    Publishes the website to GitHub pages.
-
-We recommend that you begin by typing:
-
-  code=${`cd ${cdpath}`}
-  code=${`${pkgManager} start`}
-
-Happy building awesome websites!
-`;
+  printPackageManagerHelp({pkgManager, cdpath});
 }

--- a/packages/create-docusaurus/src/prompts.ts
+++ b/packages/create-docusaurus/src/prompts.ts
@@ -25,3 +25,20 @@ export async function askPreferredLanguage(): Promise<
   }
   return language;
 }
+
+export async function askForCustomGitCloneCommand(): Promise<string> {
+  const {command} = (await prompts(
+    {
+      type: 'text',
+      name: 'command',
+      message:
+        'Write your own git clone command. The repository URL and destination directory will be supplied. E.g. "git clone --depth 10"',
+    },
+    {
+      onCancel() {
+        logger.info`Falling back to code=${'git clone'}`;
+      },
+    },
+  )) as {command?: string};
+  return command ?? 'git clone';
+}

--- a/packages/create-docusaurus/src/types.ts
+++ b/packages/create-docusaurus/src/types.ts
@@ -1,8 +1,0 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
-export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';

--- a/packages/create-docusaurus/src/utils.ts
+++ b/packages/create-docusaurus/src/utils.ts
@@ -5,47 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import crossSpawn from 'cross-spawn';
-
-// This is the same as node's child_process.SpawnOptions type, but extract from
-// cross-spawn directly to ensure direct compatibility.
-type SpawnOptions = NonNullable<Parameters<typeof crossSpawn>[2]>;
-
-// We use cross-spawn instead of spawn because of Windows compatibility issues.
-// For example, "yarn" doesn't work on Windows, it requires "yarn.cmd"
-// Tools like execa() use cross-spawn under the hood, and "resolve" the command
-
-/**
- * Run a command, similar to execa(cmd,args) but simpler
- * @param command
- * @param args
- * @param options
- * @returns the command exit code
- */
-export async function runCommand(
-  command: string,
-  args: string[] = [],
-  options: SpawnOptions = {},
-): Promise<number> {
-  // This does something similar to execa.command()
-  // we split a string command (with optional args) into command+args
-  // this way it's compatible with spawn()
-  const [realCommand, ...baseArgs] = command.split(' ');
-  const allArgs = [...baseArgs, ...args];
-  if (!realCommand) {
-    throw new Error(`Invalid command: ${command}`);
-  }
-
-  return new Promise<number>((resolve, reject) => {
-    const p = crossSpawn(realCommand, allArgs, {stdio: 'ignore', ...options});
-    p.on('error', reject);
-    p.on('close', (exitCode) =>
-      exitCode !== null
-        ? resolve(exitCode)
-        : reject(new Error(`No exit code for command ${command}`)),
-    );
-  });
-}
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {logger} from '@docusaurus/logger';
+import {type PackageManager} from './constants.js';
 
 /**
  * We use a simple kebab-case-like conversion
@@ -62,4 +25,59 @@ export function siteNameToPackageName(siteName: string): string {
     return match.map((x) => x.toLowerCase()).join('-');
   }
   return siteName;
+}
+
+export async function updatePkg(
+  pkgPath: string,
+  obj: {[key: string]: unknown},
+): Promise<void> {
+  const pkg = JSON.parse(await fs.readFile(pkgPath, 'utf8')) as {
+    [key: string]: unknown;
+  };
+  const newPkg = Object.assign(pkg, obj);
+
+  await fs.mkdir(path.dirname(pkgPath), {recursive: true});
+  await fs.writeFile(pkgPath, `${JSON.stringify(newPkg, null, 2)}\n`);
+}
+
+// No need for fs-extra dependency
+export async function pathExists(filePath: string): Promise<boolean> {
+  return fs
+    .access(filePath, fs.constants.F_OK)
+    .then(() => true)
+    .catch(() => false);
+}
+
+export function printPackageManagerHelp({
+  pkgManager,
+  cdpath,
+}: {
+  pkgManager: PackageManager;
+  cdpath: string;
+}) {
+  const useNpm = pkgManager === 'npm';
+  const useBun = pkgManager === 'bun';
+  const run = useNpm || useBun ? 'run ' : '';
+  logger.success`Created name=${cdpath}.`;
+  logger.info`Inside that directory, you can run several commands:
+
+  code=${`${pkgManager} start`}
+    Starts the development server.
+
+  code=${`${pkgManager} ${run}build`}
+    Bundles your website into static files for production.
+
+  code=${`${pkgManager} ${run}serve`}
+    Serves the built website locally.
+
+  code=${`${pkgManager} ${run}deploy`}
+    Publishes the website to GitHub pages.
+
+We recommend that you begin by typing:
+
+  code=${`cd ${cdpath}`}
+  code=${`${pkgManager} start`}
+
+Happy building awesome websites!
+`;
 }


### PR DESCRIPTION


## Motivation

The `create-docusaurus` historical package is quite messy. 

This splits it into smaller files and simplify a few things without changing any major behavior.

This should also help CodeQL avoid reporting critical issues by isolating the shell exec commands into a single file and not exporting our tiny `runCommand()` helper.

https://github.com/facebook/docusaurus/security/code-scanning/153

At the moment, CodeQL reports false positives:

<img width="1418" height="800" alt="CleanShot 2026-05-21 at 17 08 59@2x" src="https://github.com/user-attachments/assets/65fae843-31dc-48c3-af43-20ef3331465e" />

In practice, in `create-docusaurus`, the "dynamic commands" we run are all crafted locally, and those relying on user inputs are provided by the user with a CLI prompt, so it's not really unsafe to run them, considering the user can already run them.


## Test Plan

Our unit test coverage is not strong on this side


CI e2e tests running our `create-docusaurus` CLI
