### PR TITLE
fix(bundler): do not import `@swc/html`, fix StackBlitz playground

### DIFF
--- a/packages/docusaurus-faster/src/index.ts
+++ b/packages/docusaurus-faster/src/index.ts
@@ -8,7 +8,6 @@
 import {rspack as Rspack} from '@rspack/core';
 import * as lightningcss from 'lightningcss';
 import browserslist from 'browserslist';
-import {minify as swcHtmlMinifier} from '@swc/html';
 import semver from 'semver';
 import type {JsMinifyOptions, Options as SwcOptions} from '@swc/core';
 import type {CurrentBundler} from '@docusaurus/types';
@@ -42,8 +41,15 @@ export const getSwcLoaderOptions = ({
 
 export const rspack: typeof Rspack = Rspack;
 
-export function getSwcHtmlMinifier(): typeof swcHtmlMinifier {
-  return swcHtmlMinifier;
+type SwcHtmlMinifier = (typeof import('@swc/html'))['minify'];
+
+// Import it lazily: not need for the dev server, more performant
+// This also temporarily fix our StackBlitz playground
+// See https://github.com/facebook/docusaurus/issues/12008
+// See https://github.com/swc-project/swc/issues/11833
+export async function getSwcHtmlMinifier(): Promise<SwcHtmlMinifier> {
+  const {minify} = await import('@swc/html');
+  return minify;
 }
 
 // Note: these options are similar to what we use in core


### PR DESCRIPTION

## Motivation

Fix https://github.com/facebook/docusaurus/issues/12008

For now there's a Wasm binding bug in `@swc/html` that prevents it from loading in StackBlitz playground: https://github.com/swc-project/swc/issues/11833

With Docusaurus Faster enabled by default in v3.10, our StackBlitz playground is broken due to that issue, because the problematic dependency is imported eagerly.

Until they release the fix, I'd like to fix our playground by loading that dependency lazily, which is more performant anyway because this package is not needed until minimization.

This permits:
- to slightly improve perf (probably not significantly)
- to fix `yarn start` in StackBlitz
- to fix `SKIP_HTML_MINIFICATION=true yarn build` in StackBlitz, until the upstream gets officially solved


## Test Plan

CI + local tests 
