### PR TITLE
fix(utils): preserve author names containing commas in git log parsing

### DIFF
--- a/packages/docusaurus-utils/src/vcs/__tests__/gitUtils.test.ts
+++ b/packages/docusaurus-utils/src/vcs/__tests__/gitUtils.test.ts
@@ -396,6 +396,24 @@ describe('commit info APIs', () => {
         }
       `);
     });
+
+    it('preserves author names containing commas', async () => {
+      const {repoDir, git} = await createGitRepoEmpty();
+
+      await git.commitFile('comma-author.txt', {
+        fileContent: 'content',
+        commitMessage: 'Commit by author with comma in name',
+        commitDate: '2024-01-15',
+        commitAuthor: 'Doe, Jane <jane@example.com>',
+      });
+
+      const filesInfo = await getGitRepositoryFilesInfo(repoDir);
+      const fileInfo = filesInfo.get('comma-author.txt');
+
+      expect(fileInfo).toBeDefined();
+      expect(fileInfo!.creation.author).toBe('Doe, Jane');
+      expect(fileInfo!.lastUpdate.author).toBe('Doe, Jane');
+    });
   });
 });
 

--- a/packages/docusaurus-utils/src/vcs/gitUtils.ts
+++ b/packages/docusaurus-utils/src/vcs/gitUtils.ts
@@ -491,11 +491,13 @@ The command exited with code ${result.exitCode}: ${result.stderr}`,
   for (const logLine of logLines) {
     if (logLine.startsWith('t:')) {
       // t:<timestamp>,a:<author name>
-      const [timestampStr, authorStr] = logLine.split(',') as [string, string];
-      const timestamp = Number.parseInt(timestampStr.slice(2), 10) * 1000;
-      const author = authorStr.slice(2);
+      // We can't use split(',') because author names may contain commas
+      // (e.g., "Last, First" or "John Doe, Jr.")
+      const separatorIndex = logLine.indexOf(',a:');
+      const timestampStr = logLine.slice(2, separatorIndex);
+      const author = logLine.slice(separatorIndex + 3);
 
-      runningDate = timestamp;
+      runningDate = Number.parseInt(timestampStr, 10) * 1000;
       runningAuthor = author;
     }
 

--- a/packages/docusaurus-utils/src/vcs/gitUtils.ts
+++ b/packages/docusaurus-utils/src/vcs/gitUtils.ts
@@ -492,11 +492,11 @@ The command exited with code ${result.exitCode}: ${result.stderr}`,
     if (logLine.startsWith('t:')) {
       // t:<timestamp>,a:<author name>
       // We can't use split(',') because author names may contain commas
-      // (e.g., "Last, First" or "John Doe, Jr.")
-      const separatorIndex = logLine.indexOf(',a:');
-      const timestampStr = logLine.slice(2, separatorIndex);
-      const author = logLine.slice(separatorIndex + 3);
-
+      // Example: "t:123456,a:John Doe, Jr."
+      const [timestampStr, author] = logLine.slice(2).split(',a:') as [
+        string,
+        string,
+      ];
       runningDate = Number.parseInt(timestampStr, 10) * 1000;
       runningAuthor = author;
     }


### PR DESCRIPTION
## Motivation

`getGitRepositoryFilesInfo()` in `gitUtils.ts` parses `git log` output formatted as `t:<timestamp>,a:<author name>`. The current implementation uses `logLine.split(',')` to separate the timestamp from the author name.

This breaks when the author's Git `user.name` contains a comma — for example, `Doe, Jane` or `Smith, Jr.`. The split produces three array elements instead of two:

```
Input:  "t:1716666666,a:Doe, Jane"
Split:  ["t:1716666666", "a:Doe", " Jane"]
Result: author = "Doe"  ← truncated!
```

The `getFileCommitDate()` function in the same file avoids this by using a regex with a greedy `(?<author>.+)` capture group, but the newer `getGitRepositoryFilesInfo()` function (introduced in the eager VCS strategy) doesn't share that approach.

## Fix

Replaced `split(',')` with `indexOf(',a:')` to locate the known separator between the timestamp and author fields. This safely handles commas anywhere in the author name:

```ts
// Before:
const [timestampStr, authorStr] = logLine.split(',') as [string, string];
const timestamp = Number.parseInt(timestampStr.slice(2), 10) * 1000;
const author = authorStr.slice(2);

// After:
const separatorIndex = logLine.indexOf(',a:');
const timestampStr = logLine.slice(2, separatorIndex);
const author = logLine.slice(separatorIndex + 3);
```

## Test plan

Added a regression test in `gitUtils.test.ts` that commits a file with an author name containing a comma (`Doe, Jane`) and verifies that `getGitRepositoryFilesInfo()` preserves the full name.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md)
