### PR TITLE
fix(theme): make navbar width consistent with main layout on large di…

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/Layout/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/Layout/styles.module.css
@@ -12,3 +12,12 @@
 .navbarHidden {
   transform: translate3d(0, calc(-100% - 2px), 0);
 }
+
+/* Fix for Issue #7562: Keep navbar width consistent with main container */
+:global(.navbar) {
+  justify-content: center;
+}
+
+:global(.navbar__inner) {
+  max-width: var(--ifm-container-width-xl);
+}


### PR DESCRIPTION
## Pre-flight checklist
- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #7562) and the maintainers have approved on my working plan.
## Motivation
Fixes #7562
On large displays, the navbar width expands to the edges of the screen, making it inconsistent with the main content area and footer which have a maximum width. This PR limits the `navbar__inner` maximum width to match the rest of the layout (using `var(--ifm-container-width-xl)`) and centers it, improving readability and scanning on ultrawide monitors.
(AI-assisted)
## Test Plan
Tested locally by running the Docusaurus website and expanding the browser window to an ultrawide resolution. Verified that the navbar contents remain centered and aligned with the main page content layout.
### Test links
N/A

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
