### PR TITLE
fix(theme-common): fix `extractLeadingEmoji()` edge case with digits

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/__tests__/emojiUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/emojiUtils.test.ts
@@ -71,4 +71,11 @@ describe('extractLeadingEmoji', () => {
       rest: '11 Hello World',
     });
   });
+
+  it('extract emoji digits', () => {
+    expect(extractLeadingEmoji('1️⃣ Hello World')).toEqual({
+      emoji: '1️⃣',
+      rest: ' Hello World',
+    });
+  });
 });

--- a/packages/docusaurus-theme-common/src/utils/__tests__/emojiUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/emojiUtils.test.ts
@@ -64,4 +64,11 @@ describe('extractLeadingEmoji', () => {
       rest: 'Hello World 😀',
     });
   });
+
+  it('does not extract digits', () => {
+    expect(extractLeadingEmoji('11 Hello World')).toEqual({
+      emoji: null,
+      rest: '11 Hello World',
+    });
+  });
 });

--- a/packages/docusaurus-theme-common/src/utils/emojiUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/emojiUtils.ts
@@ -29,10 +29,10 @@ export function extractLeadingEmoji(input: string): {
     return {emoji: null, rest: input};
   }
 
-  // Leading grapheme contains an emoji (covers flags/ZWJ/skin tones)
+  // Leading grapheme contains an emoji (covers flags/ZWJ/skin tones, excludes digits)
   if (
     !/\p{Extended_Pictographic}/u.test(grapheme) &&
-    !/\p{Emoji}/u.test(grapheme)
+    !(/\p{Emoji}/u.test(grapheme) && !/\d/u.test(grapheme))
   ) {
     return {emoji: null, rest: input};
   }

--- a/packages/docusaurus-theme-common/src/utils/emojiUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/emojiUtils.ts
@@ -29,11 +29,10 @@ export function extractLeadingEmoji(input: string): {
     return {emoji: null, rest: input};
   }
 
-  // Leading grapheme contains an emoji (covers flags/ZWJ/skin tones, excludes digits)
-  if (
-    !/\p{Extended_Pictographic}/u.test(grapheme) &&
-    !(/\p{Emoji}/u.test(grapheme) && !/\d/u.test(grapheme))
-  ) {
+  // Leading grapheme contains an emoji
+  // Covers flags/ZWJ/skin tones, excludes digits
+  // See https://github.com/facebook/docusaurus/pull/12072
+  if (!/^\p{RGI_Emoji}$/v.test(grapheme)) {
     return {emoji: null, rest: input};
   }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

This fixes [this issue](https://github.com/facebook/docusaurus/issues/12071).

## Test Plan

A simple Unit-Test checks that numbers are no longer recognized as emoji.
