### PR TITLE
fix(theme-common): handle zero-duration collapsible transition

### DIFF
--- a/packages/docusaurus-theme-common/src/components/Collapsible/__tests__/index.test.tsx
+++ b/packages/docusaurus-theme-common/src/components/Collapsible/__tests__/index.test.tsx
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// @vitest-environment jsdom
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import React from 'react';
+import {act, cleanup, fireEvent, render, screen} from '@testing-library/react';
+import {Collapsible, useCollapsible} from '../index';
+
+function CollapsibleHarness({
+  onTransitionEnd,
+}: {
+  onTransitionEnd: (collapsed: boolean) => void;
+}) {
+  const {collapsed, toggleCollapsed} = useCollapsible({initialState: true});
+
+  return (
+    <>
+      <button type="button" onClick={toggleCollapsed}>
+        toggle
+      </button>
+      <Collapsible
+        lazy={false}
+        collapsed={collapsed}
+        onCollapseTransitionEnd={onTransitionEnd}>
+        <div data-testid="collapsible-content">content</div>
+      </Collapsible>
+    </>
+  );
+}
+
+function fireHeightTransitionEnd(element: HTMLElement) {
+  const event = new Event('transitionend', {bubbles: true});
+  Object.defineProperty(event, 'propertyName', {
+    configurable: true,
+    value: 'height',
+  });
+  fireEvent(element, event);
+}
+
+describe('Collapsible', () => {
+  let transitionProperty: string;
+  let transitionDuration: string;
+
+  beforeEach(() => {
+    transitionProperty = 'height';
+    transitionDuration = '0ms';
+    const getComputedStyle = window.getComputedStyle.bind(window);
+
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback(0);
+      return 0;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(
+      () => undefined,
+    );
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn(() => ({matches: false}) as MediaQueryList),
+    });
+    vi.spyOn(window, 'getComputedStyle').mockImplementation((element) => {
+      const style = getComputedStyle(element);
+      Object.defineProperty(style, 'transitionDuration', {
+        configurable: true,
+        value: transitionDuration,
+      });
+      Object.defineProperty(style, 'transitionProperty', {
+        configurable: true,
+        value: transitionProperty,
+      });
+      return style;
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(window, 'matchMedia');
+  });
+
+  it('does not wait for transitionend when height transition duration is zero', () => {
+    const onTransitionEnd = vi.fn();
+    render(<CollapsibleHarness onTransitionEnd={onTransitionEnd} />);
+
+    const collapsible = screen.getByTestId('collapsible-content')
+      .parentElement as HTMLElement;
+    Object.defineProperty(collapsible, 'scrollHeight', {
+      configurable: true,
+      value: 128,
+    });
+
+    expect(collapsible.style.display).toBe('none');
+    expect(collapsible.style.height).toBe('0px');
+    expect(collapsible.style.overflow).toBe('hidden');
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', {name: 'toggle'}));
+    });
+
+    expect(onTransitionEnd).toHaveBeenLastCalledWith(false);
+    expect(collapsible.style.display).toBe('block');
+    expect(collapsible.style.height).toBe('auto');
+    expect(collapsible.style.overflow).toBe('visible');
+
+    fireHeightTransitionEnd(collapsible);
+
+    expect(onTransitionEnd).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', {name: 'toggle'}));
+    });
+
+    expect(onTransitionEnd).toHaveBeenLastCalledWith(true);
+    expect(collapsible.style.display).toBe('none');
+    expect(collapsible.style.height).toBe('0px');
+    expect(collapsible.style.overflow).toBe('hidden');
+  });
+
+  it('does not wait for transitionend when height transition is not configured', () => {
+    transitionProperty = 'opacity';
+    transitionDuration = '200ms';
+    const onTransitionEnd = vi.fn();
+    render(<CollapsibleHarness onTransitionEnd={onTransitionEnd} />);
+
+    const collapsible = screen.getByTestId('collapsible-content')
+      .parentElement as HTMLElement;
+    Object.defineProperty(collapsible, 'scrollHeight', {
+      configurable: true,
+      value: 128,
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', {name: 'toggle'}));
+    });
+
+    expect(onTransitionEnd).toHaveBeenLastCalledWith(false);
+    expect(collapsible.style.display).toBe('block');
+    expect(collapsible.style.height).toBe('auto');
+    expect(collapsible.style.overflow).toBe('visible');
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', {name: 'toggle'}));
+    });
+
+    expect(onTransitionEnd).toHaveBeenLastCalledWith(true);
+    expect(collapsible.style.display).toBe('none');
+    expect(collapsible.style.height).toBe('0px');
+    expect(collapsible.style.overflow).toBe('hidden');
+  });
+
+  it('waits for height transition end when transition duration is not zero', () => {
+    transitionDuration = '1ms';
+    const onTransitionEnd = vi.fn();
+    render(<CollapsibleHarness onTransitionEnd={onTransitionEnd} />);
+
+    const collapsible = screen.getByTestId('collapsible-content')
+      .parentElement as HTMLElement;
+    Object.defineProperty(collapsible, 'scrollHeight', {
+      configurable: true,
+      value: 128,
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', {name: 'toggle'}));
+    });
+
+    expect(onTransitionEnd).not.toHaveBeenCalled();
+    expect(collapsible.style.display).toBe('block');
+    expect(collapsible.style.height).toBe('128px');
+    expect(collapsible.style.overflow).toBe('hidden');
+
+    fireHeightTransitionEnd(collapsible);
+
+    expect(onTransitionEnd).toHaveBeenLastCalledWith(false);
+    expect(collapsible.style.height).toBe('auto');
+    expect(collapsible.style.overflow).toBe('visible');
+  });
+
+  it('waits for height transition end when zero duration belongs to another property', () => {
+    transitionProperty = 'opacity, height';
+    transitionDuration = '0ms, 1ms';
+    const onTransitionEnd = vi.fn();
+    render(<CollapsibleHarness onTransitionEnd={onTransitionEnd} />);
+
+    const collapsible = screen.getByTestId('collapsible-content')
+      .parentElement as HTMLElement;
+    Object.defineProperty(collapsible, 'scrollHeight', {
+      configurable: true,
+      value: 128,
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', {name: 'toggle'}));
+    });
+
+    expect(onTransitionEnd).not.toHaveBeenCalled();
+
+    fireHeightTransitionEnd(collapsible);
+
+    expect(onTransitionEnd).toHaveBeenLastCalledWith(false);
+    expect(collapsible.style.height).toBe('auto');
+    expect(collapsible.style.overflow).toBe('visible');
+  });
+});

--- a/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
+++ b/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
@@ -11,6 +11,7 @@ import React, {
   useRef,
   useCallback,
   type RefObject,
+  type MutableRefObject,
   type Dispatch,
   type SetStateAction,
   type ReactNode,
@@ -65,6 +66,30 @@ function applyCollapsedStyle(el: HTMLElement, collapsed: boolean) {
   el.style.height = collapsedStyles.height;
 }
 
+function willNotTransitionHeight(el: HTMLElement) {
+  const style = getComputedStyle(el);
+  const transitionProperties = style.transitionProperty.split(',');
+  const transitionDurations = style.transitionDuration.split(',');
+
+  if (!style.transitionDuration || transitionDurations.length === 0) {
+    return true;
+  }
+
+  const willTransition = transitionProperties.some((property, index) => {
+    const propName = property.trim();
+    if (propName === 'height' || propName === 'all') {
+      const duration = transitionDurations[index % transitionDurations.length];
+      if (duration !== undefined) {
+        const parsedDuration = parseFloat(duration);
+        return !isNaN(parsedDuration) && parsedDuration > 0;
+      }
+    }
+    return false;
+  });
+
+  return !willTransition;
+}
+
 /*
 Lex111: Dynamic transition duration is used in Material design, this technique
 is good for a large number of items.
@@ -90,10 +115,12 @@ function useCollapseAnimation({
   collapsibleRef,
   collapsed,
   animation,
+  onCollapseTransitionEnd,
 }: {
   collapsibleRef: RefObject<HTMLElement | null>;
   collapsed: boolean;
   animation?: CollapsibleAnimationConfig;
+  onCollapseTransitionEnd: MutableRefObject<(() => void) | null>;
 }) {
   const mounted = useRef(false);
 
@@ -134,6 +161,9 @@ function useCollapseAnimation({
           requestAnimationFrame(() => {
             el.style.height = CollapsedStyles.height;
             el.style.overflow = CollapsedStyles.overflow;
+            if (willNotTransitionHeight(el)) {
+              onCollapseTransitionEnd.current?.();
+            }
           });
         }
         // When expanding
@@ -141,6 +171,9 @@ function useCollapseAnimation({
           el.style.display = 'block';
           requestAnimationFrame(() => {
             applyTransitionStyles();
+            if (willNotTransitionHeight(el)) {
+              onCollapseTransitionEnd.current?.();
+            }
           });
         }
       });
@@ -149,7 +182,7 @@ function useCollapseAnimation({
     }
 
     return startAnimation();
-  }, [collapsibleRef, collapsed, animation]);
+  }, [collapsibleRef, collapsed, animation, onCollapseTransitionEnd]);
 }
 
 type CollapsibleElementType = React.ElementType<
@@ -184,8 +217,27 @@ function CollapsibleBase({
   className,
 }: CollapsibleBaseProps) {
   const collapsibleRef = useRef<HTMLElement>(null);
+  const collapseTransitionEnd = useRef<(() => void) | null>(null);
+  const transitionFinished = useRef(false);
 
-  useCollapseAnimation({collapsibleRef, collapsed, animation});
+  useEffect(() => {
+    transitionFinished.current = false;
+    collapseTransitionEnd.current = () => {
+      if (transitionFinished.current) {
+        return;
+      }
+      transitionFinished.current = true;
+      applyCollapsedStyle(collapsibleRef.current!, collapsed);
+      onCollapseTransitionEnd?.(collapsed);
+    };
+  }, [collapsed, onCollapseTransitionEnd]);
+
+  useCollapseAnimation({
+    collapsibleRef,
+    collapsed,
+    animation,
+    onCollapseTransitionEnd: collapseTransitionEnd,
+  });
 
   return (
     <As
@@ -197,8 +249,7 @@ function CollapsibleBase({
           return;
         }
 
-        applyCollapsedStyle(collapsibleRef.current!, collapsed);
-        onCollapseTransitionEnd?.(collapsed);
+        collapseTransitionEnd.current?.();
       }}
       className={className}>
       {children}


### PR DESCRIPTION
## Summary

Fixes #12063.

This updates the shared `Collapsible` component to handle zero-duration height transitions. In browsers such as Firefox, `transitionend` may not fire for `0ms` transitions, so the component can remain stuck with temporary height/overflow animation styles.

The fix detects when the computed `height` transition duration is zero and runs the existing cleanup path synchronously instead of waiting for `transitionend`.

## Details

The check is scoped to `height` and `all` transition properties, so unrelated zero-duration transitions such as `opacity 0ms` do not bypass normal height transition behavior.

A shared completion callback is used for both the native `transitionend` path and the zero-duration fallback, with a guard to avoid duplicate cleanup.

## Tests

Added regression coverage for:

- zero-duration height transitions completing without `transitionend`
- normal nonzero height transitions still waiting for `transitionend`
- multi-property transitions where another property has `0ms` but `height` does not

## Validation

```bash
yarn test packages/docusaurus-theme-common/src/components/Collapsible/__tests__/index.test.tsx
yarn lint:js --quiet packages/docusaurus-theme-common/src/components/Collapsible/index.tsx packages/docusaurus-theme-common/src/components/Collapsible/__tests__/index.test.tsx
yarn workspace @docusaurus/theme-common build
git diff --check
```
> **AI-assisted:** Parts of the implementation were developed with Claude Code.
> Root cause analysis and proposed fix by @AkshatRaj00 in #12063. I implemented the fix based on his diagnosis and added regression tests,
> and verified the fix with tests and manual reproduction.
