### PR TITLE
fix(ci): forks should not run publish/argos workflows + fix lint fix typo 

### DIFF
--- a/.github/workflows/argos.yml
+++ b/.github/workflows/argos.yml
@@ -26,7 +26,12 @@ jobs:
     # Argos is heavy to run
     # We only want to trigger Argos on PRs with the 'Argos' label
     # See https://stackoverflow.com/questions/62325286/run-github-actions-when-pull-requests-have-a-specific-label
-    if: ${{ github.repository == 'facebook/docusaurus' && ((github.event_name != 'pull_request' && github.ref_name == 'main') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Argos'))) }}
+    if: |
+      github.repository == 'facebook/docusaurus' &&
+      (
+        (github.event_name != 'pull_request' && github.ref_name == 'main') ||
+        (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Argos'))
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code

--- a/.github/workflows/argos.yml
+++ b/.github/workflows/argos.yml
@@ -26,7 +26,7 @@ jobs:
     # Argos is heavy to run
     # We only want to trigger Argos on PRs with the 'Argos' label
     # See https://stackoverflow.com/questions/62325286/run-github-actions-when-pull-requests-have-a-specific-label
-    if: ${{ (github.event_name != 'pull_request' && github.ref_name == 'main') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Argos')) }}
+    if: ${{ github.repository == 'facebook/docusaurus' && ((github.event_name != 'pull_request' && github.ref_name == 'main') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Argos'))) }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code

--- a/.github/workflows/continuous-releases.yml
+++ b/.github/workflows/continuous-releases.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   release:
     name: Continuous Releases
+    if: github.repository == 'facebook/docusaurus'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/lint-autofix.yml
+++ b/.github/workflows/lint-autofix.yml
@@ -46,7 +46,7 @@ jobs:
         run: yarn lint:spelling:fix
 
       - name: AutoFix Dependency versions
-        run: yarn lint:spelling:fix
+        run: yarn lint:syncpack:fix
 
       - name: Print Diff
         run: git diff

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,7 @@ permissions:
 jobs:
   publish:
     name: Publish NPM release
+    if: github.repository == 'facebook/docusaurus'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION


## Motivation

Lint Fix workflow was not calling `lint:syncpack:fix` (typo)

Some CI workflows that trigger on `push: main` should only run on our main repo, not from forks. This leads to contributors encountering CI errors on their forks:

<img width="1162" height="960" alt="CleanShot 2026-05-28 at 12 52 53@2x" src="https://github.com/user-attachments/assets/017aea5e-84a6-4697-bc5e-43dc9c2f6d5c" />



## Test Plan

CI
