### PR TITLE
chore(ci): restore original CodeQL workflow + add config file

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -4,7 +4,7 @@ name: Docusaurus CodeQL config
 # The inputs (files, CLI args) are usually controlled locally
 query-filters:
   # Many false positives
-  # Example: https://github.com/facebook/docusaurus/security/code-scanning/18
+  # Example: https://github.com/facebook/docusaurus/security/code-scanning/168
   - exclude:
       id: js/path-injection
   # Many false positives

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,5 +1,9 @@
 name: Docusaurus CodeQL config
 
+paths-ignore:
+  - '**/__fixtures__/**'
+  - website/_dogfooding/_asset-tests/badSyntax.js
+
 # We can disable various rules because Docusaurus has no runtime
 # The inputs (files, CLI args) are usually controlled locally
 query-filters:
@@ -11,7 +15,6 @@ query-filters:
   # Example: https://github.com/facebook/docusaurus/security/code-scanning/150
   - exclude:
       id: js/polynomial-redos
-
   # - exclude:
   #    id: js/command-line-injection
   # - exclude:

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,18 @@
+name: Docusaurus CodeQL config
+
+# We can disable various rules because Docusaurus has no runtime
+# The inputs (files, CLI args) are usually controlled locally
+query-filters:
+  # Many false positives
+  # Example: https://github.com/facebook/docusaurus/security/code-scanning/18
+  - exclude:
+      id: js/path-injection
+  # Many false positives
+  # Example: https://github.com/facebook/docusaurus/security/code-scanning/150
+  - exclude:
+      id: js/polynomial-redos
+
+  # - exclude:
+  #    id: js/command-line-injection
+  # - exclude:
+  #    id: js/indirect-command-line-injection

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
+    if: github.repository == 'facebook/docusaurus'
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,12 +25,6 @@ jobs:
       contents: read
       security-events: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language:
-          - javascript
-
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -38,7 +32,8 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@4e94bd11f71e507f7f87df81788dff88d1dacbfb # 4.31.0
         with:
-          languages: ${{ matrix.language }}
+          languages: javascript-typescript
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@4e94bd11f71e507f7f87df81788dff88d1dacbfb # 4.31.0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,5 +38,3 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@4e94bd11f71e507f7f87df81788dff88d1dacbfb # 4.31.0
-        with:
-          debug: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,3 +38,5 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@4e94bd11f71e507f7f87df81788dff88d1dacbfb # 4.31.0
+        with:
+          debug: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+      - docusaurus-v**
+  pull_request:
+    branches:
+      - main
+      - docusaurus-v**
+  schedule:
+    - cron: 25 22 * * 3
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@4e94bd11f71e507f7f87df81788dff88d1dacbfb # 4.31.0
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@4e94bd11f71e507f7f87df81788dff88d1dacbfb # 4.31.0


### PR DESCRIPTION

## Motivation

Reverts https://github.com/facebook/docusaurus/pull/12027 because using GitHub action config file gives me more flexibility to fix CodeQL settings and ignore false positives.

I'm taking the opportunity to disable some false positive alerts that do not really apply to Docusaurus (path injection, regexp dos etc...) because as a static site generator, we have no runtime and have control over inputs (filesystem, cli args).

## Test Plan

CI
