### PR TITLE
fix(gtag.js, faster): Fix StackBlitz, vendor `@types/gtag.js`, upgrade `@swc/html` 

### DIFF
--- a/admin/scripts/generateExamples.js
+++ b/admin/scripts/generateExamples.js
@@ -69,9 +69,9 @@ async function generateTemplateExample(template) {
       hardReloadOnChange: true,
       view: 'browser',
       template: 'docusaurus',
-      node: '18',
+      node: '24',
       container: {
-        node: '18',
+        node: '24',
       },
     };
     await fs.writeFile(

--- a/examples/classic-typescript/sandbox.config.json
+++ b/examples/classic-typescript/sandbox.config.json
@@ -3,8 +3,8 @@
   "hardReloadOnChange": true,
   "view": "browser",
   "template": "docusaurus",
-  "node": "18",
+  "node": "22",
   "container": {
-    "node": "18"
+    "node": "22"
   }
 }

--- a/examples/classic-typescript/sandbox.config.json
+++ b/examples/classic-typescript/sandbox.config.json
@@ -3,8 +3,8 @@
   "hardReloadOnChange": true,
   "view": "browser",
   "template": "docusaurus",
-  "node": "24",
+  "node": "18",
   "container": {
-    "node": "24"
+    "node": "18"
   }
 }

--- a/examples/classic-typescript/sandbox.config.json
+++ b/examples/classic-typescript/sandbox.config.json
@@ -3,8 +3,8 @@
   "hardReloadOnChange": true,
   "view": "browser",
   "template": "docusaurus",
-  "node": "22",
+  "node": "24",
   "container": {
-    "node": "22"
+    "node": "24"
   }
 }

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@ai-sdk/react": "^2.0.30",
     "@crowdin/cli": "^4.14.2",
     "@eslint/js": "^10.0.1",
-    "@swc/core": "^1.15.32",
+    "@swc/core": "^1.15.40",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/packages/docusaurus-faster/package.json
+++ b/packages/docusaurus-faster/package.json
@@ -20,8 +20,8 @@
   "dependencies": {
     "@docusaurus/types": "3.10.1",
     "@rspack/core": "^1.7.10",
-    "@swc/core": "^1.15.32",
-    "@swc/html": "^1.15.32",
+    "@swc/core": "^1.15.40",
+    "@swc/html": "^1.15.40",
     "browserslist": "^4.28.2",
     "lightningcss": "^1.32.0",
     "semver": "^7.7.4",

--- a/packages/docusaurus-plugin-google-gtag/package.json
+++ b/packages/docusaurus-plugin-google-gtag/package.json
@@ -5,8 +5,10 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "tsc --build",
-    "watch": "tsc --build --watch"
+    "build": "tsc --build && node ../../admin/scripts/copyUntypedFiles.js",
+    "watch": "run-p -c copy:watch build:watch",
+    "build:watch": "tsc --build --watch",
+    "copy:watch": "node ../../admin/scripts/copyUntypedFiles.js --watch"
   },
   "publishConfig": {
     "access": "public"
@@ -21,7 +23,6 @@
     "@docusaurus/core": "3.10.1",
     "@docusaurus/types": "3.10.1",
     "@docusaurus/utils-validation": "3.10.1",
-    "@types/gtag.js": "^0.0.20",
     "tslib": "^2.6.0"
   },
   "peerDependencies": {

--- a/packages/docusaurus-plugin-google-gtag/src/index.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/index.ts
@@ -8,6 +8,9 @@
 import type {LoadContext, Plugin} from '@docusaurus/types';
 import type {PluginOptions, Options} from './options';
 
+// Not sure why it's needed to expose vendored types 🤷‍️
+export {} from './vendor-gtag';
+
 function createConfigSnippet({
   trackingID,
   anonymizeIP,

--- a/packages/docusaurus-plugin-google-gtag/src/vendor-gtag.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/vendor-gtag.ts
@@ -5,7 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Types copied from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/gtag.js
+// Types directly copied from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/gtag.js
+// I'd prefer not do that, but this should fix our StackBlitz playground
+// See https://github.com/facebook/docusaurus/pull/12080
+// See https://github.com/facebook/docusaurus/issues/11615
 
 /* eslint-disable */
 declare var gtag: Gtag.Gtag;

--- a/packages/docusaurus-plugin-google-gtag/src/vendor-gtag.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/vendor-gtag.ts
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Types copied from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/gtag.js
+
+/* eslint-disable */
+declare var gtag: Gtag.Gtag;
+declare namespace Gtag {
+  interface GtagCommands {
+    config: [
+      targetId: string,
+      config?: ControlParams | EventParams | ConfigParams | CustomParams,
+    ];
+    // eslint-disable-next-line @definitelytyped/no-single-element-tuple-type
+    set:
+      | [targetId: string, config: CustomParams | boolean | string]
+      | [config: CustomParams];
+    // eslint-disable-next-line @definitelytyped/no-single-element-tuple-type
+    js: [config: Date];
+    event: [
+      eventName: EventNames | (string & {}),
+      eventParams?: ControlParams | EventParams | CustomParams,
+    ];
+    get: [
+      targetId: string,
+      fieldName: FieldNames | string,
+      callback?: (field: string | CustomParams | undefined) => any,
+    ];
+    consent: [
+      consentArg: ConsentArg | (string & {}),
+      consentParams: ConsentParams,
+    ];
+  }
+
+  interface Gtag {
+    <Command extends keyof GtagCommands>(
+      command: Command,
+      ...args: GtagCommands[Command]
+    ): void;
+  }
+
+  interface ConfigParams {
+    page_title?: string | undefined;
+    page_location?: string | undefined;
+    page_path?: string | undefined;
+    send_page_view?: boolean | undefined;
+  }
+
+  interface CustomParams {
+    [key: string]: any;
+  }
+
+  interface ControlParams {
+    groups?: string | string[] | undefined;
+    send_to?: string | string[] | undefined;
+    event_callback?: (() => void) | undefined;
+    event_timeout?: number | undefined;
+  }
+
+  type EventNames =
+    | 'add_payment_info'
+    | 'add_shipping_info'
+    | 'add_to_cart'
+    | 'add_to_wishlist'
+    | 'begin_checkout'
+    | 'checkout_progress'
+    | 'earn_virtual_currency'
+    | 'exception'
+    | 'generate_lead'
+    | 'join_group'
+    | 'level_end'
+    | 'level_start'
+    | 'level_up'
+    | 'login'
+    | 'page_view'
+    | 'post_score'
+    | 'purchase'
+    | 'refund'
+    | 'remove_from_cart'
+    | 'screen_view'
+    | 'search'
+    | 'select_content'
+    | 'select_item'
+    | 'select_promotion'
+    | 'set_checkout_option'
+    | 'share'
+    | 'sign_up'
+    | 'spend_virtual_currency'
+    | 'tutorial_begin'
+    | 'tutorial_complete'
+    | 'unlock_achievement'
+    | 'timing_complete'
+    | 'view_cart'
+    | 'view_item'
+    | 'view_item_list'
+    | 'view_promotion'
+    | 'view_search_results';
+
+  interface EventParams {
+    checkout_option?: string | undefined;
+    checkout_step?: number | undefined;
+    content_id?: string | undefined;
+    content_type?: string | undefined;
+    coupon?: string | undefined;
+    currency?: string | undefined;
+    description?: string | undefined;
+    fatal?: boolean | undefined;
+    items?: Item[] | undefined;
+    method?: string | undefined;
+    number?: string | undefined;
+    promotions?: Promotion[] | undefined;
+    screen_name?: string | undefined;
+    search_term?: string | undefined;
+    shipping?: Currency | undefined;
+    tax?: Currency | undefined;
+    transaction_id?: string | undefined;
+    value?: number | undefined;
+    event_label?: string | undefined;
+    event_category?: string | undefined;
+    /** @see {@link https://developers.google.com/analytics/devguides/collection/gtagjs/sending-data#specify_different_transport_mechanisms specify_different_transport_mechanisms} */
+    transport_type?: 'image' | 'xhr' | 'beacon' | undefined;
+  }
+
+  type Currency = string | number;
+
+  /**
+   * Interface of an item object used in lists for this event.
+   *
+   * Reference:
+   * @see {@link https://developers.google.com/analytics/devguides/collection/ga4/reference/events#view_item_item view_item_item}
+   * @see {@link https://developers.google.com/analytics/devguides/collection/ga4/reference/events#view_item_list_item view_item_list_item}
+   * @see {@link https://developers.google.com/analytics/devguides/collection/ga4/reference/events#select_item_item select_item_item}
+   * @see {@link https://developers.google.com/analytics/devguides/collection/ga4/reference/events#add_to_cart_item add_to_cart_item}
+   * @see {@link https://developers.google.com/analytics/devguides/collection/ga4/reference/events#view_cart_item view_cart_item}
+   */
+  interface Item {
+    item_id?: string | undefined;
+    item_name?: string | undefined;
+    affiliation?: string | undefined;
+    coupon?: string | undefined;
+    currency?: string | undefined;
+    creative_name?: string | undefined;
+    creative_slot?: string | undefined;
+    discount?: Currency | undefined;
+    index?: number | undefined;
+    item_brand?: string | undefined;
+    item_category?: string | undefined;
+    item_category2?: string | undefined;
+    item_category3?: string | undefined;
+    item_category4?: string | undefined;
+    item_category5?: string | undefined;
+    item_list_id?: string | undefined;
+    item_list_name?: string | undefined;
+    item_variant?: string | undefined;
+    location_id?: string | undefined;
+    price?: Currency | undefined;
+    promotion_id?: string | undefined;
+    promotion_name?: string | undefined;
+    quantity?: number | undefined;
+  }
+
+  interface Promotion {
+    creative_name?: string | undefined;
+    creative_slot?: string | undefined;
+    promotion_id?: string | undefined;
+    promotion_name?: string | undefined;
+  }
+
+  type FieldNames = 'client_id' | 'session_id' | 'gclid';
+
+  type ConsentArg = 'default' | 'update';
+
+  /**
+   * Reference:
+   * @see {@link https://support.google.com/tagmanager/answer/10718549#consent-types consent-types}
+   * @see {@link https://developers.google.com/tag-platform/devguides/consent consent}
+   */
+  interface ConsentParams {
+    ad_personalization?: 'granted' | 'denied' | undefined;
+    ad_user_data?: 'granted' | 'denied' | undefined;
+    ad_storage?: 'granted' | 'denied' | undefined;
+    analytics_storage?: 'granted' | 'denied' | undefined;
+    functionality_storage?: 'granted' | 'denied' | undefined;
+    personalization_storage?: 'granted' | 'denied' | undefined;
+    security_storage?: 'granted' | 'denied' | undefined;
+    wait_for_update?: number | undefined;
+    region?: string[] | undefined;
+  }
+}

--- a/packages/docusaurus-plugin-google-gtag/tsconfig.client.json
+++ b/packages/docusaurus-plugin-google-gtag/tsconfig.client.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.base.client.json",
-  "compilerOptions": {
-    "types": ["gtag.js"]
-  },
-  "include": ["src/gtag.ts", "src/*.d.ts"],
+  "compilerOptions": {},
+  "include": ["src/gtag.ts", "src//vendor-gtag.ts", "src/*.d.ts"],
   "exclude": ["**/__tests__/**"]
 }

--- a/project-words.txt
+++ b/project-words.txt
@@ -59,6 +59,7 @@ Datagit
 datagit
 Datagit's
 dedup
+definitelytyped
 devto
 dingers
 Dmitry
@@ -95,6 +96,7 @@ FOUC
 Français
 froms
 gabrielcsapo
+gclid
 getcanary
 Gifs
 gingergeek

--- a/website/src/types.d.ts
+++ b/website/src/types.d.ts
@@ -6,4 +6,4 @@
  */
 
 /// <reference types="@docusaurus/plugin-ideal-image" />
-/// <reference types="@types/gtag.js" />
+/// <reference types="@docusaurus/plugin-google-gtag" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -4208,166 +4208,226 @@
   resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.32.tgz#3592714588fdbb8b7a869f81ff96c7236fcf1c09"
   integrity sha512-/YWMvJDPu+AAwuUsM2G+DNQ/7zhodURGzdQyewEqcvgklAdDHs3LwQmLLnyn6SJl8DT8UOxkbzK+D1PmPeelRg==
 
+"@swc/core-darwin-arm64@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.40.tgz#b05d715b04c4fd47baf59288233da85a683cc0bc"
+  integrity sha512-PaYyclfmQ++77D8ityYvmmVzHv9aG8ROwt2GfG6/ccloy4Hgf80qtOnzb9VYvPsUT7Ty1uhuDRhv3XYpf62qhQ==
+
 "@swc/core-darwin-x64@1.15.32":
   version "1.15.32"
   resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.15.32.tgz#965044b632933146e319862ea7e4b717eb9f83dd"
   integrity sha512-KOTXJXdAhWL+hZ77MYP3z+4pcMFaQhQ74yqyN1uz093q0YnbxpqMtYpPISbYvMHzVRNNx5kN+9RZAXEaadhWVA==
+
+"@swc/core-darwin-x64@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.15.40.tgz#3180daef5c1e47b435f8edd084509e0a5c0d883b"
+  integrity sha512-HbbPzvfLBUXjIB1Ezks+//lNUjmLjfyd63XSwprJgrZaXYdm70kohXPJUWdqKZozolFxbPaO+xtBaiUp6BoueA==
 
 "@swc/core-linux-arm-gnueabihf@1.15.32":
   version "1.15.32"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.32.tgz#70e70ad6ad961055f4a9be9e4947e455c18239e6"
   integrity sha512-oOoxLweljlc0A4X8ybsgxV7cVaYTwBOg2iMDJcFR3Sr48C+lsv9VzSmqdK/IVIXF4W4GjLc3VqTAdSMXlfVLuQ==
 
+"@swc/core-linux-arm-gnueabihf@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.40.tgz#18fcd3c70e48fdfae07c9f18751b1409ce1e5e84"
+  integrity sha512-SlRZsCjOCPR2LvFs0Ri/Xrx/5o5TCt8vl4gW6mX1hEZOG0a625RxzRHpHdAQNGykmAN/7IeaFAJG+QnNmxlHcA==
+
 "@swc/core-linux-arm64-gnu@1.15.32":
   version "1.15.32"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.32.tgz#7b82e2cc5995e8f919e29f6ce702285f5f1c3ad1"
   integrity sha512-oDzEkdl6D6BAWdMtU5KGO7y3HR5fJcvByNLyEk9+ugj8nP5Ovb7P4kBcStBXc4MPExFGQryehiINMlmY8HlclA==
+
+"@swc/core-linux-arm64-gnu@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.40.tgz#26304933922f2a8e3194770e404403fc25a19c89"
+  integrity sha512-Q8byxJt2fh8CR3EUX6snBpy47AoBVm+In/+Z3rjDHMjC38ZvR9/gtUUNCT0tfrn4EdVsO8/QPi59nxrxvqxvBQ==
 
 "@swc/core-linux-arm64-musl@1.15.32":
   version "1.15.32"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.32.tgz#16c581b9f859b0175a8bab5cbf694bef7dbf95b8"
   integrity sha512-omcqjoZP/b8D8PuczVoRwJieC6ibj7qIxTftNYokz4/aSmKFHvsd7nIFfPk5ZvtzncbH4AY7+Dkr/Lp2gWxYeA==
 
+"@swc/core-linux-arm64-musl@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.40.tgz#3402dfba04ba7b8ea81f243e2f8fa2c336b54d03"
+  integrity sha512-4z0MgHU+7M0pZDqBN1El7mFXDI1SBwinfcUkAyA4v8QrhOIUOZltySt2aStQLZGrdXVXM4Y4ylfiTC04ED+MoQ==
+
 "@swc/core-linux-ppc64-gnu@1.15.32":
   version "1.15.32"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.32.tgz#420f7744dae327c8e4917c87ced5c1b3e0a38f96"
   integrity sha512-KGkTMyz/Tbn3PBNu0AVZ4GTDFKnICrYcTiNPZq8DrvK42pnFsf3GNDrIG9E5AtQlTmC0YigkWKmu0eMcfTrmgA==
+
+"@swc/core-linux-ppc64-gnu@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.40.tgz#b3df9065cad352328c1eeef08a28fc9fe98785aa"
+  integrity sha512-fLI4iUgeSZu0eRWUXwe6YzPFx9gHbFiPkl8Rp3mJfP8OpNR3nTQCGPvHdDh9xniW7mVvgMY4ni7A4VzqI1KrpA==
 
 "@swc/core-linux-s390x-gnu@1.15.32":
   version "1.15.32"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.32.tgz#9b563a3a73c544f29454e53894bfe533b9a27ffe"
   integrity sha512-G3Aa4tVS/3OGZBkoNIwUF9F6RAy+Osb4GOlo62SinLmDiErz/ykmM7KH0wkz6l9kM8jJq1HyAM6atJTUEbBk7g==
 
+"@swc/core-linux-s390x-gnu@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.40.tgz#58e5b601f641dde81b30626ef66a668701ec918f"
+  integrity sha512-YqeKMAb7d4nQSGMJQ454IlaCENpzcDqhvBE9+CPfdnYpnUXxd+BSrB6Xk0YjW8UyoEhUj4p6quATCxbsp6J3jg==
+
 "@swc/core-linux-x64-gnu@1.15.32":
   version "1.15.32"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.32.tgz#615c7bcc1890379dffcc74b6780e2277e65f4b61"
   integrity sha512-ERsjfGcj6CBmj3vJnGDO8m8rTvw6RqMcWo1dogOtNx3/+/0+NNpJiXDobJrr1GwInI/BHAEkvSFIH6d2LqPcUQ==
+
+"@swc/core-linux-x64-gnu@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.40.tgz#cf057dce0c148c53f2d30152baaf60ea29e5d59c"
+  integrity sha512-7HOuS1iGcme/j/TuL1TfmmLGiMQrjv/GmjyZeydl00FKPtpGXEldwqfI56xgd1YzrzoB2svWjxbGGyQ0TEASxg==
 
 "@swc/core-linux-x64-musl@1.15.32":
   version "1.15.32"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.32.tgz#038604d25bdebb1d1ad780d827a44654fa4b5bdd"
   integrity sha512-N4Ggahe/8SUbTX50P6EdhbW9YWcgbZVb52R4cq6MK+zsoMjRq7rGvV5ztA05QnbaCYqMYx8rTY7KAIA3Crdo4Q==
 
+"@swc/core-linux-x64-musl@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.40.tgz#21fb1a4d0193e9bbcd1469ecd36166d2e96e4006"
+  integrity sha512-h4kZYHc7dpc9P9u4brRJaS8Pl7tPVHAeiLSzw7T5RfIJgAoSdaCMKzI/2Uay9gFhaw8uyCDl0L5q37r0EpAfIA==
+
 "@swc/core-win32-arm64-msvc@1.15.32":
   version "1.15.32"
   resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.32.tgz#c82006e6ef92a998e96d2160b1657f5334af4d54"
   integrity sha512-01yN0o9jvo8xBTP12aPK2wW8b41jmOlGbDDlAnoynotc4pO6xA0zby9f1z6j++qXDpGBttLySq1omgVrlQKYcw==
+
+"@swc/core-win32-arm64-msvc@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.40.tgz#1dba23b2b0db86b3d6d65da2abd627cc607a1fbc"
+  integrity sha512-+mQgKZXSj6mV38Zh05QaxSjUDmGP/R2JWlXZTDLSPkDzHU6p3GxN9eeSf5dfyDVU86946fmCvSzyl/ucImx8+A==
 
 "@swc/core-win32-ia32-msvc@1.15.32":
   version "1.15.32"
   resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.32.tgz#e2ae1c95bd6599322bc6e9a82685b7537a193f7b"
   integrity sha512-fLagI9XZYNpTcmlqAcp3KBtmj7E19WCmYD80Jxj1Kn5tGNa7yxNLd3NNdWxuZGUPl5iC0/KqZru7g08gF6Fsrw==
 
+"@swc/core-win32-ia32-msvc@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.40.tgz#b2da1e33165d469467b1046a2189db468da488eb"
+  integrity sha512-yvwdPLGd25mcj/mNatjNQ0lZujtQD6psH3v9PNmMb+fSzjbNG8KIDxjFWrcV+fsFVLOkyOmdJsFmX7NAFjVyPw==
+
 "@swc/core-win32-x64-msvc@1.15.32":
   version "1.15.32"
   resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.32.tgz#2535c791821054072a511dee0d13e5de9c5cd29b"
   integrity sha512-gbc2bQ/T2CiR+w0OvcVKwLOFAcPZBvmWmolbwpg1E8UrpeC03DGtyMUApOHNXNYWA3SHFrYXCQtosrcMza1YFg==
 
-"@swc/core@^1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.15.32.tgz#2333d66f4b8e7c4fded087ead13c135ff84ab9d6"
-  integrity sha512-/eWL0n43D64QWEUHLtTE+jDqjkJhyidjkDhv6f0uJohOUAhywxQ9wXYp845DNNds0JpCdI4Uo0a9bl+vbXf+ew==
+"@swc/core-win32-x64-msvc@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.40.tgz#3563f7e8ce8708f5fda43eb8e0956ef11e0da320"
+  integrity sha512-OXtKsLU1bVtInzzDEAY2sYiF/rl4tvAnLLLpuMp3HzAOQZ5A+i69AKDhA1YLQTaMAqO3vzyYNVAYVRMPtSYD4w==
+
+"@swc/core@^1.15.32", "@swc/core@^1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.15.40.tgz#941c949aa88c0d8d291f102f519f3c2c77701b90"
+  integrity sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg==
   dependencies:
     "@swc/counter" "^0.1.3"
     "@swc/types" "^0.1.26"
   optionalDependencies:
-    "@swc/core-darwin-arm64" "1.15.32"
-    "@swc/core-darwin-x64" "1.15.32"
-    "@swc/core-linux-arm-gnueabihf" "1.15.32"
-    "@swc/core-linux-arm64-gnu" "1.15.32"
-    "@swc/core-linux-arm64-musl" "1.15.32"
-    "@swc/core-linux-ppc64-gnu" "1.15.32"
-    "@swc/core-linux-s390x-gnu" "1.15.32"
-    "@swc/core-linux-x64-gnu" "1.15.32"
-    "@swc/core-linux-x64-musl" "1.15.32"
-    "@swc/core-win32-arm64-msvc" "1.15.32"
-    "@swc/core-win32-ia32-msvc" "1.15.32"
-    "@swc/core-win32-x64-msvc" "1.15.32"
+    "@swc/core-darwin-arm64" "1.15.40"
+    "@swc/core-darwin-x64" "1.15.40"
+    "@swc/core-linux-arm-gnueabihf" "1.15.40"
+    "@swc/core-linux-arm64-gnu" "1.15.40"
+    "@swc/core-linux-arm64-musl" "1.15.40"
+    "@swc/core-linux-ppc64-gnu" "1.15.40"
+    "@swc/core-linux-s390x-gnu" "1.15.40"
+    "@swc/core-linux-x64-gnu" "1.15.40"
+    "@swc/core-linux-x64-musl" "1.15.40"
+    "@swc/core-win32-arm64-msvc" "1.15.40"
+    "@swc/core-win32-ia32-msvc" "1.15.40"
+    "@swc/core-win32-x64-msvc" "1.15.40"
 
 "@swc/counter@^0.1.3":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@swc/counter/-/counter-0.1.3.tgz#cc7463bd02949611c6329596fccd2b0ec782b0e9"
   integrity sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==
 
-"@swc/html-darwin-arm64@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/html-darwin-arm64/-/html-darwin-arm64-1.15.32.tgz#e23503640b0a5b57a7e0f754c9b47db4565c26ea"
-  integrity sha512-WgY386nwyz24cTJ+Nztd4cKvfPJexLYAzurSYDmuYxS3HihWoTFZWMDomTfM8yr2UCi8SwW+zTNAWxJxUaKESg==
+"@swc/html-darwin-arm64@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/html-darwin-arm64/-/html-darwin-arm64-1.15.40.tgz#f3154aaf76ebd12918485c9132d328cfc464f3a6"
+  integrity sha512-A9oxSh60pMEsX/4VBpn3e6s8DfGWsHzAeG+Vd9mXgkTqt/ouX12owP6RyqfqK8v0WuEsBKkGY0+MbwLvlOG8NQ==
 
-"@swc/html-darwin-x64@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/html-darwin-x64/-/html-darwin-x64-1.15.32.tgz#b117b6255fc78ef823762d943d1609997575d150"
-  integrity sha512-uge7XExmbPREWO+2dZQvAbeiAvUlR+3TxxgYETJw39f8Nlclc3rWXaievpO3iRPbg1s8BsZ9fGGhoN7yYrwUwg==
+"@swc/html-darwin-x64@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/html-darwin-x64/-/html-darwin-x64-1.15.40.tgz#7c9695aeacc799a1f12beaa8481e677f8a9bafa2"
+  integrity sha512-GZ5KxJ/1pqnpOAjaa9hnkSk3M1LHjc5ci5GCt5/llAgDKFLDHzydIflHXTOIaS4nRCtfVMmD0joKX+ZWruSkJw==
 
-"@swc/html-linux-arm-gnueabihf@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/html-linux-arm-gnueabihf/-/html-linux-arm-gnueabihf-1.15.32.tgz#d3878afdc2e04a37d5910e3ed672ac7d6a7c77a1"
-  integrity sha512-EuserzRHqXX6R6KScuBn+U3IX9ll3j4+sHM2Y3J/vIH7TbQ5IrvCFuu8w7El5R9j0ByCWvsDa2QdiLCQtsmFlw==
+"@swc/html-linux-arm-gnueabihf@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/html-linux-arm-gnueabihf/-/html-linux-arm-gnueabihf-1.15.40.tgz#ce2d0f6b43bb147f957a382a03c4344ab260f314"
+  integrity sha512-Bbwtl0G6vYcWlDQmjeuyFx8YIvqi1StlQWjRNB1ZtvrRNL3JadFARhijBONiUIyTK9MgUbWtTV3QU69qzjNENQ==
 
-"@swc/html-linux-arm64-gnu@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/html-linux-arm64-gnu/-/html-linux-arm64-gnu-1.15.32.tgz#3b2a613a3997da30a28ed426d885090c777ba846"
-  integrity sha512-gvlByySjNDWX2FUIGVBWOhd00rySz0AOydQpuXCK0ldYbFVMby9oXbp2JVmE5UsB6J4YZqZh4ajmmqCGvFHi4Q==
+"@swc/html-linux-arm64-gnu@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/html-linux-arm64-gnu/-/html-linux-arm64-gnu-1.15.40.tgz#fc604873631a96f9e1c74d48f8dd27b6f82c5100"
+  integrity sha512-buu4fGyCIhkwmCetI4CfWOPn7cphJHwQ9ksK685hlL0R0PUaDCNdIxo+JAz0mK2JgPhoGqnKsVEmV6gLIL5GBw==
 
-"@swc/html-linux-arm64-musl@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/html-linux-arm64-musl/-/html-linux-arm64-musl-1.15.32.tgz#bda38cc74442e9ec901592e62f22dc4cd3d7e8ac"
-  integrity sha512-iTrXjSeVwhHp+w7I5srCSpG9prebj+j/lmWalljNXGagTuVmtEWdH/EDvtSq1JfJyKQ6KRKyeB3Qg6yGHhjr+Q==
+"@swc/html-linux-arm64-musl@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/html-linux-arm64-musl/-/html-linux-arm64-musl-1.15.40.tgz#b6d23f8e475c66ffe9a2aea8d1ab2c1702f055fb"
+  integrity sha512-BwWtpAGEHIP1QwKExWqBIjGpAHMahjT26ORZv3+TbwW4IuEl2QP5FrcYc30O8abCG5J1lWRl1vXKYDpzbIDz1A==
 
-"@swc/html-linux-ppc64-gnu@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/html-linux-ppc64-gnu/-/html-linux-ppc64-gnu-1.15.32.tgz#07f81c31e99ba12c77630faf643c0d9645073719"
-  integrity sha512-sh6yGlZk7YqaQ4XisqEe0tBSTy0WcwmEnMEq9EG6mIU16PCGTbROHMfTw0W81jtvUyjqtCQC9axbSJLAW3zIeA==
+"@swc/html-linux-ppc64-gnu@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/html-linux-ppc64-gnu/-/html-linux-ppc64-gnu-1.15.40.tgz#fc9f8e5c4b86401fe4d778312898c6ced61efba4"
+  integrity sha512-wLtHgwmZu5K7PvuTROklgWJO6D+KwywpYR1geI8dSWX/AYnx/KCGVK9ncPzWVfnLXWhXbkgua3Ujdrfoxf+qSw==
 
-"@swc/html-linux-s390x-gnu@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/html-linux-s390x-gnu/-/html-linux-s390x-gnu-1.15.32.tgz#ae81f055b84e5bc7964bc6c805b2b9b19f737df4"
-  integrity sha512-zBavh0QnsvjM9QMPmtOqMaUGSLr5tdj2gxEx4xXzOXBFkUKKRA+qEfx6LdTzIbrqqtK5Xf6CPBPT9kzhDLuaCA==
+"@swc/html-linux-s390x-gnu@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/html-linux-s390x-gnu/-/html-linux-s390x-gnu-1.15.40.tgz#198c771e2dc6493b898f565efade542b44f55a32"
+  integrity sha512-WbWzQBCmvECZG6ep9D5SMMZTFCbFmRSCc7lPD3YhhaK16BNqr1AybvybZYOgxX9Ot5tq7gTWCgjFZXLDOn6Y/g==
 
-"@swc/html-linux-x64-gnu@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/html-linux-x64-gnu/-/html-linux-x64-gnu-1.15.32.tgz#97c896d9d44df9d6181033e95063e63e28e26008"
-  integrity sha512-IveuScZfAwDZEBs6pTvdG/MwGyMPuxp74l9ngp2PbUboVBIfUS894kATBaBuSBYXajZ4v4wqv01PGM81rUhGQg==
+"@swc/html-linux-x64-gnu@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/html-linux-x64-gnu/-/html-linux-x64-gnu-1.15.40.tgz#5b7ac2a96dbcd4947cb5375c11b3c647ca3d9949"
+  integrity sha512-i+/JqL5j9mTGMcVshWLMzciqyE3Np+gN5+UqMyO1D5zSmniJD5MHRlGXCtLaWx/MIKX0Q4Xkre33o56fmxp+uA==
 
-"@swc/html-linux-x64-musl@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/html-linux-x64-musl/-/html-linux-x64-musl-1.15.32.tgz#80020178bb09da23ef74deb3a1508dc582577368"
-  integrity sha512-wRXdcS0eaYU1Pm15gNGmVM7fsJ/xCxy3BnfNH52MC/ObgCIzBcFl3Yjn6yr6nkqNtDZyEt8IlQFQno5zEEvIpw==
+"@swc/html-linux-x64-musl@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/html-linux-x64-musl/-/html-linux-x64-musl-1.15.40.tgz#f78fc3fc68f976121d2a1c95e8a8987375bc7ae1"
+  integrity sha512-mroZnb5omFc4iE01UsJgta+Nm0sIFWpGfTPk+BHfH165MZAM4wNndeczX5RpGZbQSF1nNpCoNgqJyT7l3hITMg==
 
-"@swc/html-win32-arm64-msvc@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/html-win32-arm64-msvc/-/html-win32-arm64-msvc-1.15.32.tgz#dedf30e0aec1f21457493280e36ccc1ce770c5f9"
-  integrity sha512-GzQQkdi4kC5ZjKloTQXgsI9FNQYb3z1mmF9ZbVDykdRgzKnqWGbx/gwTcWUhiurI9KsyL1t95PmOnU11Jw/mqg==
+"@swc/html-win32-arm64-msvc@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/html-win32-arm64-msvc/-/html-win32-arm64-msvc-1.15.40.tgz#1a11bfa36e0e7d14c63b118413fe3e151f24111a"
+  integrity sha512-qg1LXRrsY9FXy0S7vouSF0kkn1vdkTD//FW66iuezH7HMm5/DJGwEj7oc1zTKPWU0HnwOINOUbl6rUHrRuXHAQ==
 
-"@swc/html-win32-ia32-msvc@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/html-win32-ia32-msvc/-/html-win32-ia32-msvc-1.15.32.tgz#f5e98851375d4284875fd7904771cbc7abf7613b"
-  integrity sha512-BJqmiTbCWcd1hG9nLEktIASTv0SD91cIKHdt8Zza7AvSjH+BmDX0AW8krVDsJpXWQEtWEYzroe9rweNOMSVfjQ==
+"@swc/html-win32-ia32-msvc@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/html-win32-ia32-msvc/-/html-win32-ia32-msvc-1.15.40.tgz#3a1976de161087add90f2cf86c88d8a261433cbc"
+  integrity sha512-5NwMmgt9A70LQzcYOl4OiIJk5AhsGP69fNRfkmXXop+iIcAGUmYy+d6F2/Gc0u05j9G0R04NPWcHBQrHQhr0Gw==
 
-"@swc/html-win32-x64-msvc@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/html-win32-x64-msvc/-/html-win32-x64-msvc-1.15.32.tgz#1264fd79a637858df4746b02f7faeaf9b0576fce"
-  integrity sha512-8uOl327V1nCISIILtpQWrY8dl4JFo8UK5TCFcpMJ8ldt4wggr7cPnvkp2bJkT/pL7djjrDJQZ2BpNfu62M2zWA==
+"@swc/html-win32-x64-msvc@1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/html-win32-x64-msvc/-/html-win32-x64-msvc-1.15.40.tgz#769327f061bbdb4ed77877758dd4a20ff18170b7"
+  integrity sha512-WUNZqCZ+8WY1pr8t3X3fq4gI5+FL/tCCzlrJ2lLn0s+TyA2SLm/RPfXxQIr94EnjJWcIV21G//6/uXeBN8cPzw==
 
-"@swc/html@^1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/html/-/html-1.15.32.tgz#478cb5463a964bcf1b532b2cc1a713aceeffd69e"
-  integrity sha512-Mv37uFfZQt7j89U3KJPqeQt6vl5Bxk7aqOrNDKWRAmrQOJ+lYJKq4hmYWW6Rk3wdGw03SlEfK3RmnzCN9gsqAA==
+"@swc/html@^1.15.40":
+  version "1.15.40"
+  resolved "https://registry.yarnpkg.com/@swc/html/-/html-1.15.40.tgz#84614c328988ae2dd579724a0ddaa55116c875f1"
+  integrity sha512-YVWNrh3wZWH2oXz7uL+s1WZbFIsnAp9cCl/b+C7ufDJqhsOvbr0un9IOYZ/CxRIRdnHGfhVD199n8baD/kRQew==
   dependencies:
     "@swc/counter" "^0.1.3"
   optionalDependencies:
-    "@swc/html-darwin-arm64" "1.15.32"
-    "@swc/html-darwin-x64" "1.15.32"
-    "@swc/html-linux-arm-gnueabihf" "1.15.32"
-    "@swc/html-linux-arm64-gnu" "1.15.32"
-    "@swc/html-linux-arm64-musl" "1.15.32"
-    "@swc/html-linux-ppc64-gnu" "1.15.32"
-    "@swc/html-linux-s390x-gnu" "1.15.32"
-    "@swc/html-linux-x64-gnu" "1.15.32"
-    "@swc/html-linux-x64-musl" "1.15.32"
-    "@swc/html-win32-arm64-msvc" "1.15.32"
-    "@swc/html-win32-ia32-msvc" "1.15.32"
-    "@swc/html-win32-x64-msvc" "1.15.32"
+    "@swc/html-darwin-arm64" "1.15.40"
+    "@swc/html-darwin-x64" "1.15.40"
+    "@swc/html-linux-arm-gnueabihf" "1.15.40"
+    "@swc/html-linux-arm64-gnu" "1.15.40"
+    "@swc/html-linux-arm64-musl" "1.15.40"
+    "@swc/html-linux-ppc64-gnu" "1.15.40"
+    "@swc/html-linux-s390x-gnu" "1.15.40"
+    "@swc/html-linux-x64-gnu" "1.15.40"
+    "@swc/html-linux-x64-musl" "1.15.40"
+    "@swc/html-win32-arm64-msvc" "1.15.40"
+    "@swc/html-win32-ia32-msvc" "1.15.40"
+    "@swc/html-win32-x64-msvc" "1.15.40"
 
 "@swc/types@^0.1.26":
   version "0.1.26"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4203,120 +4203,60 @@
     "@svgr/plugin-jsx" "8.1.0"
     "@svgr/plugin-svgo" "8.1.0"
 
-"@swc/core-darwin-arm64@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.32.tgz#3592714588fdbb8b7a869f81ff96c7236fcf1c09"
-  integrity sha512-/YWMvJDPu+AAwuUsM2G+DNQ/7zhodURGzdQyewEqcvgklAdDHs3LwQmLLnyn6SJl8DT8UOxkbzK+D1PmPeelRg==
-
 "@swc/core-darwin-arm64@1.15.40":
   version "1.15.40"
   resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.40.tgz#b05d715b04c4fd47baf59288233da85a683cc0bc"
   integrity sha512-PaYyclfmQ++77D8ityYvmmVzHv9aG8ROwt2GfG6/ccloy4Hgf80qtOnzb9VYvPsUT7Ty1uhuDRhv3XYpf62qhQ==
-
-"@swc/core-darwin-x64@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.15.32.tgz#965044b632933146e319862ea7e4b717eb9f83dd"
-  integrity sha512-KOTXJXdAhWL+hZ77MYP3z+4pcMFaQhQ74yqyN1uz093q0YnbxpqMtYpPISbYvMHzVRNNx5kN+9RZAXEaadhWVA==
 
 "@swc/core-darwin-x64@1.15.40":
   version "1.15.40"
   resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.15.40.tgz#3180daef5c1e47b435f8edd084509e0a5c0d883b"
   integrity sha512-HbbPzvfLBUXjIB1Ezks+//lNUjmLjfyd63XSwprJgrZaXYdm70kohXPJUWdqKZozolFxbPaO+xtBaiUp6BoueA==
 
-"@swc/core-linux-arm-gnueabihf@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.32.tgz#70e70ad6ad961055f4a9be9e4947e455c18239e6"
-  integrity sha512-oOoxLweljlc0A4X8ybsgxV7cVaYTwBOg2iMDJcFR3Sr48C+lsv9VzSmqdK/IVIXF4W4GjLc3VqTAdSMXlfVLuQ==
-
 "@swc/core-linux-arm-gnueabihf@1.15.40":
   version "1.15.40"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.40.tgz#18fcd3c70e48fdfae07c9f18751b1409ce1e5e84"
   integrity sha512-SlRZsCjOCPR2LvFs0Ri/Xrx/5o5TCt8vl4gW6mX1hEZOG0a625RxzRHpHdAQNGykmAN/7IeaFAJG+QnNmxlHcA==
-
-"@swc/core-linux-arm64-gnu@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.32.tgz#7b82e2cc5995e8f919e29f6ce702285f5f1c3ad1"
-  integrity sha512-oDzEkdl6D6BAWdMtU5KGO7y3HR5fJcvByNLyEk9+ugj8nP5Ovb7P4kBcStBXc4MPExFGQryehiINMlmY8HlclA==
 
 "@swc/core-linux-arm64-gnu@1.15.40":
   version "1.15.40"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.40.tgz#26304933922f2a8e3194770e404403fc25a19c89"
   integrity sha512-Q8byxJt2fh8CR3EUX6snBpy47AoBVm+In/+Z3rjDHMjC38ZvR9/gtUUNCT0tfrn4EdVsO8/QPi59nxrxvqxvBQ==
 
-"@swc/core-linux-arm64-musl@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.32.tgz#16c581b9f859b0175a8bab5cbf694bef7dbf95b8"
-  integrity sha512-omcqjoZP/b8D8PuczVoRwJieC6ibj7qIxTftNYokz4/aSmKFHvsd7nIFfPk5ZvtzncbH4AY7+Dkr/Lp2gWxYeA==
-
 "@swc/core-linux-arm64-musl@1.15.40":
   version "1.15.40"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.40.tgz#3402dfba04ba7b8ea81f243e2f8fa2c336b54d03"
   integrity sha512-4z0MgHU+7M0pZDqBN1El7mFXDI1SBwinfcUkAyA4v8QrhOIUOZltySt2aStQLZGrdXVXM4Y4ylfiTC04ED+MoQ==
-
-"@swc/core-linux-ppc64-gnu@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.32.tgz#420f7744dae327c8e4917c87ced5c1b3e0a38f96"
-  integrity sha512-KGkTMyz/Tbn3PBNu0AVZ4GTDFKnICrYcTiNPZq8DrvK42pnFsf3GNDrIG9E5AtQlTmC0YigkWKmu0eMcfTrmgA==
 
 "@swc/core-linux-ppc64-gnu@1.15.40":
   version "1.15.40"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.40.tgz#b3df9065cad352328c1eeef08a28fc9fe98785aa"
   integrity sha512-fLI4iUgeSZu0eRWUXwe6YzPFx9gHbFiPkl8Rp3mJfP8OpNR3nTQCGPvHdDh9xniW7mVvgMY4ni7A4VzqI1KrpA==
 
-"@swc/core-linux-s390x-gnu@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.32.tgz#9b563a3a73c544f29454e53894bfe533b9a27ffe"
-  integrity sha512-G3Aa4tVS/3OGZBkoNIwUF9F6RAy+Osb4GOlo62SinLmDiErz/ykmM7KH0wkz6l9kM8jJq1HyAM6atJTUEbBk7g==
-
 "@swc/core-linux-s390x-gnu@1.15.40":
   version "1.15.40"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.40.tgz#58e5b601f641dde81b30626ef66a668701ec918f"
   integrity sha512-YqeKMAb7d4nQSGMJQ454IlaCENpzcDqhvBE9+CPfdnYpnUXxd+BSrB6Xk0YjW8UyoEhUj4p6quATCxbsp6J3jg==
-
-"@swc/core-linux-x64-gnu@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.32.tgz#615c7bcc1890379dffcc74b6780e2277e65f4b61"
-  integrity sha512-ERsjfGcj6CBmj3vJnGDO8m8rTvw6RqMcWo1dogOtNx3/+/0+NNpJiXDobJrr1GwInI/BHAEkvSFIH6d2LqPcUQ==
 
 "@swc/core-linux-x64-gnu@1.15.40":
   version "1.15.40"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.40.tgz#cf057dce0c148c53f2d30152baaf60ea29e5d59c"
   integrity sha512-7HOuS1iGcme/j/TuL1TfmmLGiMQrjv/GmjyZeydl00FKPtpGXEldwqfI56xgd1YzrzoB2svWjxbGGyQ0TEASxg==
 
-"@swc/core-linux-x64-musl@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.32.tgz#038604d25bdebb1d1ad780d827a44654fa4b5bdd"
-  integrity sha512-N4Ggahe/8SUbTX50P6EdhbW9YWcgbZVb52R4cq6MK+zsoMjRq7rGvV5ztA05QnbaCYqMYx8rTY7KAIA3Crdo4Q==
-
 "@swc/core-linux-x64-musl@1.15.40":
   version "1.15.40"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.40.tgz#21fb1a4d0193e9bbcd1469ecd36166d2e96e4006"
   integrity sha512-h4kZYHc7dpc9P9u4brRJaS8Pl7tPVHAeiLSzw7T5RfIJgAoSdaCMKzI/2Uay9gFhaw8uyCDl0L5q37r0EpAfIA==
-
-"@swc/core-win32-arm64-msvc@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.32.tgz#c82006e6ef92a998e96d2160b1657f5334af4d54"
-  integrity sha512-01yN0o9jvo8xBTP12aPK2wW8b41jmOlGbDDlAnoynotc4pO6xA0zby9f1z6j++qXDpGBttLySq1omgVrlQKYcw==
 
 "@swc/core-win32-arm64-msvc@1.15.40":
   version "1.15.40"
   resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.40.tgz#1dba23b2b0db86b3d6d65da2abd627cc607a1fbc"
   integrity sha512-+mQgKZXSj6mV38Zh05QaxSjUDmGP/R2JWlXZTDLSPkDzHU6p3GxN9eeSf5dfyDVU86946fmCvSzyl/ucImx8+A==
 
-"@swc/core-win32-ia32-msvc@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.32.tgz#e2ae1c95bd6599322bc6e9a82685b7537a193f7b"
-  integrity sha512-fLagI9XZYNpTcmlqAcp3KBtmj7E19WCmYD80Jxj1Kn5tGNa7yxNLd3NNdWxuZGUPl5iC0/KqZru7g08gF6Fsrw==
-
 "@swc/core-win32-ia32-msvc@1.15.40":
   version "1.15.40"
   resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.40.tgz#b2da1e33165d469467b1046a2189db468da488eb"
   integrity sha512-yvwdPLGd25mcj/mNatjNQ0lZujtQD6psH3v9PNmMb+fSzjbNG8KIDxjFWrcV+fsFVLOkyOmdJsFmX7NAFjVyPw==
-
-"@swc/core-win32-x64-msvc@1.15.32":
-  version "1.15.32"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.32.tgz#2535c791821054072a511dee0d13e5de9c5cd29b"
-  integrity sha512-gbc2bQ/T2CiR+w0OvcVKwLOFAcPZBvmWmolbwpg1E8UrpeC03DGtyMUApOHNXNYWA3SHFrYXCQtosrcMza1YFg==
 
 "@swc/core-win32-x64-msvc@1.15.40":
   version "1.15.40"
@@ -5001,11 +4941,6 @@
   dependencies:
     "@types/minimatch" "*"
     "@types/node" "*"
-
-"@types/gtag.js@^0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@types/gtag.js/-/gtag.js-0.0.20.tgz#e47edabb4ed5ecac90a079275958e6c929d7c08a"
-  integrity sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg==
 
 "@types/hast@^3.0.0":
   version "3.0.4"


### PR DESCRIPTION


## Motivation

Fix https://github.com/facebook/docusaurus/issues/11615

Fix https://github.com/facebook/docusaurus/issues/12008

Let's force bump `@swc/html` to a version that works within StackBlitz

Also, I'm interning on the `@types/gtag.js` package because, for an unknown reasons, this specific dependency has been causing troubles in StackBlitz

## Test Plan

CI

### Test links

https://deploy-preview-12080--docusaurus-2.netlify.app/

