### PR TITLE
feat(dev-server): add dev-server CLI options for HTTPS support 

### DIFF
--- a/packages/docusaurus/src/commands/cli.ts
+++ b/packages/docusaurus/src/commands/cli.ts
@@ -203,8 +203,6 @@ export async function createCLIProgram({
       '--no-minify',
       'build website without minimizing JS bundles (default: false)',
     )
-    /*
-    TODO
     .option(
       '--https',
       'serve the dev site over HTTPS using a self-signed cert (default: false). Preferred over the HTTPS=true env var. Implied when both --ssl-cert and --ssl-key are provided.',
@@ -217,7 +215,6 @@ export async function createCLIProgram({
       '--ssl-key <path>',
       'path to a TLS private key file (implies HTTPS). Preferred over the SSL_KEY_FILE env var; CLI takes precedence if both are set.',
     )
-    */
     .action(start);
 
   cli

--- a/packages/docusaurus/src/commands/start/start.ts
+++ b/packages/docusaurus/src/commands/start/start.ts
@@ -19,13 +19,9 @@ export type StartCLIOptions = HostPortOptions &
     open?: boolean;
     poll?: boolean | number;
     minify?: boolean;
-
-    /*
-    TODO Docusaurus v4: wire new CLI parameters
     https?: true;
     sslCert?: string;
     sslKey?: string;
-     */
   };
 
 async function doStart(

--- a/packages/docusaurus/src/commands/start/webpack.ts
+++ b/packages/docusaurus/src/commands/start/webpack.ts
@@ -61,13 +61,9 @@ async function createDevServerConfig({
   const pollingOptions = createPollingOptions(cliOptions);
 
   const httpsConfig = await getHttpsConfig({
-    /*
-    TODO Docusaurus v4: wire new CLI parameters
     https: cliOptions.https,
     sslCert: cliOptions.sslCert,
     sslKey: cliOptions.sslKey,
-
-     */
   });
 
   // https://webpack.js.org/configuration/dev-server

--- a/website/docs/cli.mdx
+++ b/website/docs/cli.mdx
@@ -45,6 +45,9 @@ Builds and serves a preview of your site locally with [Webpack Dev Server](https
 | `--config` | `undefined` | Path to Docusaurus config file, default to `[siteDir]/docusaurus.config.js` |
 | `--poll [optionalIntervalMs]` | `false` | Use polling of files rather than watching for live reload as a fallback in environments where watching doesn't work. More information [here](https://webpack.js.org/configuration/watch/#watchoptionspoll). |
 | `--no-minify` | `false` | Build website without minimizing JS/CSS bundles. |
+| `--https` | `false` | Serve the dev site over HTTPS using a self-signed certificate. Implied when both `--ssl-cert` and `--ssl-key` are provided. |
+| `--ssl-cert` | `undefined` | Path to a TLS certificate file (implies HTTPS). |
+| `--ssl-key` | `undefined` | Path to a TLS private key file (implies HTTPS). |
 
 :::info
 
@@ -70,13 +73,23 @@ There are multiple ways to obtain a certificate. We will use [mkcert](https://gi
 
 2. Run `mkcert -install` to install the cert in your trust store, and restart your browser
 
-3. Start the app with Docusaurus HTTPS env variables:
+3. Start the app with the Docusaurus HTTPS CLI options:
 
-```bash
-HTTPS=true SSL_CRT_FILE=localhost.pem SSL_KEY_FILE=localhost-key.pem yarn start
+```bash npm2yarn
+npm run start -- --ssl-cert localhost.pem --ssl-key localhost-key.pem
 ```
 
 4. Open `https://localhost:3000/`
+
+:::tip Self-signed certificate
+
+Use the `--https` option to serve the dev site over HTTPS with an automatically generated self-signed certificate:
+
+```bash npm2yarn
+npm run start -- --https
+```
+
+:::
 
 ### `docusaurus build [siteDir]` {/* #docusaurus-build-sitedir */}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4263,7 +4263,7 @@
   resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.40.tgz#3563f7e8ce8708f5fda43eb8e0956ef11e0da320"
   integrity sha512-OXtKsLU1bVtInzzDEAY2sYiF/rl4tvAnLLLpuMp3HzAOQZ5A+i69AKDhA1YLQTaMAqO3vzyYNVAYVRMPtSYD4w==
 
-"@swc/core@^1.15.32", "@swc/core@^1.15.40":
+"@swc/core@^1.15.40":
   version "1.15.40"
   resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.15.40.tgz#941c949aa88c0d8d291f102f519f3c2c77701b90"
   integrity sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg==


### PR DESCRIPTION


## Motivation

Follow-up of https://github.com/facebook/docusaurus/pull/12065

Add support for `npm run start -- --https --ssl-cert path.cert --ssl-key path.key`

In Docusaurus v3, it was previously exposed with env variables (`HTTPS`, `SSL_CRT_FILE`, `SSL_KEY_FILE`), less practical/explicit.

For now, we'll keep the env variables around and may remove them in the future, so they have been removed from the documentation. 

If you have a good reason to use env variables, please tell us.


## Test Plan

CI + local test on our own website:

```bash
npm run start -- --https

npm run start -- --ssl-cert ../packages/docusaurus/src/webpack/utils/__tests__/__fixtures__/getHttpsConfig/host.crt --ssl-key ../packages/docusaurus/src/webpack/utils/__tests__/__fixtures__/getHttpsConfig/host.key
```


Docs: https://deploy-preview-12082--docusaurus-2.netlify.app/docs/cli/#enabling-https

