### PR TITLE
break(core): Remove legacy `postBuild({head})` API and v4 future flag

### DIFF
--- a/packages/docusaurus-types/src/config.d.ts
+++ b/packages/docusaurus-types/src/config.d.ts
@@ -37,7 +37,6 @@ export type FasterConfig = {
 };
 
 export type FutureV4Config = {
-  removeLegacyPostBuildHeadAttribute: boolean;
   useCssCascadeLayers: boolean;
   siteStorageNamespacing: boolean;
   fasterByDefault: boolean;

--- a/packages/docusaurus-types/src/plugin.d.ts
+++ b/packages/docusaurus-types/src/plugin.d.ts
@@ -10,7 +10,6 @@ import type {RuleSetRule, Configuration as WebpackConfiguration} from 'webpack';
 import type {CustomizeRuleString} from 'webpack-merge/dist/types';
 import type {CommanderStatic} from 'commander';
 import type Joi from 'joi';
-import type {HelmetServerState} from 'react-helmet-async';
 import type {ThemeConfig} from './config';
 import type {LoadContext, Props} from './context';
 import type {SwizzleConfig} from './swizzle';
@@ -137,10 +136,6 @@ export type Plugin<Content = unknown> = {
   postBuild?: (
     props: Props & {
       content: Content;
-      // TODO Docusaurus v4: remove old messy unserializable "head" API
-      //  breaking change, replaced by routesBuildMetadata
-      //  Reason: https://github.com/facebook/docusaurus/pull/10826
-      head: {[location: string]: HelmetServerState};
       routesBuildMetadata: {[location: string]: RouteBuildMetadata};
     },
   ) => Promise<void> | void;

--- a/packages/docusaurus/src/client/serverEntry.tsx
+++ b/packages/docusaurus/src/client/serverEntry.tsx
@@ -19,10 +19,7 @@ import {
 import {toPageCollectedMetadataInternal} from './serverHelmetUtils';
 import type {AppRenderer, PageCollectedDataInternal} from '../common';
 
-const render: AppRenderer['render'] = async ({
-  pathname,
-  v4RemoveLegacyPostBuildHeadAttribute,
-}) => {
+const render: AppRenderer['render'] = async ({pathname}) => {
   await preload(pathname);
 
   const modules = new Set<string>();
@@ -48,12 +45,6 @@ const render: AppRenderer['render'] = async ({
   const {helmet} = helmetContext as FilledContext;
 
   const metadata = toPageCollectedMetadataInternal({helmet});
-
-  // TODO Docusaurus v4 remove with deprecated postBuild({head}) API
-  //  the returned collectedData must be serializable to run in workers
-  if (v4RemoveLegacyPostBuildHeadAttribute) {
-    metadata.helmet = null;
-  }
 
   const collectedData: PageCollectedDataInternal = {
     metadata,

--- a/packages/docusaurus/src/client/serverHelmetUtils.tsx
+++ b/packages/docusaurus/src/client/serverHelmetUtils.tsx
@@ -39,7 +39,6 @@ export function toPageCollectedMetadataInternal({
   const noIndex = tags.some(isNoIndexTag);
 
   return {
-    helmet, // TODO Docusaurus v4 remove
     public: {
       noIndex,
     },

--- a/packages/docusaurus/src/commands/build/buildLocale.ts
+++ b/packages/docusaurus/src/commands/build/buildLocale.ts
@@ -158,10 +158,6 @@ async function executePluginsPostBuild({
   props: Props;
   collectedData: SiteCollectedData;
 }) {
-  const head = props.siteConfig.future.v4.removeLegacyPostBuildHeadAttribute
-    ? {}
-    : _.mapValues(collectedData, (d) => d.metadata.helmet!);
-
   const routesBuildMetadata = _.mapValues(
     collectedData,
     (d) => d.metadata.public,
@@ -174,7 +170,6 @@ async function executePluginsPostBuild({
       }
       await plugin.postBuild({
         ...props,
-        head,
         routesBuildMetadata,
         content: plugin.content,
       });

--- a/packages/docusaurus/src/common.d.ts
+++ b/packages/docusaurus/src/common.d.ts
@@ -16,9 +16,7 @@ export type AppRenderResult = {
 };
 
 export type AppRenderer = {
-  render: (params: {
-    pathname: string;
-  }) => Promise<AppRenderResult>;
+  render: (params: {pathname: string}) => Promise<AppRenderResult>;
 
   // It's important to shut down the app renderer
   // Otherwise Node.js require cache leaks memory

--- a/packages/docusaurus/src/common.d.ts
+++ b/packages/docusaurus/src/common.d.ts
@@ -8,7 +8,6 @@
 // This file is for types that are common between client/server
 // In particular the interface between SSG and serverEntry code
 
-import type {HelmetServerState} from 'react-helmet-async';
 import type {RouteBuildMetadata} from '@docusaurus/types';
 
 export type AppRenderResult = {
@@ -19,9 +18,6 @@ export type AppRenderResult = {
 export type AppRenderer = {
   render: (params: {
     pathname: string;
-
-    // TODO Docusaurus v4: remove deprecated postBuild({head}) API
-    v4RemoveLegacyPostBuildHeadAttribute: boolean;
   }) => Promise<AppRenderResult>;
 
   // It's important to shut down the app renderer
@@ -42,9 +38,6 @@ export type RouteBuildMetadataInternal = {
 
 export type PageCollectedMetadata = {
   public: RouteBuildMetadata;
-  // TODO Docusaurus v4 remove legacy unserializable helmet data structure
-  // See https://github.com/facebook/docusaurus/pull/10850
-  helmet: HelmetServerState | null;
 };
 
 // This data structure must remain serializable!

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/config.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/config.test.ts.snap
@@ -28,7 +28,6 @@ exports[`loadSiteConfig > website with .cjs siteConfig 1`] = `
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },
@@ -116,7 +115,6 @@ exports[`loadSiteConfig > website with ts + js config 1`] = `
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },
@@ -204,7 +202,6 @@ exports[`loadSiteConfig > website with valid JS CJS config 1`] = `
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },
@@ -292,7 +289,6 @@ exports[`loadSiteConfig > website with valid JS ESM config 1`] = `
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },
@@ -380,7 +376,6 @@ exports[`loadSiteConfig > website with valid TypeScript CJS config 1`] = `
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },
@@ -468,7 +463,6 @@ exports[`loadSiteConfig > website with valid TypeScript ESM config 1`] = `
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },
@@ -556,7 +550,6 @@ exports[`loadSiteConfig > website with valid async config 1`] = `
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },
@@ -646,7 +639,6 @@ exports[`loadSiteConfig > website with valid async config creator function 1`] =
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },
@@ -736,7 +728,6 @@ exports[`loadSiteConfig > website with valid config creator function 1`] = `
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },
@@ -829,7 +820,6 @@ exports[`loadSiteConfig > website with valid siteConfig 1`] = `
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/site.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/site.test.ts.snap
@@ -108,7 +108,6 @@ exports[`loadSite > custom-i18n-site > loads site 1`] = `
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },
@@ -284,7 +283,6 @@ exports[`loadSite > simple-site-with-baseUrl > loads site - custom config 1`] = 
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },
@@ -452,7 +450,6 @@ exports[`loadSite > simple-site-with-baseUrl > loads site - custom outDir 1`] = 
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },
@@ -620,7 +617,6 @@ exports[`loadSite > simple-site-with-baseUrl > loads site 1`] = `
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },
@@ -832,7 +828,6 @@ exports[`loadSite > simple-site-with-baseUrl-i18n > loads site -  locale fr + cu
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },
@@ -1066,7 +1061,6 @@ exports[`loadSite > simple-site-with-baseUrl-i18n > loads site - custom outDir 1
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },
@@ -1300,7 +1294,6 @@ exports[`loadSite > simple-site-with-baseUrl-i18n > loads site - locale de 1`] =
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },
@@ -1534,7 +1527,6 @@ exports[`loadSite > simple-site-with-baseUrl-i18n > loads site - locale en 1`] =
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },
@@ -1768,7 +1760,6 @@ exports[`loadSite > simple-site-with-baseUrl-i18n > loads site - locale es 1`] =
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },
@@ -2002,7 +1993,6 @@ exports[`loadSite > simple-site-with-baseUrl-i18n > loads site - locale fr 1`] =
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },
@@ -2236,7 +2226,6 @@ exports[`loadSite > simple-site-with-baseUrl-i18n > loads site - locale it 1`] =
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },
@@ -2470,7 +2459,6 @@ exports[`loadSite > simple-site-with-baseUrl-i18n > loads site 1`] = `
       "v4": {
         "fasterByDefault": false,
         "mdx1CompatDisabledByDefault": false,
-        "removeLegacyPostBuildHeadAttribute": false,
         "siteStorageNamespacing": false,
         "useCssCascadeLayers": false,
       },

--- a/packages/docusaurus/src/server/__tests__/configValidation.test.ts
+++ b/packages/docusaurus/src/server/__tests__/configValidation.test.ts
@@ -63,7 +63,6 @@ describe('normalizeConfig', () => {
       },
       future: {
         v4: {
-          removeLegacyPostBuildHeadAttribute: true,
           useCssCascadeLayers: true,
           siteStorageNamespacing: true,
           fasterByDefault: true,
@@ -1343,7 +1342,6 @@ describe('future', () => {
   it('accepts future - full', () => {
     const future: DocusaurusConfig['future'] = {
       v4: {
-        removeLegacyPostBuildHeadAttribute: true,
         useCssCascadeLayers: true,
         siteStorageNamespacing: true,
         fasterByDefault: true,
@@ -1727,34 +1725,26 @@ describe('future', () => {
       ).toEqual(fasterContaining(DEFAULT_FASTER_CONFIG_TRUE));
     });
 
-    it('rejects faster - true (v4: false)', () => {
-      expect(() =>
+    it('accepts faster - true (v4: false)', () => {
+      expect(
         normalizeConfig({
           future: {
             v4: false,
             faster: true,
           },
         }),
-      ).toThrowErrorMatchingInlineSnapshot(`
-        [Error: Docusaurus config \`future.faster.ssgWorkerThreads\` requires the future flag \`future.v4.removeLegacyPostBuildHeadAttribute\` to be turned on.
-        If you use Docusaurus Faster, we recommend that you also activate Docusaurus v4 future flags: \`{future: {v4: true}}\`
-        All the v4 future flags are documented here: https://docusaurus.io/docs/api/docusaurus-config#future]
-      `);
+      ).toEqual(fasterContaining(DEFAULT_FASTER_CONFIG_TRUE));
     });
 
-    it('rejects faster - true (v4: undefined)', () => {
-      expect(() =>
+    it('accepts faster - true (v4: undefined)', () => {
+      expect(
         normalizeConfig({
           future: {
-            v4: false,
+            v4: undefined,
             faster: true,
           },
         }),
-      ).toThrowErrorMatchingInlineSnapshot(`
-        [Error: Docusaurus config \`future.faster.ssgWorkerThreads\` requires the future flag \`future.v4.removeLegacyPostBuildHeadAttribute\` to be turned on.
-        If you use Docusaurus Faster, we recommend that you also activate Docusaurus v4 future flags: \`{future: {v4: true}}\`
-        All the v4 future flags are documented here: https://docusaurus.io/docs/api/docusaurus-config#future]
-      `);
+      ).toEqual(fasterContaining(DEFAULT_FASTER_CONFIG_TRUE));
     });
 
     it('rejects faster - number', () => {
@@ -2330,40 +2320,32 @@ describe('future', () => {
         ).toEqual(fasterContaining({ssgWorkerThreads: true}));
       });
 
-      it('rejects - true (v4: false)', () => {
+      it('accepts - true (v4: false)', () => {
         const faster: Partial<FasterConfig> = {
           ssgWorkerThreads: true,
         };
-        expect(() =>
+        expect(
           normalizeConfig({
             future: {
               v4: false,
               faster,
             },
           }),
-        ).toThrowErrorMatchingInlineSnapshot(`
-          [Error: Docusaurus config \`future.faster.ssgWorkerThreads\` requires the future flag \`future.v4.removeLegacyPostBuildHeadAttribute\` to be turned on.
-          If you use Docusaurus Faster, we recommend that you also activate Docusaurus v4 future flags: \`{future: {v4: true}}\`
-          All the v4 future flags are documented here: https://docusaurus.io/docs/api/docusaurus-config#future]
-        `);
+        ).toEqual(fasterContaining({ssgWorkerThreads: true}));
       });
 
-      it('rejects - true (v4: undefined)', () => {
+      it('accepts - true (v4: undefined)', () => {
         const faster: Partial<FasterConfig> = {
           ssgWorkerThreads: true,
         };
-        expect(() =>
+        expect(
           normalizeConfig({
             future: {
               v4: undefined,
               faster,
             },
           }),
-        ).toThrowErrorMatchingInlineSnapshot(`
-          [Error: Docusaurus config \`future.faster.ssgWorkerThreads\` requires the future flag \`future.v4.removeLegacyPostBuildHeadAttribute\` to be turned on.
-          If you use Docusaurus Faster, we recommend that you also activate Docusaurus v4 future flags: \`{future: {v4: true}}\`
-          All the v4 future flags are documented here: https://docusaurus.io/docs/api/docusaurus-config#future]
-        `);
+        ).toEqual(fasterContaining({ssgWorkerThreads: true}));
       });
 
       it('accepts - false', () => {
@@ -2497,7 +2479,6 @@ describe('future', () => {
           future: {
             v4: {
               fasterByDefault: true,
-              removeLegacyPostBuildHeadAttribute: true,
             },
           },
         }),
@@ -2510,7 +2491,6 @@ describe('future', () => {
           future: {
             v4: {
               fasterByDefault: true,
-              removeLegacyPostBuildHeadAttribute: true,
             },
             faster: {swcJsLoader: false},
           },
@@ -2562,7 +2542,6 @@ describe('future', () => {
 
     it('accepts v4 - full', () => {
       const v4: FutureV4Config = {
-        removeLegacyPostBuildHeadAttribute: true,
         useCssCascadeLayers: true,
         siteStorageNamespacing: true,
         fasterByDefault: true,
@@ -2606,81 +2585,6 @@ describe('future', () => {
         [Error: "future.v4" must be one of [object, boolean]
         ]
       `);
-    });
-
-    describe('removeLegacyPostBuildHeadAttribute', () => {
-      it('accepts - undefined', () => {
-        const v4: Partial<FutureV4Config> = {
-          removeLegacyPostBuildHeadAttribute: undefined,
-        };
-        expect(
-          normalizeConfig({
-            future: {
-              v4,
-            },
-          }),
-        ).toEqual(v4Containing({removeLegacyPostBuildHeadAttribute: false}));
-      });
-
-      it('accepts - true', () => {
-        const v4: Partial<FutureV4Config> = {
-          removeLegacyPostBuildHeadAttribute: true,
-        };
-        expect(
-          normalizeConfig({
-            future: {
-              v4,
-            },
-          }),
-        ).toEqual(v4Containing({removeLegacyPostBuildHeadAttribute: true}));
-      });
-
-      it('accepts - false', () => {
-        const v4: Partial<FutureV4Config> = {
-          removeLegacyPostBuildHeadAttribute: false,
-        };
-        expect(
-          normalizeConfig({
-            future: {
-              v4,
-            },
-          }),
-        ).toEqual(v4Containing({removeLegacyPostBuildHeadAttribute: false}));
-      });
-
-      it('rejects - null', () => {
-        const v4: Partial<FutureV4Config> = {
-          // @ts-expect-error: invalid
-          removeLegacyPostBuildHeadAttribute: 42,
-        };
-        expect(() =>
-          normalizeConfig({
-            future: {
-              v4,
-            },
-          }),
-        ).toThrowErrorMatchingInlineSnapshot(`
-          [Error: "future.v4.removeLegacyPostBuildHeadAttribute" must be a boolean
-          ]
-        `);
-      });
-
-      it('rejects - number', () => {
-        const v4: Partial<FutureV4Config> = {
-          // @ts-expect-error: invalid
-          removeLegacyPostBuildHeadAttribute: 42,
-        };
-        expect(() =>
-          normalizeConfig({
-            future: {
-              v4,
-            },
-          }),
-        ).toThrowErrorMatchingInlineSnapshot(`
-          [Error: "future.v4.removeLegacyPostBuildHeadAttribute" must be a boolean
-          ]
-        `);
-      });
     });
 
     describe('useCssCascadeLayers', () => {
@@ -2849,7 +2753,6 @@ describe('future', () => {
       it('accepts - true', () => {
         const v4: Partial<FutureV4Config> = {
           fasterByDefault: true,
-          removeLegacyPostBuildHeadAttribute: true,
         };
         expect(
           normalizeConfig({

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -99,7 +99,6 @@ export const DEFAULT_FASTER_CONFIG_TRUE: FasterConfig = {
 };
 
 export const DEFAULT_FUTURE_V4_CONFIG: FutureV4Config = {
-  removeLegacyPostBuildHeadAttribute: false,
   useCssCascadeLayers: false,
   siteStorageNamespacing: false,
   fasterByDefault: false,
@@ -108,7 +107,6 @@ export const DEFAULT_FUTURE_V4_CONFIG: FutureV4Config = {
 
 // When using the "v4: true" shortcut
 export const DEFAULT_FUTURE_V4_CONFIG_TRUE: FutureV4Config = {
-  removeLegacyPostBuildHeadAttribute: true,
   useCssCascadeLayers: true,
   siteStorageNamespacing: true,
   fasterByDefault: true,
@@ -315,9 +313,6 @@ const FASTER_CONFIG_SCHEMA = Joi.alternatives()
 const FUTURE_V4_SCHEMA = Joi.alternatives()
   .try(
     Joi.object<FutureV4Config>({
-      removeLegacyPostBuildHeadAttribute: Joi.boolean().default(
-        DEFAULT_FUTURE_V4_CONFIG.removeLegacyPostBuildHeadAttribute,
-      ),
       useCssCascadeLayers: Joi.boolean().default(
         DEFAULT_FUTURE_V4_CONFIG.useCssCascadeLayers,
       ),
@@ -619,22 +614,6 @@ Please migrate and move this option to code=${'siteConfig.markdown.hooks.onBroke
     config.future.experimental_vcs = vcsConfig;
   }
 
-  if (
-    config.future.faster.ssgWorkerThreads &&
-    !config.future.v4.removeLegacyPostBuildHeadAttribute
-  ) {
-    throw new Error(
-      `Docusaurus config ${logger.code(
-        'future.faster.ssgWorkerThreads',
-      )} requires the future flag ${logger.code(
-        'future.v4.removeLegacyPostBuildHeadAttribute',
-      )} to be turned on.
-If you use Docusaurus Faster, we recommend that you also activate Docusaurus v4 future flags: ${logger.code(
-        '{future: {v4: true}}',
-      )}
-All the v4 future flags are documented here: https://docusaurus.io/docs/api/docusaurus-config#future`,
-    );
-  }
 
   if (
     config.future.faster.rspackPersistentCache &&

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -614,7 +614,6 @@ Please migrate and move this option to code=${'siteConfig.markdown.hooks.onBroke
     config.future.experimental_vcs = vcsConfig;
   }
 
-
   if (
     config.future.faster.rspackPersistentCache &&
     !config.future.faster.rspackBundler

--- a/packages/docusaurus/src/ssg/ssgParams.ts
+++ b/packages/docusaurus/src/ssg/ssgParams.ts
@@ -30,9 +30,6 @@ export type SSGParams = {
   htmlMinifierType: HtmlMinifierType;
   serverBundlePath: string;
   ssgTemplateContent: string;
-
-  // TODO Docusaurus v4: remove deprecated postBuild({head}) API
-  v4RemoveLegacyPostBuildHeadAttribute: boolean;
 };
 
 export async function createSSGParams({
@@ -64,9 +61,6 @@ export async function createSSGParams({
     htmlMinifierType: props.siteConfig.future.faster.swcHtmlMinimizer
       ? 'swc'
       : 'terser',
-
-    v4RemoveLegacyPostBuildHeadAttribute:
-      props.siteConfig.future.v4.removeLegacyPostBuildHeadAttribute,
   };
 
   // Useless but ensures that SSG params remain serializable

--- a/packages/docusaurus/src/ssg/ssgRenderer.ts
+++ b/packages/docusaurus/src/ssg/ssgRenderer.ts
@@ -162,7 +162,6 @@ function reduceCollectedData(
     anchors: pageCollectedData.anchors,
     metadata: {
       public: pageCollectedData.metadata.public,
-      helmet: pageCollectedData.metadata.helmet,
     },
     links: pageCollectedData.links,
   };
@@ -183,11 +182,7 @@ async function generateStaticFile({
 }): Promise<SSGResult> {
   try {
     // This only renders the app HTML
-    const appRenderResult = await appRenderer.render({
-      pathname,
-      v4RemoveLegacyPostBuildHeadAttribute:
-        params.v4RemoveLegacyPostBuildHeadAttribute,
-    });
+    const appRenderResult = await appRenderer.render({pathname});
     // This renders the full page HTML, including head tags...
     const fullPageHtml = renderSSGTemplate({
       params,

--- a/website/docs/api/docusaurus.config.js.mdx
+++ b/website/docs/api/docusaurus.config.js.mdx
@@ -250,7 +250,6 @@ Example:
 export default {
   future: {
     v4: {
-      removeLegacyPostBuildHeadAttribute: true,
       useCssCascadeLayers: true,
       siteStorageNamespacing: true,
       fasterByDefault: true,
@@ -272,7 +271,6 @@ export default {
 ```
 
 - `v4`: Permits to opt-in for upcoming Docusaurus v4 breaking changes and features, to prepare your site in advance for this new version. Use `true` as a shorthand to enable all the flags.
-  - [`removeLegacyPostBuildHeadAttribute`](https://github.com/facebook/docusaurus/pull/10435): Removes the legacy `plugin.postBuild({head})` API that prevents us from applying useful SSG optimizations ([explanations](https://github.com/facebook/docusaurus/pull/10850)).
   - [`useCssCascadeLayers`](https://github.com/facebook/docusaurus/pull/11142): This enables the [Docusaurus CSS Cascade Layers plugin](./plugins/plugin-css-cascade-layers.mdx) with pre-configured layers that we plan to apply by default for Docusaurus v4.
   - [`siteStorageNamespacing`](https://github.com/facebook/docusaurus/pull/11797): Defaults the [`storage.namespace`](#storage) config to `true` instead of `false`. This enables automatic browser storage key namespacing, which avoids storage key conflicts when multiple Docusaurus sites are hosted under the same domain, or on localhost.
   - [`fasterByDefault`](https://github.com/facebook/docusaurus/pull/11802): Defaults all `future.faster` flags to `true` instead of `false`. This enables [Docusaurus Faster](https://github.com/facebook/docusaurus/issues/10556) features by default. Requires having `@docusaurus/faster` in your dependencies. If you explicitly set individual `faster` flags, those explicit values take precedence.
@@ -285,7 +283,7 @@ export default {
   - [`rspackBundler`](https://github.com/facebook/docusaurus/pull/10402): Use [Rspack](https://rspack.dev/) to bundle your app (instead of [webpack](https://webpack.js.org/)).
   - [`rspackPersistentCache`](https://github.com/facebook/docusaurus/pull/10931): Use [Rspack Persistent Cache](https://rspack.dev/config/cache) to re-build your app faster on subsequent builds. Requires `rspackBundler: true`. Requires persisting `./node_modules/.cache` across rebuilds.
   - [`mdxCrossCompilerCache`](https://github.com/facebook/docusaurus/pull/10479): Compile MDX files only once for both browser/Node.js environments instead of twice.
-  - [`ssgWorkerThreads`](https://github.com/facebook/docusaurus/pull/10826): Using a Node.js worker thread pool to execute the static site generation phase faster. Requires `future.v4.removeLegacyPostBuildHeadAttribute` to be turned on.
+  - [`ssgWorkerThreads`](https://github.com/facebook/docusaurus/pull/10826): Using a Node.js worker thread pool to execute the static site generation phase faster.
   - [`gitEagerVcs`](https://github.com/facebook/docusaurus/pull/11512): Upgrades the default [VCS strategy](#vcs) to `default-v2`, that reads your whole Git repository at once instead of per-file, making Git operations faster on large repositories.
 - `experimental_router`: The router type to use. Possible values are `browser` and `hash`. Defaults to `browser`. The `hash` router is only useful for rare cases where you want to opt-out of static site generation, have a fully client-side app with a single `index.html` entrypoint file. This can be useful to distribute a Docusaurus site as a `.zip` archive that you can [browse locally without running a web server](https://github.com/facebook/docusaurus/issues/3825).
 - [`experimental_vcs`](#vcs): The Version Control System (VCS) implementation to use to read file info (creation/last update date/author). Read the [dedicated section](#vcs) below for details.


### PR DESCRIPTION


## Motivation

Remove the legacy `head` attribute in plugin `postBuild()` lifecycle hook, and its associated v4 future flag

See also https://docusaurus.io/blog/releases/3.8#postbuild-change

This shouldn't impact anyone, but let me know if it does and you can't use `postBuild({routesBuildMetadata})` instead.





## Test Plan

CI

### Test links

https://deploy-preview-12084--docusaurus-2.netlify.app/

## Related issues/PRs

https://github.com/facebook/docusaurus/pull/10850