### PR TITLE
break(theme): `@docusaurus/theme-common` doesn't export `<UnlistedMetadata>` anymore (AI-assisted)

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/ContentVisibility/Unlisted/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/ContentVisibility/Unlisted/index.tsx
@@ -7,14 +7,22 @@
 
 import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
+import Head from '@docusaurus/Head';
 import {
   ThemeClassNames,
   UnlistedBannerTitle,
   UnlistedBannerMessage,
-  UnlistedMetadata,
 } from '@docusaurus/theme-common';
 import Admonition from '@theme/Admonition';
 import type {Props} from '@theme/ContentVisibility/Unlisted';
+
+function UnlistedMetadata(): ReactNode {
+  return (
+    <Head>
+      <meta name="robots" content="noindex, nofollow" />
+    </Head>
+  );
+}
 
 function UnlistedBanner({className}: Props) {
   return (

--- a/packages/docusaurus-theme-common/src/index.ts
+++ b/packages/docusaurus-theme-common/src/index.ts
@@ -138,7 +138,6 @@ export {
 export {
   UnlistedBannerTitle,
   UnlistedBannerMessage,
-  UnlistedMetadata,
   DraftBannerTitle,
   DraftBannerMessage,
 } from './translations/contentVisibilityTranslations';

--- a/packages/docusaurus-theme-common/src/translations/contentVisibilityTranslations.tsx
+++ b/packages/docusaurus-theme-common/src/translations/contentVisibilityTranslations.tsx
@@ -7,7 +7,6 @@
 
 import React, {type ReactNode} from 'react';
 import Translate from '@docusaurus/Translate';
-import Head from '@docusaurus/Head';
 
 export function UnlistedBannerTitle(): ReactNode {
   return (
@@ -27,16 +26,6 @@ export function UnlistedBannerMessage(): ReactNode {
       This page is unlisted. Search engines will not index it, and only users
       having a direct link can access it.
     </Translate>
-  );
-}
-
-// TODO Docusaurus v4 breaking change (since it's v3 public theme-common API :/)
-//  Move this to theme/ContentVisibility/Unlisted
-export function UnlistedMetadata(): ReactNode {
-  return (
-    <Head>
-      <meta name="robots" content="noindex, nofollow" />
-    </Head>
   );
 }
 


### PR DESCRIPTION


## Motivation

Minor breaking change: `<UnlistedMetadata>` is not exported from `@docusaurus/theme-common` anymore but colocated inline directly in theme-classic

This shouldn't really impact anyone. This export wasn't even documented, but it's part of `@docusaurus/theme-common` so we still consider this a breaking change and ship this in a v4.0 major release.

## Test Plan

ci
