### PR TITLE
docs(utils): fix incorrect encodePath JSDoc examples

### DIFF
--- a/packages/docusaurus-utils/src/urlUtils.ts
+++ b/packages/docusaurus-utils/src/urlUtils.ts
@@ -138,8 +138,8 @@ export function fileToPath(file: string): string {
  * Similar to `encodeURI`, but uses `encodeURIComponent` and assumes there's no
  * query.
  *
- * `encodeURI("/question?/answer")` => `"/question?/answer#section"`;
- * `encodePath("/question?/answer#section")` => `"/question%3F/answer%23foo"`
+ * `encodeURI("/question?/answer")` => `"/question?/answer"`;
+ * `encodePath("/question?/answer#section")` => `"/question%3F/answer%23section"`
  */
 export function encodePath(userPath: string): string {
   return userPath


### PR DESCRIPTION
The JSDoc examples for `encodePath` (`packages/docusaurus-utils/src/urlUtils.ts`) describe output that the inputs never produce:

- `encodeURI("/question?/answer")` was shown returning `"/question?/answer#section"` — but `#section` is not in the input. The actual result is `"/question?/answer"`.
- `encodePath("/question?/answer#section")` was shown as `"/question%3F/answer%23foo"` — but `foo` never appears in the input. The actual result is `"/question%3F/answer%23section"`.

This corrects both examples to the real outputs (verified with `node`):

```js
encodeURI("/question?/answer")            // "/question?/answer"
encodePath("/question?/answer#section")   // "/question%3F/answer%23section"
```

Docs-only (a JSDoc comment); no behavior change.
