### PR TITLE
fix(theme-common): avoid treating digits as emoji icons

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/__tests__/emojiUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/emojiUtils.test.ts
@@ -37,10 +37,24 @@ describe('extractLeadingEmoji', () => {
     });
   });
 
+  it('extracts leading keycap emoji', () => {
+    expect(extractLeadingEmoji('1️⃣ First item')).toEqual({
+      emoji: '1️⃣',
+      rest: ' First item',
+    });
+  });
+
   it('preserves original string', () => {
     expect(extractLeadingEmoji('Hello World')).toEqual({
       emoji: null,
       rest: 'Hello World',
+    });
+  });
+
+  it('preserves original string - leading digit', () => {
+    expect(extractLeadingEmoji('11 Something')).toEqual({
+      emoji: null,
+      rest: '11 Something',
     });
   });
 

--- a/packages/docusaurus-theme-common/src/utils/emojiUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/emojiUtils.ts
@@ -7,6 +7,15 @@
 
 const segmenter = new Intl.Segmenter(undefined, {granularity: 'grapheme'});
 
+function isEmojiGrapheme(grapheme: string): boolean {
+  return (
+    /\p{Extended_Pictographic}/u.test(grapheme) ||
+    /\p{Emoji_Presentation}/u.test(grapheme) ||
+    /\p{Regional_Indicator}/u.test(grapheme) ||
+    /[#*0-9]\uFE0F?\u20E3/u.test(grapheme)
+  );
+}
+
 /**
  * This method splits "⚠️ Hello World" into "⚠️" + " Hello World".
  * It is quite strict and dumb, only useful to handle best-effort heuristics.
@@ -30,10 +39,7 @@ export function extractLeadingEmoji(input: string): {
   }
 
   // Leading grapheme contains an emoji (covers flags/ZWJ/skin tones)
-  if (
-    !/\p{Extended_Pictographic}/u.test(grapheme) &&
-    !/\p{Emoji}/u.test(grapheme)
-  ) {
+  if (!isEmojiGrapheme(grapheme)) {
     return {emoji: null, rest: input};
   }
 


### PR DESCRIPTION
## Problem

DocCard uses the leading grapheme of a label as an icon when it looks like an emoji. Unicode `\p{Emoji}` also matches bare ASCII digits, so titles such as `11 Something` lose their leading digit to the icon slot.

Closes #12071.

## Root cause

`extractLeadingEmoji()` treated any grapheme matching `\p{Emoji}` as an emoji. Digits are included in that property because they can participate in keycap emoji sequences.

## Solution

Narrow the heuristic to emoji presentation, pictographic emoji, regional indicators for flags, and explicit keycap sequences. This preserves labels that start with digits while still extracting real emoji such as `😀`, `🇫🇷`, `👨‍👩‍👧‍👦`, and `1️⃣`.

## Tests

- `yarn build:packages`
- `yarn test packages/docusaurus-theme-common/src/utils/__tests__/emojiUtils.test.ts`
- `yarn format:diff packages/docusaurus-theme-common/src/utils/emojiUtils.ts packages/docusaurus-theme-common/src/utils/__tests__/emojiUtils.test.ts`
- `node node_modules/eslint/bin/eslint.js --cache --report-unused-disable-directives packages/docusaurus-theme-common/src/utils/emojiUtils.ts packages/docusaurus-theme-common/src/utils/__tests__/emojiUtils.test.ts`
- `git diff --check`