### PR TITLE
fix(core): retry hash scroll to fix deep-link anchor race condition (#11835)

### DIFF
--- a/packages/docusaurus/src/client/ClientLifecyclesDispatcher.tsx
+++ b/packages/docusaurus/src/client/ClientLifecyclesDispatcher.tsx
@@ -28,15 +28,43 @@ export function dispatchLifecycleAction<K extends keyof ClientModule>(
   return () => callbacks.forEach((cb) => cb?.());
 }
 
+const MAX_SCROLL_FRAME_RETRIES = 5;
+
+// Scrolls to the element matching the hash id, retrying on subsequent animation
+// frames if the element is not in the DOM yet (race on slow/async navigation).
+// Returns a cleanup function that cancels any pending retry.
+function scrollToHashElement(id: string): () => void {
+  let rafId: number | null = null;
+
+  const tryScroll = (remainingRetries: number) => {
+    const element = document.getElementById(id);
+    if (element) {
+      element.scrollIntoView();
+      return;
+    }
+    if (remainingRetries > 0) {
+      rafId = requestAnimationFrame(() => tryScroll(remainingRetries - 1));
+    }
+  };
+
+  tryScroll(MAX_SCROLL_FRAME_RETRIES);
+
+  return () => {
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+    }
+  };
+}
+
 function scrollAfterNavigation({
   location,
   previousLocation,
 }: {
   location: Location;
   previousLocation: Location | null;
-}) {
+}): (() => void) | undefined {
   if (!previousLocation) {
-    return; // no-op: use native browser feature
+    return undefined; // no-op: use native browser feature
   }
 
   const samePathname = location.pathname === previousLocation.pathname;
@@ -45,17 +73,24 @@ function scrollAfterNavigation({
 
   // Query-string changes: do not scroll to top/hash
   if (samePathname && sameHash && !sameSearch) {
-    return;
+    return undefined;
   }
 
   const {hash} = location;
   if (!hash) {
     window.scrollTo(0, 0);
-  } else {
-    const id = decodeURIComponent(hash.substring(1));
-    const element = document.getElementById(id);
-    element?.scrollIntoView();
+    return undefined;
   }
+
+  let id: string;
+  try {
+    id = decodeURIComponent(hash.substring(1));
+  } catch {
+    // Malformed hash (e.g. "#%E0%A4%A"): can't decode, nothing to scroll to.
+    return undefined;
+  }
+
+  return scrollToHashElement(id);
 }
 
 function ClientLifecyclesDispatcher({
@@ -69,9 +104,17 @@ function ClientLifecyclesDispatcher({
 }): ReactNode {
   useIsomorphicLayoutEffect(() => {
     if (previousLocation !== location) {
-      scrollAfterNavigation({location, previousLocation});
-      dispatchLifecycleAction('onRouteDidUpdate', {previousLocation, location});
+      const cancelScroll = scrollAfterNavigation({location, previousLocation});
+      const cleanupLifecycle = dispatchLifecycleAction('onRouteDidUpdate', {
+        previousLocation,
+        location,
+      });
+      return () => {
+        cancelScroll?.();
+        cleanupLifecycle();
+      };
     }
+    return undefined;
   }, [previousLocation, location]);
   return children;
 }

--- a/packages/docusaurus/src/client/__tests__/ClientLifecyclesDispatcher.test.tsx
+++ b/packages/docusaurus/src/client/__tests__/ClientLifecyclesDispatcher.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// @vitest-environment jsdom
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import React from 'react';
+import {render} from '@testing-library/react';
+import ClientLifecyclesDispatcher from '../ClientLifecyclesDispatcher';
+import type {Location} from 'history';
+
+vi.mock('@generated/client-modules', () => ({default: []}));
+
+function makeLocation(partial: Partial<Location>): Location {
+  return {
+    pathname: '/',
+    search: '',
+    hash: '',
+    state: null,
+    key: 'k',
+    ...partial,
+  } as Location;
+}
+
+function renderNav(prev: Location, next: Location) {
+  return render(
+    <ClientLifecyclesDispatcher location={next} previousLocation={prev}>
+      <div />
+    </ClientLifecyclesDispatcher>,
+  );
+}
+
+async function advanceFrames(n: number) {
+  for (let i = 0; i < n; i++) {
+    await vi.advanceTimersByTimeAsync(0);
+  }
+}
+
+describe('ClientLifecyclesDispatcher', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    global.requestAnimationFrame = ((cb: FrameRequestCallback) =>
+      setTimeout(() => cb(performance.now()), 0)) as typeof global.requestAnimationFrame;
+    global.cancelAnimationFrame = ((id: number) =>
+      clearTimeout(id)) as typeof global.cancelAnimationFrame;
+    // jsdom defines window.scrollTo, so we can spy on it directly.
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+    // jsdom does NOT define Element.prototype.scrollIntoView; initialise a
+    // no-op first (only if missing) so vi.spyOn has a method to wrap and
+    // vi.restoreAllMocks() can clean it up afterwards.
+    Element.prototype.scrollIntoView ??= () => {};
+    vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('scrolls immediately when the target element already exists', () => {
+    const target = document.createElement('div');
+    target.id = 'target';
+    document.body.append(target);
+
+    renderNav(
+      makeLocation({pathname: '/a'}),
+      makeLocation({pathname: '/b', hash: '#target'}),
+    );
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(window.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('scrolls after retry when the element appears on a later frame', async () => {
+    renderNav(
+      makeLocation({pathname: '/a'}),
+      makeLocation({pathname: '/b', hash: '#late'}),
+    );
+
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+
+    const target = document.createElement('div');
+    target.id = 'late';
+    document.body.append(target);
+
+    await advanceFrames(2);
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up after bounded retries when the element never appears (no throw, no scroll)', async () => {
+    renderNav(
+      makeLocation({pathname: '/a'}),
+      makeLocation({pathname: '/b', hash: '#never'}),
+    );
+
+    await advanceFrames(10);
+
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it('does not throw and does not scroll for a malformed hash', () => {
+    renderNav(
+      makeLocation({pathname: '/a'}),
+      makeLocation({pathname: '/b', hash: '#%E0%A4%A'}),
+    );
+
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it('does not scroll when only the query string changed', () => {
+    const prev = makeLocation({pathname: '/a', hash: '#x', search: '?a=1'});
+    const next = makeLocation({pathname: '/a', hash: '#x', search: '?a=2'});
+
+    renderNav(prev, next);
+
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+    expect(window.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('scrolls to top when navigating to a location without a hash', () => {
+    renderNav(
+      makeLocation({pathname: '/a', hash: '#x'}),
+      makeLocation({pathname: '/b'}),
+    );
+
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it('does nothing on initial load (no previousLocation)', () => {
+    render(
+      <ClientLifecyclesDispatcher
+        location={makeLocation({hash: '#x'})}
+        previousLocation={null}>
+        <div />
+      </ClientLifecyclesDispatcher>,
+    );
+
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+    expect(window.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('cancels a pending retry when navigating again before the element appears', async () => {
+    const {rerender} = renderNav(
+      makeLocation({pathname: '/a'}),
+      makeLocation({pathname: '/b', hash: '#late'}),
+    );
+
+    rerender(
+      <ClientLifecyclesDispatcher
+        location={makeLocation({pathname: '/c'})}
+        previousLocation={makeLocation({pathname: '/b', hash: '#late'})}>
+        <div />
+      </ClientLifecyclesDispatcher>,
+    );
+
+    const target = document.createElement('div');
+    target.id = 'late';
+    document.body.append(target);
+
+    await advanceFrames(10);
+
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+  });
+});


### PR DESCRIPTION
## Motivation

Fixes #11835.

When deep-linking to an anchor (a URL containing a `#hash`) during client-side navigation, the scroll to the target element is unreliable. `scrollAfterNavigation` calls `document.getElementById(id)?.scrollIntoView()` synchronously inside the layout effect, but the target element may not be rendered yet (a race condition that is common on slow-loading / async-rendered pages). When the element is missing, `getElementById` returns `null` and the scroll silently fails — the page stays at the top.

This PR makes the hash scroll robust:

- **Bounded `requestAnimationFrame` retry** (`scrollToHashElement`): if the target element isn't in the DOM yet, retry on the next animation frame, up to `MAX_SCROLL_FRAME_RETRIES` (5). This mirrors the existing rAF pattern already used in `scrollUtils.tsx` / `Collapsible`. The loop is bounded (a non-existent anchor never loops forever) and **self-cancelling** — the effect cleanup calls `cancelAnimationFrame`, so a pending retry from a previous navigation can't scroll to a stale anchor.
- **`decodeURIComponent` is now wrapped in `try/catch`** — a malformed hash (e.g. `#%E0%A4%A`) previously could throw; now it safely no-ops.
- **Initial-load behavior is unchanged** (`!previousLocation` still relies on the browser's native hash scroll) — this PR intentionally scopes the fix to the client-side navigation path, which is the reproducible failure.

In the common case where the element already exists, the scroll still happens synchronously on the first attempt — no added delay.

## Test Plan

Adds `ClientLifecyclesDispatcher.test.tsx` (Vitest, jsdom) covering:

- scrolls immediately when the target element already exists
- scrolls after retry when the element appears on a later frame (the race)
- gives up after the bounded number of retries when the element never appears (no throw, no scroll)
- does not throw and does not scroll for a malformed hash
- does not scroll on query-string-only changes
- scrolls to top when navigating to a location without a hash
- does nothing on initial load (no `previousLocation`)
- cancels a pending retry when navigating again before the element appears

```
yarn vitest run packages/docusaurus/src/client/__tests__/ClientLifecyclesDispatcher.test.tsx
```

All 8 new tests pass; the full `packages/docusaurus/src/client` suite (15 files, 113 tests) passes with no regressions; ESLint and `tsc` are clean.

> Note: `MAX_SCROLL_FRAME_RETRIES` (5) is a small tunable — happy to adjust if maintainers prefer a different bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
