### PR TITLE
fix(theme-common): don't detect digits and text symbols as leading emoji (#12071)

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/__tests__/emojiUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/emojiUtils.test.ts
@@ -64,4 +64,72 @@ describe('extractLeadingEmoji', () => {
       rest: 'Hello World 😀',
     });
   });
+
+  it('does not detect bare leading digit as emoji', () => {
+    expect(extractLeadingEmoji('11 Something')).toEqual({
+      emoji: null,
+      rest: '11 Something',
+    });
+  });
+
+  it('does not detect a single digit as emoji', () => {
+    expect(extractLeadingEmoji('9')).toEqual({
+      emoji: null,
+      rest: '9',
+    });
+  });
+
+  it('does not detect bare hash as emoji', () => {
+    expect(extractLeadingEmoji('#')).toEqual({
+      emoji: null,
+      rest: '#',
+    });
+  });
+
+  it('extracts real keycap emoji (digit + VS16 + combining keycap)', () => {
+    // 1️⃣ is digit "1" followed by U+FE0F (Variation Selector-16) and
+    // U+20E3 (Combining Enclosing Keycap) — a multi-codepoint grapheme
+    // that should still be detected as emoji
+    expect(extractLeadingEmoji('1\u{FE0F}\u{20E3} Something')).toEqual({
+      emoji: '1\u{FE0F}\u{20E3}',
+      rest: ' Something',
+    });
+  });
+
+  it('extracts emoji-presentation emoji - 🎉', () => {
+    expect(extractLeadingEmoji('🎉 Party')).toEqual({
+      emoji: '🎉',
+      rest: ' Party',
+    });
+  });
+
+  it('extracts VS16 emoji - ⚠️ (text-default + variation selector)', () => {
+    // ⚠ (U+26A0) has Emoji=true, Emoji_Presentation=false.  With VS16
+    // (U+FE0F) it becomes a multi-codepoint grapheme that IS an emoji
+    expect(extractLeadingEmoji('⚠\u{FE0F} Warning')).toEqual({
+      emoji: '⚠\u{FE0F}',
+      rest: ' Warning',
+    });
+  });
+
+  it('does not detect text-presentation symbols - ©', () => {
+    expect(extractLeadingEmoji('© 2026')).toEqual({
+      emoji: null,
+      rest: '© 2026',
+    });
+  });
+
+  it('does not detect text-presentation symbols - ™', () => {
+    expect(extractLeadingEmoji('™ Brand')).toEqual({
+      emoji: null,
+      rest: '™ Brand',
+    });
+  });
+
+  it('does not detect text-presentation symbols - ♠', () => {
+    expect(extractLeadingEmoji('♠ Cards')).toEqual({
+      emoji: null,
+      rest: '♠ Cards',
+    });
+  });
 });

--- a/packages/docusaurus-theme-common/src/utils/emojiUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/emojiUtils.ts
@@ -29,7 +29,28 @@ export function extractLeadingEmoji(input: string): {
     return {emoji: null, rest: input};
   }
 
-  // Leading grapheme contains an emoji (covers flags/ZWJ/skin tones)
+  // Distinguish single-codepoint from multi-codepoint graphemes.
+  //
+  // Single-codepoint graphemes: many non-emoji symbols like ©, ®, ™, ♠, ♥,
+  // #, *, and ASCII digits match /\p{Emoji}/u because Unicode classifies
+  // them as Emoji Keycap Base or text-default emoji.  Using
+  // /\p{Emoji_Presentation}/u instead correctly rejects them — it only
+  // matches characters whose default presentation is emoji (e.g. 😀, 🎉).
+  //
+  // Multi-codepoint graphemes (length > 1): real keycap emoji (digit +
+  // U+FE0F + U+20E3), VS16 sequences (⚠ + U+FE0F → ⚠️), flags, and ZWJ
+  // compositions.  These are unambiguous emoji and should be detected via
+  // the broader /\p{Extended_Pictographic}/u || /\p{Emoji}/u check.
+  if ([...grapheme].length === 1) {
+    // Single codepoint — only emoji-presentation chars qualify
+    if (/\p{Emoji_Presentation}/u.test(grapheme)) {
+      return {emoji: grapheme, rest: input.slice(grapheme.length)};
+    }
+    return {emoji: null, rest: input};
+  }
+
+  // Multi-codepoint grapheme — accept if it contains an emoji property
+  // (covers keycaps, VS16 combos, flags, ZWJ, skin tones)
   if (
     !/\p{Extended_Pictographic}/u.test(grapheme) &&
     !/\p{Emoji}/u.test(grapheme)


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #12071) and the maintainers have approved on my working plan. <!-- bug fix, small scope -->

## Motivation

Fixes #12071.

`extractLeadingEmoji` (used by `DocCard` to split a leading emoji icon from a label) wrongly treats bare ASCII digits as emoji. A page titled `11 Something` renders with `1` extracted as the card icon and `1 Something` as the title.

The root cause is that `/\p{Emoji}/u.test("1") === true`: under Unicode, ASCII digits `0-9`, `#` and `*` carry the `Emoji` property because they are **Emoji Keycap Bases** (the base of keycap sequences like `1️⃣`). The same problem affects other characters that have `Emoji=Yes` but default to **text** presentation — e.g. `©`, `®`, `™`, `♠`, `♥`, `‼`, `↔` — so a title like `© 2026 …` would also pick `©` as its icon.

### Fix

`extractLeadingEmoji` now classifies the leading grapheme by codepoint count, following [UTS #51](https://unicode.org/reports/tr51/):

- **Single-codepoint grapheme** → treated as emoji **only if** it has `\p{Emoji_Presentation}` (i.e. its *default* presentation is emoji, like `😀` / `🎉`). This rejects digits, `#`, `*`, `©`, `®`, `™`, `♠`, etc., which default to text and require a VS16 to render as emoji.
- **Multi-codepoint grapheme** (length > 1) → keeps the broader `\p{Extended_Pictographic} || \p{Emoji}` check, so VS16 sequences (`⚠️` = `⚠` + U+FE0F), real keycaps (`1️⃣` = digit + U+FE0F + U+20E3), flags and ZWJ compositions are still detected.

## Test Plan

Unit tests added to `packages/docusaurus-theme-common/src/utils/__tests__/emojiUtils.test.ts`. All 17 tests pass (`yarn vitest run packages/docusaurus-theme-common/src/utils/__tests__/emojiUtils.test.ts`), and the full `@docusaurus/theme-common` suite (115 tests) and typecheck/lint are green.

| Input | Before | After |
|---|---|---|
| `11 Something` | `{ emoji: "1", rest: "1 Something" }` ❌ | `{ emoji: null, rest: "11 Something" }` ✅ |
| `9` | `{ emoji: "9", … }` ❌ | `{ emoji: null, rest: "9" }` ✅ |
| `# Heading` | `{ emoji: "#", … }` ❌ | `{ emoji: null, … }` ✅ |
| `© 2026` | `{ emoji: "©", … }` ❌ | `{ emoji: null, … }` ✅ |
| `™ Brand` | `{ emoji: "™", … }` ❌ | `{ emoji: null, … }` ✅ |
| `♠ Cards` | `{ emoji: "♠", … }` ❌ | `{ emoji: null, … }` ✅ |
| `🎉 Party` | `{ emoji: "🎉", … }` ✅ | `{ emoji: "🎉", … }` ✅ (unchanged) |
| `⚠️ Warning` | `{ emoji: "⚠️", … }` ✅ | `{ emoji: "⚠️", … }` ✅ (unchanged) |
| `1️⃣ Keycap` | `{ emoji: "1️⃣", … }` ✅ | `{ emoji: "1️⃣", … }` ✅ (unchanged) |

### Test links

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

Closes #12071.
