### PR TITLE
feat(core): add Link autoApplyTrailingSlash prop to opt out of trailing slash (#6282)

### DIFF
--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -181,6 +181,12 @@ declare module '@docusaurus/Link' {
       readonly href?: string;
       readonly autoAddBaseUrl?: boolean;
 
+      /**
+       * Set to false to skip applying the site trailingSlash config to this
+       * link (useful for direct asset/file links).
+       */
+      readonly autoApplyTrailingSlash?: boolean;
+
       /** Escape hatch in case broken links check doesn't make sense. */
       readonly 'data-noBrokenLinkCheck'?: boolean;
     };

--- a/packages/docusaurus/src/client/exports/Link.tsx
+++ b/packages/docusaurus/src/client/exports/Link.tsx
@@ -37,6 +37,7 @@ function Link(
     isActive,
     'data-noBrokenLinkCheck': noBrokenLinkCheck,
     autoAddBaseUrl = true,
+    autoApplyTrailingSlash = true,
     ...props
   }: Props,
   forwardedRef: React.ForwardedRef<HTMLAnchorElement>,
@@ -91,7 +92,7 @@ function Link(
     targetLink = targetLink?.slice(1);
   }
 
-  if (targetLink && isInternal) {
+  if (targetLink && isInternal && autoApplyTrailingSlash) {
     targetLink = applyTrailingSlash(targetLink, {trailingSlash, baseUrl});
   }
 

--- a/packages/docusaurus/src/client/exports/__tests__/Link.test.tsx
+++ b/packages/docusaurus/src/client/exports/__tests__/Link.test.tsx
@@ -134,6 +134,31 @@ describe('<Link>', () => {
       `);
     });
 
+    it('can opt out of trailing slash with autoApplyTrailingSlash={false}', () => {
+      const {container} = render(
+        <Link to="/docs/intro" autoApplyTrailingSlash={false} />,
+        {trailingSlash: true},
+      );
+      expect(container.firstElementChild).toMatchInlineSnapshot(`
+        <a
+          data-test-link-type="react-router"
+          href="/docs/intro"
+        />
+      `);
+    });
+
+    it('still applies trailing slash by default when autoApplyTrailingSlash is not set', () => {
+      const {container} = render(<Link to="/docs/intro" />, {
+        trailingSlash: true,
+      });
+      expect(container.firstElementChild).toMatchInlineSnapshot(`
+        <a
+          data-test-link-type="react-router"
+          href="/docs/intro/"
+        />
+      `);
+    });
+
     it("can render '#anchor'", () => {
       const {container} = render(<Link to="#anchor" />);
       expect(container.firstElementChild).toMatchInlineSnapshot(`


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #6282) and the maintainers have approved on my working plan. <!-- issue is labeled "status: accepting pr" -->

## Motivation

Fixes #6282.

When a site uses `trailingSlash: true`, direct asset links get a trailing slash appended, which turns them into 404s because the host treats the path as a page rather than a file. For example a Markdown link to `./assets/example.docx` is emitted as `.../assets/file/<hash>.docx/` and fails to resolve.

As discussed in the issue, a reliable automatic "asset vs page" heuristic is hard (`.html`, dotted page slugs, version dirs like `3.0rc1`, etc. all confuse extension-based guessing). So instead of guessing, this follows @slorber's suggestion to add an explicit opt-out prop on `<Link>`, mirroring the existing `autoAddBaseUrl` prop.

## What

Adds a new boolean prop `autoApplyTrailingSlash` to `<Link>`, defaulting to `true`:

```jsx
<Link autoApplyTrailingSlash={false} href="./assets/example.docx">
  Download
</Link>
```

When `false`, the site's `trailingSlash` config is not applied to that link, so the asset path is preserved exactly. The default keeps existing links unchanged, and all other `<Link>` behavior (`autoAddBaseUrl`, `pathname://` handling, internal-link detection, hash router) is untouched.

`applyTrailingSlash` (the util) is intentionally left unchanged — no heuristic.

## Test Plan

Unit tests added to `packages/docusaurus/src/client/exports/__tests__/Link.test.tsx`:

- with `trailingSlash: true` and a normal internal link → trailing slash still applied (default behavior unchanged);
- with `trailingSlash: true` and `autoApplyTrailingSlash={false}` → the href is left without a trailing slash.

All 24 tests in that file pass (`yarn vitest run packages/docusaurus/src/client/exports/__tests__/Link.test.tsx`); typecheck and lint are clean.

### Test links

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

Closes #6282.
