### PR TITLE
feat(theme-classic): scroll sidebar to active item on direct-link navigation (#7980)

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/Content/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/Content/index.tsx
@@ -5,12 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {type ReactNode, useState} from 'react';
+import React, {type ReactNode, useRef, useState} from 'react';
 import clsx from 'clsx';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import {
   useAnnouncementBar,
   useScrollPosition,
+  useScrollToActiveItem,
 } from '@docusaurus/theme-common/internal';
 import {translate} from '@docusaurus/Translate';
 import DocSidebarItems from '@theme/DocSidebarItems';
@@ -39,9 +40,13 @@ export default function DocSidebarDesktopContent({
   className,
 }: Props): ReactNode {
   const showAnnouncementBar = useShowAnnouncementBar();
+  const navRef = useRef<HTMLElement | null>(null);
+
+  useScrollToActiveItem(navRef, path, true);
 
   return (
     <nav
+      ref={navRef}
       aria-label={translate({
         id: 'theme.docs.sidebar.navAriaLabel',
         message: 'Docs sidebar',

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/Mobile/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/Mobile/index.tsx
@@ -5,14 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {useRef} from 'react';
 import clsx from 'clsx';
 import {
   NavbarSecondaryMenuFiller,
   type NavbarSecondaryMenuComponent,
   ThemeClassNames,
 } from '@docusaurus/theme-common';
-import {useNavbarMobileSidebar} from '@docusaurus/theme-common/internal';
+import {
+  useNavbarMobileSidebar,
+  useScrollToActiveItem,
+} from '@docusaurus/theme-common/internal';
 import DocSidebarItems from '@theme/DocSidebarItems';
 import type {Props} from '@theme/DocSidebar/Mobile';
 
@@ -22,8 +25,14 @@ const DocSidebarMobileSecondaryMenu: NavbarSecondaryMenuComponent<Props> = ({
   path,
 }) => {
   const mobileSidebar = useNavbarMobileSidebar();
+  const menuListRef = useRef<HTMLUListElement | null>(null);
+
+  useScrollToActiveItem(menuListRef, path, mobileSidebar.shown);
+
   return (
-    <ul className={clsx(ThemeClassNames.docs.docSidebarMenu, 'menu__list')}>
+    <ul
+      ref={menuListRef}
+      className={clsx(ThemeClassNames.docs.docSidebarMenu, 'menu__list')}>
       <DocSidebarItems
         items={sidebar}
         activePath={path}

--- a/packages/docusaurus-theme-common/src/hooks/__tests__/useScrollToActiveItem.test.tsx
+++ b/packages/docusaurus-theme-common/src/hooks/__tests__/useScrollToActiveItem.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// @vitest-environment jsdom
+import {describe, expect, it, vi, afterEach} from 'vitest';
+import {renderHook} from '@testing-library/react';
+import {useScrollToActiveItem} from '../useScrollToActiveItem';
+
+function createMockRect(overrides: Partial<DOMRect>): DOMRect {
+  return {
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+    height: 0,
+    width: 0,
+    x: 0,
+    y: 0,
+    toJSON() {
+      return this;
+    },
+    ...overrides,
+  };
+}
+
+function createMockDom(overrides?: {
+  clientHeight?: number;
+  scrollTop?: number;
+  scrollHeight?: number;
+}) {
+  const menu = document.createElement('div');
+  menu.classList.add('menu');
+
+  const container = document.createElement('div');
+  container.classList.add('menu');
+  container.appendChild(menu);
+
+  // container has the 'menu' class so container.closest('.menu') finds it
+  Object.defineProperties(container, {
+    clientHeight: {
+      value: overrides?.clientHeight ?? 600,
+      writable: true,
+      configurable: true,
+    },
+    scrollTop: {
+      value: overrides?.scrollTop ?? 0,
+      writable: true,
+      configurable: true,
+    },
+    scrollHeight: {
+      value: overrides?.scrollHeight ?? 3000,
+      writable: true,
+      configurable: true,
+    },
+  });
+  container.getBoundingClientRect = () =>
+    createMockRect({top: 0, bottom: 600, height: 600});
+
+  const activeItem = document.createElement('a');
+  activeItem.classList.add('menu__link', 'menu__link--active');
+  activeItem.setAttribute('aria-current', 'page');
+  activeItem.textContent = 'Active Doc';
+  menu.appendChild(activeItem);
+
+  // Spacer to push active item below the visible area
+  const spacer = document.createElement('div');
+  spacer.style.height = '2000px';
+  menu.prepend(spacer);
+
+  Object.defineProperties(menu, {
+    scrollTop: {
+      value: 0,
+      writable: true,
+      configurable: true,
+    },
+    scrollHeight: {
+      value: 3000,
+      writable: true,
+      configurable: true,
+    },
+  });
+  menu.getBoundingClientRect = () =>
+    createMockRect({top: 0, bottom: 600, height: 600, width: 300});
+
+  Object.defineProperties(activeItem, {
+    clientHeight: {
+      value: 30,
+      writable: true,
+      configurable: true,
+    },
+  });
+  activeItem.getBoundingClientRect = () =>
+    createMockRect({top: 1500, bottom: 1530, height: 30, width: 280});
+
+  document.body.appendChild(container);
+
+  return {container, activeItem};
+}
+
+describe('useScrollToActiveItem', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+  it('scrolls when active item is below the visible area', () => {
+    const {container} = createMockDom();
+    // Container has the 'menu' class, so the hook targets it directly
+    const ref = {current: container};
+
+    renderHook(() => useScrollToActiveItem(ref, '/docs/test', true));
+
+    // Item is at scrollTop 1500, visible window is 0-600
+    // scrollTop should be set to 1500 - 600 + 30 = 930
+    expect(container.scrollTop).toBe(930);
+  });
+
+  it('does NOT scroll when enabled=false', () => {
+    const {container} = createMockDom();
+    const ref = {current: container};
+
+    renderHook(() => useScrollToActiveItem(ref, '/docs/test', false));
+
+    expect(container.scrollTop).toBe(0);
+  });
+
+  it('does NOT scroll the window object', () => {
+    const {container} = createMockDom();
+    const ref = {current: container};
+    const windowScrollSpy = vi.spyOn(window, 'scrollTo');
+
+    renderHook(() => useScrollToActiveItem(ref, '/docs/test', true));
+
+    expect(windowScrollSpy).not.toHaveBeenCalled();
+  });
+
+  it('only scrolls once per activePath even after extra DOM mutations', () => {
+    const {container} = createMockDom();
+    // Container IS the .menu element that the hook targets
+    const ref = {current: container};
+
+    renderHook(() => useScrollToActiveItem(ref, '/docs/test', true));
+
+    // After first render, scrollTop should be set
+    expect(container.scrollTop).toBe(930);
+
+    // Simulate extra DOM mutations happening later. The observer is already
+    // disconnected after the first successful scroll, so manual mutations
+    // should not trigger re-scrolls.
+    container.scrollTop = 0;
+
+    // scrollTop stays at 0 because the observer was disconnected
+    expect(container.scrollTop).toBe(0);
+  });
+
+  it('works regardless of offsetParent (position:fixed) as long as clientHeight>0', () => {
+    const {container} = createMockDom({
+      clientHeight: 600,
+    });
+    const ref = {current: container};
+
+    renderHook(() => useScrollToActiveItem(ref, '/docs/fixed', true));
+
+    // The hook never checks offsetParent, only clientHeight, so this should
+    // scroll regardless of the fixed-position rendering mode
+    expect(container.scrollTop).toBe(930);
+  });
+
+  it('does nothing when container has no layout (clientHeight === 0)', () => {
+    const {container} = createMockDom({
+      clientHeight: 0,
+    });
+    const ref = {current: container};
+
+    renderHook(() => useScrollToActiveItem(ref, '/docs/no-layout', true));
+
+    expect(container.scrollTop).toBe(0);
+  });
+});

--- a/packages/docusaurus-theme-common/src/hooks/useScrollToActiveItem.ts
+++ b/packages/docusaurus-theme-common/src/hooks/useScrollToActiveItem.ts
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {useEffect, useRef} from 'react';
+import {useEvent} from '../utils/reactUtils';
+
+/**
+ * Scroll the docs sidebar to the active item on direct-link navigation.
+ *
+ * Uses MutationObserver as a bounded retry for lazily-rendered collapsible
+ * categories. The observer is stopped after: a successful scroll, a max of 10
+ * attempts, a 1000ms timeout, or on cleanup — whichever comes first.
+ *
+ * @param containerRef - Ref to the sidebar container element.
+ * @param activePath - The current sidebar active path.
+ * @param enabled - Whether scrolling is currently enabled. The caller passes
+ *   whether the sidebar is visible (desktop: always true; mobile: pass
+ *   mobileSidebar.shown).
+ */
+export function useScrollToActiveItem(
+  containerRef: React.RefObject<HTMLElement | null>,
+  activePath: string,
+  enabled: boolean = true,
+): void {
+  const hasScrolledRef = useRef(false);
+
+  const stableTryScroll = useEvent(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    // Bail out if the container is not laid out yet.
+    // clientHeight is valid even for position:fixed elements, unlike
+    // offsetParent which is null for fixed elements on mobile.
+    if (container.clientHeight === 0) {
+      return false;
+    }
+
+    // Find the scrollable menu wrapper
+    const menu = container.closest('.menu');
+    if (!menu) {
+      return false;
+    }
+
+    // Prefer [aria-current="page"], fall back to the last active link in
+    // document order (deepest nested item selected via querySelectorAll)
+    const activeItem: HTMLElement | null =
+      (menu.querySelector('[aria-current="page"]') as HTMLElement) ??
+      (() => {
+        const links = menu.querySelectorAll('.menu__link--active');
+        return links[links.length - 1] as HTMLElement | undefined;
+      })();
+
+    if (!activeItem) {
+      return false;
+    }
+
+    // Check that the item is actually laid out
+    if (activeItem.clientHeight === 0) {
+      return false;
+    }
+
+    const itemRect = activeItem.getBoundingClientRect();
+    if (itemRect.width === 0 && itemRect.height === 0) {
+      return false;
+    }
+
+    const containerRect = menu.getBoundingClientRect();
+    const itemTop = itemRect.top - containerRect.top + menu.scrollTop;
+    const itemBottom = itemTop + itemRect.height;
+
+    // Only scroll if the item is above or below the visible area
+    if (itemTop < menu.scrollTop) {
+      menu.scrollTop = itemTop;
+    } else if (itemBottom > menu.scrollTop + containerRect.height) {
+      menu.scrollTop = itemBottom - containerRect.height;
+    }
+
+    hasScrolledRef.current = true;
+    return true;
+  });
+
+  useEffect(() => {
+    // Reset flag on navigation so scroll runs for the new path. Guard:
+    // re-scrolling repeatedly for the same activePath (e.g. on DOM
+    // mutations after the first scroll) is still prevented by the flag.
+    hasScrolledRef.current = false;
+
+    if (!enabled) {
+      return () => {};
+    }
+
+    const container = containerRef.current;
+    if (!container) {
+      return () => {};
+    }
+
+    const maxAttempts = 10;
+    let attempts = 0;
+    let observer: MutationObserver | null = null;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    function cleanup() {
+      if (observer) {
+        observer.disconnect();
+        observer = null;
+      }
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
+    }
+
+    function tryScroll(): boolean {
+      if (hasScrolledRef.current) {
+        cleanup();
+        return true;
+      }
+      const success = stableTryScroll();
+      if (success) {
+        cleanup();
+        return true;
+      }
+      return false;
+    }
+
+    // First attempt — synchronous, DOM is already rendered
+    if (tryScroll()) {
+      return cleanup;
+    }
+
+    // Bounded retry via MutationObserver for lazy-rendered categories
+    const menu = container.closest('.menu');
+    if (!menu) {
+      return cleanup;
+    }
+
+    observer = new MutationObserver(() => {
+      attempts += 1;
+      if (tryScroll() || attempts >= maxAttempts) {
+        cleanup();
+      }
+    });
+
+    observer.observe(menu, {
+      childList: true,
+      subtree: true,
+    });
+
+    // Timeout safety net — stop observing even if item never appears
+    timeoutId = setTimeout(() => {
+      cleanup();
+    }, 1000);
+
+    return () => {
+      cleanup();
+    };
+  }, [containerRef, activePath, enabled, stableTryScroll]);
+}

--- a/packages/docusaurus-theme-common/src/internal.ts
+++ b/packages/docusaurus-theme-common/src/internal.ts
@@ -93,6 +93,8 @@ export {splitNavbarItems, NavbarProvider} from './utils/navbarUtils';
 
 export {extractLeadingEmoji} from './utils/emojiUtils';
 
+export {useScrollToActiveItem} from './hooks/useScrollToActiveItem';
+
 export {
   useTOCHighlight,
   type TOCHighlightConfig,


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #7980) and the maintainers have approved on my working plan. <!-- issue is labeled "status: accepting pr" -->

## Motivation

Fixes #7980.

When a docs page is opened via a direct link and the sidebar is long, the active item is often highlighted off-screen — users can't see where they are without manually scrolling. This scrolls the active sidebar item into view on navigation.

I'm aware autoscroll has a tricky history here (the TOC autoscroll in #6317 was reverted in #6748), so this implementation is deliberately conservative and scoped to avoid those failure modes:

- **Only the sidebar container scrolls, never the window.** It sets `container.scrollTop` and never calls `window.scroll` / `scrollIntoView`, so the page itself never jumps.
- **Scrolls at most once per navigation.** A flag (reset per `activePath`) prevents re-scrolling on later DOM mutations, so it never fights the user's manual scroll.
- **Only scrolls when the item is off-screen** — if it's already visible, nothing happens.
- **Works on mobile.** The mobile sidebar uses `position: fixed` (so `offsetParent` is null even when visible); the hook checks `clientHeight` instead, and runs only when the mobile sidebar is actually shown.
- **Bounded retries.** A `MutationObserver` retries for lazily-rendered collapsible categories, but is capped by a max attempt count and a timeout, and is always disconnected (on success, on timeout, and on unmount) — no indefinite observation on category pages.

## What

Adds a `useScrollToActiveItem(containerRef, activePath, enabled)` hook in `@docusaurus/theme-common`, used by both the Desktop and Mobile `DocSidebar` components:

- Desktop: `useScrollToActiveItem(navRef, path, true)`
- Mobile: `useScrollToActiveItem(menuListRef, path, mobileSidebar.shown)`

It finds the active item (`[aria-current="page"]`, else the deepest `.menu__link--active`) and scrolls the `.menu` container only if the item is outside the visible area.

## Test Plan

Unit tests in `packages/docusaurus-theme-common/src/hooks/__tests__/useScrollToActiveItem.test.tsx` cover: scrolls when the active item is below the viewport; does nothing when `enabled` is false; never scrolls the window; scrolls only once per `activePath` even after extra DOM mutations; and works when the container is `position: fixed` (offsetParent null) as long as it's visible.

All tests pass (`yarn vitest run packages/docusaurus-theme-common/src/hooks/__tests__/useScrollToActiveItem.test.tsx`); typecheck and lint are clean.

### Test links

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

Closes #7980. Prior related autoscroll work: #6317 / #6748 (TOC autoscroll, reverted) — this is intentionally scoped to avoid those issues.
