### PR TITLE
fix: prevent digits from being detected as emoji in extractLeadingEmoji

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/emojiUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/emojiUtils.ts
@@ -30,9 +30,13 @@ export function extractLeadingEmoji(input: string): {
   }
 
   // Leading grapheme contains an emoji (covers flags/ZWJ/skin tones)
+  // Use Extended_Pictographic for actual emoji/pictographs
+  // Use Emoji_Presentation instead of Emoji to exclude digits (0-9),
+  // #, *, and other characters that are technically Emoji but displayed
+  // as text by default. See https://github.com/facebook/docusaurus/issues/12071
   if (
     !/\p{Extended_Pictographic}/u.test(grapheme) &&
-    !/\p{Emoji}/u.test(grapheme)
+    !/\p{Emoji_Presentation}/u.test(grapheme)
   ) {
     return {emoji: null, rest: input};
   }


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes #12071

### Problem

The `extractLeadingEmoji` function in `emojiUtils.ts` uses `\p{Emoji}` to detect emoji characters. However, the Unicode `Emoji` property includes digits (0-9), `#`, and `*` since these characters have emoji presentations (e.g., 0️⃣, #️⃣, *️⃣).

This causes `DocCard` to incorrectly extract leading digits from document titles as emoji, leading to weird rendering where numbers are stripped from titles.

### Solution

Replaced `\p{Emoji}` with `\p{Emoji_Presentation}`, which only matches characters that display as emoji by default (not as text). This excludes:
- Digits 0-9
- `#` and `*`
- Other characters that are technically emoji but render as text by default

The `\p{Extended_Pictographic}` check is kept as the primary check (covers most emoji including flags), and `\p{Emoji_Presentation}` serves as a fallback for edge cases like ⚠️ that aren't Extended_Pictographic but should still be detected.

### Test Plan

Existing tests continue to pass. Additionally, the following cases should now correctly return `null` for the emoji:
- `extractLeadingEmoji("123 Hello")` → `{emoji: null, rest: "123 Hello"}`
- `extractLeadingEmoji("# Heading")` → `{emoji: null, rest: "# Heading"}`
- `extractLeadingEmoji("* Item")` → `{emoji: null, rest: "* Item"}`

While actual emoji still work:
- `extractLeadingEmoji("😀 Hello")` → `{emoji: "😀", rest: " Hello"}`
- `extractLeadingEmoji("⚠️ Warning")` → `{emoji: "⚠️", rest: " Warning"}`

### Suggested test addition

```typescript
it('does not extract leading digits as emoji', () => {
  expect(extractLeadingEmoji('123 Hello World')).toEqual({
    emoji: null,
    rest: '123 Hello World',
  });
});

it('does not extract # as emoji', () => {
  expect(extractLeadingEmoji('# Heading')).toEqual({
    emoji: null,
    rest: '# Heading',
  });
});
```
