### PR TITLE
docs: document authentication and access restriction strategies (#6890)

### DIFF
--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -86,6 +86,47 @@ export default function Home() {
 }
 ```
 
+## Authentication and access restriction {/* #authentication */}
+
+Docusaurus builds a **static site**, so there is no built-in way to restrict access to pages or require users to log in. By default, anything you deploy is public. To put content behind authentication, you handle it at the **hosting/infrastructure layer**, or render protected content **client-side** from an authenticated API.
+
+There is no single right answer — the best approach depends on your host and on what exactly you want to protect.
+
+### Protecting the whole site {/* #protecting-the-whole-site */}
+
+The simplest option is to let your static host or CDN gate access to the entire deployment:
+
+- Some hosts offer **built-in password protection**, such as [Netlify's site protection](https://docs.netlify.com/visitor-access/password-protection/).
+- CDNs with **edge functions** (for example [Cloudflare Workers](https://developers.cloudflare.com/workers/)) let you implement cookie-based sessions or an OAuth flow in front of a static site. See this [Cloudflare Worker GitHub OAuth example](https://github.com/gr2m/cloudflare-worker-github-oauth-login).
+
+With edge functions you can go further and build **two versions** of your static site (one for anonymous visitors, one for authenticated users), then use the edge function to inspect the auth cookie and serve the appropriate deployment.
+
+### Protecting a section of the site {/* #protecting-a-section */}
+
+If only part of your site is sensitive, you can render that section **client-side** and fetch its content from a protected API at runtime, similar to [Gatsby's client-only routes](https://www.gatsbyjs.com/docs/how-to/routing/client-only-routes-and-user-authentication/). The static build only ships a shell (a spinner or a login screen), and the real content is loaded in the browser after the user is authenticated.
+
+A typical setup looks like this:
+
+- Register a catch-all route for the protected area, for example with a [plugin's `addRoute`](./api/plugin-methods/lifecycle-apis.mdx#addRoute):
+
+  ```js
+  addRoute({
+    path: '/admin',
+    component: '@site/src/components/Admin',
+    exact: false,
+  });
+  ```
+
+- On the server, that route statically renders only a placeholder (a spinner or login page) to `/admin/index.html`.
+- Configure your host to serve `/admin/index.html` for any `/admin/*` request (for example, a Netlify redirect — remember to handle every [i18n](./i18n/i18n-introduction.mdx) locale).
+- After mounting in the browser, the `Admin` component reads the auth state, renders the real UI client-side, and fetches data from an authenticated API.
+
+:::warning
+
+Client-side gating hides content in the UI but the **API** is what actually enforces access. Never rely on the static site alone to keep data private — always authorize requests on the server that serves the protected data.
+
+:::
+
 ## Choosing a hosting provider {/* #choosing-a-hosting-provider */}
 
 There are a few common hosting options:


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior. <!-- docs-only change -->
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #6890) and the maintainers have approved on my working plan. <!-- issue is labeled "status: accepting pr" -->

## Motivation

Closes #6890.

The issue asks for documentation on how to authenticate / restrict access to a Docusaurus site. As @Josh-Cena suggested, this belongs under the deployment docs, and @slorber had already written up the possible strategies and their tradeoffs in [#958](https://github.com/facebook/docusaurus/issues/958#issuecomment-1057075925). This PR organizes that guidance into a proper docs section.

## What

Adds an **"Authentication and access restriction"** section to `website/docs/deployment.mdx` (right after "Using environment variables"), covering the three strategies from the maintainers:

1. **Whole-site protection** via static host / CDN built-in password protection (e.g. Netlify) or CDN edge functions (Cloudflare Workers) for cookie/OAuth flows — including the "two static builds (anon vs authed) routed by the edge on the auth cookie" approach.
2. **Section-level protection** via client-side-rendered routes that fetch from a protected API (similar to Gatsby client-only routes): `addRoute` catch-all, a static spinner/login shell at `/admin/index.html`, a host redirect `/admin/* → /admin/index.html` (per i18n locale), and client-side rendering after mount.

It frames clearly that Docusaurus is a static site with **no built-in auth**, and includes a `:::warning` that the **API**, not the static build, is what truly enforces access.

## Test Plan

Docs-only change. Verified with `yarn build` (website builds successfully with no broken links), and formatting passes `oxfmt`. Internal links (`addRoute` lifecycle API, i18n introduction) resolve to existing pages.

### Test links

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/docs/deployment#authentication

## Related issues/PRs

Closes #6890. Source material: #958 (auth strategies).
