### PR TITLE
refactor(theme-classic): remove inert React 18 workaround

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/MobileSidebar/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/MobileSidebar/Layout/index.tsx
@@ -5,23 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {version, type ReactNode} from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {useNavbarSecondaryMenu} from '@docusaurus/theme-common/internal';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import type {Props} from '@theme/Navbar/MobileSidebar/Layout';
-
-// TODO Docusaurus v4: remove temporary inert workaround
-//  See https://github.com/facebook/react/issues/17157
-//  See https://github.com/radix-ui/themes/pull/509
-function inertProps(inert: boolean) {
-  const isBeforeReact19 = parseInt(version!.split('.')[0]!, 10) < 19;
-  if (isBeforeReact19) {
-    // TODO Docusaurus v4: remove temporary inert workaround
-    return {inert: inert ? '' : undefined} as unknown as {inert: boolean};
-  }
-  return {inert};
-}
 
 function NavbarMobileSidebarPanel({
   children,
@@ -36,7 +24,7 @@ function NavbarMobileSidebarPanel({
         ThemeClassNames.layout.navbar.mobileSidebar.panel,
         'navbar-sidebar__item menu',
       )}
-      {...inertProps(inert)}>
+      inert={inert}>
       {children}
     </div>
   );


### PR DESCRIPTION


## Motivation

Remove React 18 inert workaround now that we only support React 19+

See https://github.com/facebook/react/issues/17157
See https://github.com/radix-ui/themes/pull/509