### PR TITLE
break(theme-common: move `useSearchQueryString()` + `useSearchLinkCreator()` to theme-search-algolia

### DIFF
--- a/packages/docusaurus-theme-common/src/index.ts
+++ b/packages/docusaurus-theme-common/src/index.ts
@@ -70,11 +70,6 @@ export {
   type TagLetterEntry,
 } from './utils/tagsUtils';
 
-export {
-  useSearchQueryString,
-  useSearchLinkCreator,
-} from './hooks/useSearchPage';
-
 export {useAnchorTargetClassName} from './utils/anchorUtils';
 
 export {isMultiColumnFooterLinks} from './utils/footerUtils';

--- a/packages/docusaurus-theme-search-algolia/src/client/index.ts
+++ b/packages/docusaurus-theme-search-algolia/src/client/index.ts
@@ -12,4 +12,5 @@ export {
 } from './useAlgoliaContextualFacetFilters';
 export {useSearchResultUrlProcessor} from './useSearchResultUrlProcessor';
 export {useAlgoliaAskAi} from './useAlgoliaAskAi';
+export {useSearchQueryString, useSearchLinkCreator} from './searchPage';
 export {mergeFacetFilters} from './utils';

--- a/packages/docusaurus-theme-search-algolia/src/client/searchPage.ts
+++ b/packages/docusaurus-theme-search-algolia/src/client/searchPage.ts
@@ -7,8 +7,8 @@
 
 import {useCallback} from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import {useQueryString} from '../utils/historyUtils';
-import type {ThemeConfig as AlgoliaThemeConfig} from '@docusaurus/theme-search-algolia';
+import {useQueryString} from '@docusaurus/theme-common';
+import {useAlgoliaThemeConfig} from './useAlgoliaThemeConfig';
 
 const SEARCH_PARAM_QUERY = 'q';
 
@@ -24,19 +24,20 @@ export function useSearchQueryString(): [string, (newValue: string) => void] {
  */
 export function useSearchLinkCreator(): (searchValue: string) => string {
   const {
-    siteConfig: {baseUrl, themeConfig},
+    siteConfig: {baseUrl},
   } = useDocusaurusContext();
   const {
     algolia: {searchPagePath},
-  } = themeConfig as AlgoliaThemeConfig;
+  } = useAlgoliaThemeConfig();
 
   return useCallback(
-    (searchValue: string) =>
+    function createSearchLink(searchValue: string) {
       // Refer to https://github.com/facebook/docusaurus/pull/2838
       // Note: if searchPagePath is falsy, useSearchPage() will not be called
-      `${baseUrl}${
+      return `${baseUrl}${
         searchPagePath as string
-      }?${SEARCH_PARAM_QUERY}=${encodeURIComponent(searchValue)}`,
+      }?${SEARCH_PARAM_QUERY}=${encodeURIComponent(searchValue)}`;
+    },
     [baseUrl, searchPagePath],
   );
 }

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
@@ -18,15 +18,13 @@ import {useDocSearchKeyboardEvents} from '@docsearch/react/useDocSearchKeyboardE
 import Head from '@docusaurus/Head';
 import Link from '@docusaurus/Link';
 import {useHistory} from '@docusaurus/router';
-import {
-  isRegexpStringMatch,
-  useSearchLinkCreator,
-} from '@docusaurus/theme-common';
+import {isRegexpStringMatch} from '@docusaurus/theme-common';
 import {
   useAlgoliaContextualFacetFilters,
   useSearchResultUrlProcessor,
   useAlgoliaAskAi,
   mergeFacetFilters,
+  useSearchLinkCreator,
 } from '@docusaurus/theme-search-algolia/client';
 import Translate from '@docusaurus/Translate';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.tsx
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.tsx
@@ -28,13 +28,13 @@ import {
   PageMetadata,
   useEvent,
   usePluralForm,
-  useSearchQueryString,
 } from '@docusaurus/theme-common';
 import Translate, {translate} from '@docusaurus/Translate';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import {
   useAlgoliaThemeConfig,
   useSearchResultUrlProcessor,
+  useSearchQueryString,
 } from '@docusaurus/theme-search-algolia/client';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';


### PR DESCRIPTION


## Motivation

We have a cyclic theme-common <-> theme-search-algolia cyclic dependency surfaced by my migration attempt to pnpm.

We shouldn't do this, and this code should have been in theme-search-algolia from the beginning.

Since it's a `@docusaurus/theme-common` export, but has never been documented, I'm considering it a soft breaking change, although it shouldn't annoy anyone.

The code should now be imported from:

```ts
import {
  useSearchLinkCreator,
  useSearchQueryString,
} from '@docusaurus/theme-search-algolia/client';
```


## Test Plan

CI
