### PR TITLE
feat(content-docs): add `created` frontmatter field support

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/docs.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docs.ts
@@ -120,6 +120,7 @@ async function doProcessDocMetadata({
     // but allow to disable this behavior with front matter
     parse_number_prefixes: parseNumberPrefixes = true,
     last_update: lastUpdateFrontMatter,
+    created,
   } = frontMatter;
 
   const lastUpdate = await readLastUpdateData(
@@ -240,6 +241,7 @@ async function doProcessDocMetadata({
     version: versionMetadata.versionName,
     lastUpdatedBy: lastUpdate.lastUpdatedBy,
     lastUpdatedAt: lastUpdate.lastUpdatedAt,
+    createdAt: created !== undefined ? new Date(created).getTime() : undefined,
     sidebarPosition,
     frontMatter,
   };

--- a/packages/docusaurus-plugin-content-docs/src/frontMatter.ts
+++ b/packages/docusaurus-plugin-content-docs/src/frontMatter.ts
@@ -14,6 +14,7 @@ import {
   validateFrontMatter,
   ContentVisibilitySchema,
   FrontMatterLastUpdateSchema,
+  FrontMatterCreatedSchema,
 } from '@docusaurus/utils-validation';
 import type {DocFrontMatter} from '@docusaurus/plugin-content-docs';
 
@@ -46,6 +47,7 @@ export const DocFrontMatterSchema = Joi.object<DocFrontMatter>({
   pagination_prev: Joi.string().allow(null),
   ...FrontMatterTOCHeadingLevels,
   last_update: FrontMatterLastUpdateSchema,
+  created: FrontMatterCreatedSchema,
 })
   .unknown()
   .concat(ContentVisibilitySchema);

--- a/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
+++ b/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
@@ -409,6 +409,8 @@ declare module '@docusaurus/plugin-content-docs' {
     unlisted?: boolean;
     /** Allows overriding the last updated author and/or date. */
     last_update?: FrontMatterLastUpdate;
+    /** Allows manually specifying the creation date of the document. */
+    created?: Date | string;
   };
 
   export type DocMetadataBase = LastUpdateData & {

--- a/packages/docusaurus-utils-validation/src/index.ts
+++ b/packages/docusaurus-utils-validation/src/index.ts
@@ -29,5 +29,7 @@ export {
   ContentVisibilitySchema,
   FrontMatterLastUpdateErrorMessage,
   FrontMatterLastUpdateSchema,
+  FrontMatterCreatedErrorMessage,
+  FrontMatterCreatedSchema,
 } from './validationSchemas';
 export {getTagsFilePathsToWatch, getTagsFile} from './tagsFile';

--- a/packages/docusaurus-utils-validation/src/validationSchemas.ts
+++ b/packages/docusaurus-utils-validation/src/validationSchemas.ts
@@ -182,3 +182,12 @@ export const FrontMatterLastUpdateSchema = Joi.object({
     'object.missing': FrontMatterLastUpdateErrorMessage,
     'object.base': FrontMatterLastUpdateErrorMessage,
   });
+
+export const FrontMatterCreatedErrorMessage =
+  '{{#label}} does not look like a valid created date. Please use a string or Date.';
+
+export const FrontMatterCreatedSchema = Joi.date()
+  .raw()
+  .messages({
+    'date.base': FrontMatterCreatedErrorMessage,
+  });


### PR DESCRIPTION
## Summary

Closes #5691

This PR implements the  frontmatter field for docs, allowing authors to manually specify a creation date — mirroring the existing  pattern.

## Changes

### `@docusaurus/utils-validation`
- Added `FrontMatterCreatedSchema` — a `Joi.date().raw()` schema that accepts a string or Date value
- Added `FrontMatterCreatedErrorMessage` for user-facing validation errors
- Exported both from the package index

### `@docusaurus/plugin-content-docs`
- Added `created` field to `DocFrontMatterSchema` (validated via `FrontMatterCreatedSchema`)
- Added `created?: Date | string` to the `DocFrontMatter` type in `plugin-content-docs.d.ts`
- Read `created` from frontmatter in `doProcessDocMetadata` and expose it as `createdAt` (Unix timestamp) on the returned `DocMetadataBase` object

## Usage

```md
---
title: My Document
created: 2024-01-15
---
```

or with a full ISO string:

```md
---
created: 2024-01-15T10:30:00Z
---
```

## Notes
- Follows the same pattern as the existing `last_update` frontmatter field
- If `created` is not provided, `createdAt` is `undefined` (no default, consistent with how Docusaurus avoids magic defaults)
- The value is normalized to a Unix timestamp (milliseconds) for consistency with `lastUpdatedAt`

## Test Plan
- [ ] Unit tests for `FrontMatterCreatedSchema` validation (valid dates, invalid strings, missing field)
- [ ] Integration test: doc with `created` frontmatter exposes `createdAt` in metadata
- [ ] Integration test: doc without `created` frontmatter has `createdAt: undefined`