### PR TITLE
docs(deployment): add localized 404 pages guidance for self-hosting

### DIFF
--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -144,22 +144,6 @@ It is not the best option, compared to a static hosting provider / CDN.
 
 :::
 
-### Localized 404 Pages {/* #localized-404-pages */}
-
-When your site has [multiple languages](../i18n/i18n-introduction.mdx), Docusaurus automatically generates a localized `404.html` file for each locale (e.g., `/fr/404.html`). However, most servers will only serve the root `/404.html` by default, regardless of which language the visitor was using.
-
-To serve the correct localized 404 page, you need to configure your server to redirect missing pages to the appropriate locale-specific 404 file. For example:
-
-- If a visitor requests `/fr/nonexistent-page`, the server should serve `/fr/404.html` instead of `/404.html`.
-
-This behavior depends on your hosting provider:
-
-- **Netlify and Cloudflare Pages**: Use a `_redirects` file to define locale-specific redirects.
-- **Apache/Nginx**: Use `ErrorDocument` or `try_files` directives with locale-aware rules.
-- **GitHub Pages**: Does not support server-side redirects, so localized 404 pages cannot be served automatically.
-
-Consult your hosting provider's documentation for the exact configuration.
-
 :::warning
 
 In the following sections, we will introduce a few common hosting providers and how they should be configured to deploy Docusaurus sites most efficiently. Docusaurus is not affiliated with any of these services, and this information is provided for convenience only. Some of the write-ups are provided by third-parties, and recent API changes may not be reflected on our side. If you see outdated content, PRs are welcome.

--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -144,6 +144,22 @@ It is not the best option, compared to a static hosting provider / CDN.
 
 :::
 
+### Localized 404 Pages {/* #localized-404-pages */}
+
+When your site has [multiple languages](../i18n/i18n-introduction.mdx), Docusaurus automatically generates a localized `404.html` file for each locale (e.g., `/fr/404.html`). However, most servers will only serve the root `/404.html` by default, regardless of which language the visitor was using.
+
+To serve the correct localized 404 page, you need to configure your server to redirect missing pages to the appropriate locale-specific 404 file. For example:
+
+- If a visitor requests `/fr/nonexistent-page`, the server should serve `/fr/404.html` instead of `/404.html`.
+
+This behavior depends on your hosting provider:
+
+- **Netlify and Cloudflare Pages**: Use a `_redirects` file to define locale-specific redirects.
+- **Apache/Nginx**: Use `ErrorDocument` or `try_files` directives with locale-aware rules.
+- **GitHub Pages**: Does not support server-side redirects, so localized 404 pages cannot be served automatically.
+
+Consult your hosting provider's documentation for the exact configuration.
+
 :::warning
 
 In the following sections, we will introduce a few common hosting providers and how they should be configured to deploy Docusaurus sites most efficiently. Docusaurus is not affiliated with any of these services, and this information is provided for convenience only. Some of the write-ups are provided by third-parties, and recent API changes may not be reflected on our side. If you see outdated content, PRs are welcome.

--- a/website/docs/i18n/i18n-tutorial.mdx
+++ b/website/docs/i18n/i18n-tutorial.mdx
@@ -565,3 +565,21 @@ It is also possible to deploy each locale as a separate subdomain, assemble the 
 Docusaurus doesn't care about how you manage your translations: all it needs is that all translation files (JSON, Markdown, or other data files) are available in the file system during building. However, as site creators, you would need to consider how translations are managed so your translation contributors could collaborate well.
 
 We will share two common translation collaboration strategies: [**using git**](./i18n-git.mdx) and [**using Crowdin**](./i18n-crowdin.mdx).
+
+## Translate your 404 page {/* #translate-your-404-page */}
+
+When your site has [multiple languages](../i18n/i18n-introduction.mdx), Docusaurus automatically generates a localized `404.html` file for each locale (e.g., `/fr/404.html`). However, most servers will only serve the root `/404.html` by default, regardless of which language the visitor was using.
+
+To serve the correct localized 404 page, you need to configure your server to redirect missing pages to the appropriate locale-specific 404 file. For example:
+
+- `/nonexistent-page` should serve `/404.html`
+- `/fr/nonexistent-page` should serve `/fr/404.html`
+- `/it/nonexistent-page` should serve `/it/404.html`
+
+This behavior depends on your hosting provider:
+
+- **Netlify and Cloudflare Pages**: Use a `_redirects` file to define locale-specific redirects.
+- **Apache/Nginx**: Use `ErrorDocument` or `try_files` directives with locale-aware rules.
+- **GitHub Pages**: Does not support server-side redirects, so localized 404 pages cannot be served automatically.
+
+Consult your hosting provider's documentation for the exact configuration.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

This adds documentation for serving localized 404 pages, as discussed in issue #10473. Users with multi-language sites often don't realize their server needs special configuration to serve locale-specific 404 pages like /fr/404.html.

## Test Plan

Ran the Docusaurus website locally with `pnpm start` and verified the new section appears correctly under "Self-Hosting" at http://localhost:3000/docs/deployment#localized-404-pages

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

Closes #10473
