### PR TITLE
fix(i18n): add callout clarifying write-translations only handles JSO…

### DIFF
--- a/packages/docusaurus/src/commands/writeTranslations.ts
+++ b/packages/docusaurus/src/commands/writeTranslations.ts
@@ -121,4 +121,13 @@ Available locales are: ${context.i18n.locales.join(',')}.`,
       await writePluginTranslationFiles({localizationDir, plugin, options});
     }),
   );
+
+  console.log(
+    `\n${'='.repeat(60)}\n` +
+      `📝 Note: This command only creates JSON translation files for UI strings and plugin data.\n` +
+      `   Markdown files (docs, blog, pages) are NOT copied automatically.\n` +
+      `   To translate Markdown content, copy your files manually to the i18n folder.\n` +
+      `   See: https://docusaurus.io/docs/i18n/tutorial#translate-markdown-files\n` +
+      `${'='.repeat(60)}\n`,
+  );
 }

--- a/website/docs/i18n/i18n-tutorial.mdx
+++ b/website/docs/i18n/i18n-tutorial.mdx
@@ -369,6 +369,12 @@ It will extract and initialize the JSON translation files that you need to trans
 }
 ```
 
+:::note
+
+This command only creates JSON translation files for UI strings and plugin data. It does **not** copy your Markdown files (docs, blog, pages). To translate Markdown content, see the [Translate Markdown files](#translate-markdown-files) section below.
+
+:::
+
 Plugins and themes will also write their own JSON translation files, such as:
 
 ```json title="i18n/fr/docusaurus-theme-classic/navbar.json"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

Users running the `write-translations` command often expect it to copy their Markdown files to the i18n folder, but it only generates JSON translation files for UI strings and plugin data. This causes confusion, especially for new users setting up multi-language sites.

This PR addresses #8703 by:
1. Adding a console message after `write-translations` runs, clearly stating the 
   command only handles JSON files and linking to Markdown translation docs
2. Adding a `:::note` callout in the i18n tutorial at the exact point of confusion, 
   signposting users to the "Translate Markdown files" section

Closes #8703

## Test Plan

Code change:
- Ran `pnpm start` to build the project
- The console message appears after the write-translations command completes
- Message includes a working link to the i18n tutorial

Docs change:
- Verified the new `:::note` callout renders correctly on the local dev server
- The internal link `#translate-markdown-files` correctly scrolls to the right section
- Tested at http://localhost:3000/docs/i18n/tutorial

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

Closes #8703
