### PR TITLE
fix(examples): sync example Node.js versions with templates and generation workflow

### DIFF
--- a/examples/classic-typescript/package.json
+++ b/examples/classic-typescript/package.json
@@ -45,7 +45,7 @@
     ]
   },
   "engines": {
-    "node": ">=20.0"
+    "node": ">=24.14"
   },
   "description": "Docusaurus example project (classic-typescript template)"
 }

--- a/examples/classic-typescript/sandbox.config.json
+++ b/examples/classic-typescript/sandbox.config.json
@@ -3,8 +3,8 @@
   "hardReloadOnChange": true,
   "view": "browser",
   "template": "docusaurus",
-  "node": "18",
+  "node": "24",
   "container": {
-    "node": "18"
+    "node": "24"
   }
 }

--- a/examples/classic/package.json
+++ b/examples/classic/package.json
@@ -41,7 +41,7 @@
     ]
   },
   "engines": {
-    "node": ">=20.0"
+    "node": ">=24.14"
   },
   "description": "Docusaurus example project"
 }

--- a/examples/classic/sandbox.config.json
+++ b/examples/classic/sandbox.config.json
@@ -3,8 +3,8 @@
   "hardReloadOnChange": true,
   "view": "browser",
   "template": "docusaurus",
-  "node": "18",
+  "node": "24",
   "container": {
-    "node": "18"
+    "node": "24"
   }
 }


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Summary

The generated example artifacts at `examples/` contain values that are out of sync with the current template definitions and generation workflow:

- **Engine field** in `package.json` files still requires `">=20.0"`, while the local templates at `packages/create-docusaurus/templates/` specify `">=24.14"`.
- **Sandbox node version** in `sandbox.config.json` files still specifies `"18"`, while the generation script at `admin/scripts/generateExamples.js` emits `"24"`.

The examples are generated from the published `create-docusaurus` package. At the time of the last regeneration, the published package produced values that differ from the current local templates and generation workflow.

This PR updates the checked-in example artifacts so they are consistent with the current template definitions and the values emitted by `admin/scripts/generateExamples.js`.

No regeneration was performed as part of this change; only the stale values in the generated artifacts were updated.


## Changes

- `examples/classic/package.json` — engine `">=20.0"` → `">=24.14"`
- `examples/classic-typescript/package.json` — engine `">=20.0"` → `">=24.14"`
- `examples/classic/sandbox.config.json` — node version `"18"` → `"24"` (two occurrences)
- `examples/classic-typescript/sandbox.config.json` — node version `"18"` → `"24"` (two occurrences)

## Verification

- 4 files changed
- 6 insertions, 6 deletions
- All values now match template definitions and generation workflow

## Issue

Closes #12120
