### PR TITLE
docs(deployment): link to DeployHQ self-hosting writeup

### DIFF
--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -905,6 +905,10 @@ You can deploy any other changes in the future with the command `surge`.
 
 You can deploy your Docusaurus project to [Stormkit](https://www.stormkit.io), a deployment platform for static websites, single-page applications (SPAs), and serverless functions. For detailed instructions, refer to this [guide](https://www.stormkit.io/blog/how-to-deploy-docusarous).
 
+## Deploying to DeployHQ {/* #deploying-to-deployhq */}
+
+You can deploy your Docusaurus site to your own server with [DeployHQ](https://www.deployhq.com), a Git-based deployment platform with managed build pipelines, atomic releases, and one-click rollback. For detailed instructions, refer to the [DeployHQ guide to deploying Docusaurus](https://www.deployhq.com/guides/deploy-docusaurus).
+
 ## Deploying to QuantCDN {/* #deploying-to-quantcdn */}
 
 1. Install [Quant CLI](https://docs.quantcdn.io/docs/cli/get-started)


### PR DESCRIPTION
Adds a one-line link to an externally-maintained DeployHQ guide for self-hosting a Docusaurus site, matching the pattern the deployment page already uses for Stormkit, Render, and Koyeb.

The guide at https://www.deployhq.com/guides/deploy-docusaurus covers the BYO-server path: Git-based deployment from GitHub/GitLab/Bitbucket, a managed build environment that runs `npm run build`, and transfer of the `build/` output to a Linux VPS, shared host, S3, Azure Blob, or Rackspace Cloud Files — including `baseUrl` and `trailingSlash` handling for sub-path deployments. This complements the existing managed-host entries on this page rather than competing with them; it's specifically for users who've already opted out of Netlify / Vercel / Cloudflare Pages.

Per the existing `:::warning` at the top of "Hosting Providers" ("we have stopped accepting PRs adding new hosting options. You can, however, publish your writeup on a separate site … and ask us to include a link to your writeup"), this PR is the link-to-external-writeup variant, not a full sub-section.

### Scope

- One file changed: `website/docs/deployment.mdx`
- One new H2 section with one anchor and two short sentences
- Slotted between `## Deploying to Stormkit` and `## Deploying to QuantCDN` (clusters with the smaller commercial deploy platforms)
- No images, no badges, no UTM parameters

### Disclosure

This PR was drafted with AI assistance and reviewed by the contributor before opening, per `CONTRIBUTING.md`.

### CLA

The Meta CLA will be required before merge — I'll sign it when the bot links it.
