### PR TITLE
fix(theme): constrain navbar width to match content area on large displays

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/Layout/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/Layout/styles.module.css
@@ -5,6 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+.navbar {
+  justify-content: center;
+}
+
+.navbar__inner {
+  max-width: var(--ifm-container-width-xl);
+}
+
 .navbarHideable {
   transition: transform var(--ifm-transition-fast) ease;
 }


### PR DESCRIPTION
## Summary

On wide viewports, the navbar expanded to full screen width while the main content area was constrained to `--ifm-container-width-xl`. This caused navbar items to appear at the far edges of the screen, requiring users to scan the entire width.

## Changes

- Add `justify-content: center` to `.navbar`
- Add `max-width: var(--ifm-container-width-xl)` to `.navbar__inner`

This aligns the navbar with the content area, footer, and other page elements, creating a consistent vertical scanning area.

## Before

Navbar items spread to the far edges of the screen on large displays.

## After

Navbar is centered and constrained to the same max-width as the content area.

Closes #7562