### PR TITLE
fix(theme): replace system-ui font with proper documentation font stack

### DIFF
--- a/packages/docusaurus-theme-classic/src/nprogress.css
+++ b/packages/docusaurus-theme-classic/src/nprogress.css
@@ -13,6 +13,14 @@
 
 :root {
   --docusaurus-progress-bar-color: var(--ifm-color-primary);
+  /*
+  Override Infima's system-ui font stack to use a proper documentation font.
+  system-ui causes CJK character rendering issues on non-CJK OS locales.
+  See https://github.com/facebook/docusaurus/issues/11727
+  */
+  --ifm-font-family-base: 'Inter', 'Segoe UI', 'Roboto', 'Ubuntu',
+    'Cantarell', 'Noto Sans', sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 }
 
 #nprogress {


### PR DESCRIPTION
## Summary

The `system-ui` CSS font value causes CJK (Chinese, Japanese, Korean) character rendering issues when the OS locale doesn't match the content language. For example, Chinese text renders with Japanese font shapes on Japanese Windows, and vice versa.

This is a well-known issue with `system-ui` — it was designed for native desktop app UIs, not for multilingual documentation sites.

## Changes

Override `--ifm-font-family-base` in `:root` after Infima's CSS loads, replacing `system-ui` with a cross-platform font stack:

- **Inter** as the primary font (modern, designed for screens)
- System font fallbacks: **Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans**
- Generic `sans-serif` as final fallback
- Emoji fonts included for consistent emoji rendering

## Why this approach

The Infima CSS framework defines `--ifm-font-family-base` with `system-ui` included. Since Infima is an external dependency (alpha), we override the CSS variable in our own `:root` block, which loads right after Infima via `getClientModules()`.

See: https://infinnie.github.io/blog/2017/systemui.html
See: https://heistak.github.io/your-code-displays-japanese-wrong/

Closes #11727