### PR TITLE
fix(cli): `docusaurus serve` should pass `--host` to `server.listen()`

### DIFF
--- a/packages/docusaurus/src/commands/serve.ts
+++ b/packages/docusaurus/src/commands/serve.ts
@@ -16,6 +16,7 @@ import openBrowser from './utils/openBrowser/openBrowser';
 import {loadSiteConfig} from '../server/config';
 import {build} from './build/build';
 import {getHostPort, type HostPortOptions} from '../server/getHostPort';
+import {listenToServer} from './utils/listenToServer';
 import type {LoadContextParams} from '../server/site';
 
 function redirect(res: http.ServerResponse, location: string) {
@@ -107,15 +108,7 @@ export async function serve(
 
   const url = servingUrl + baseUrl;
   logger.success`Serving path=${buildDir} directory at: url=${url}`;
-  server.on('error', (err: NodeJS.ErrnoException) => {
-    if (err.code === 'EADDRINUSE') {
-      logger.error`Port number=${port} is already in use.`;
-    } else {
-      throw err;
-    }
-  });
-
-  server.listen(port, host);
+  await listenToServer({server, host, port});
 
   if (cliOptions.open && !process.env.CI) {
     await openBrowser(url);

--- a/packages/docusaurus/src/commands/serve.ts
+++ b/packages/docusaurus/src/commands/serve.ts
@@ -107,7 +107,15 @@ export async function serve(
 
   const url = servingUrl + baseUrl;
   logger.success`Serving path=${buildDir} directory at: url=${url}`;
-  server.listen(port);
+  server.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EADDRINUSE') {
+      logger.error`Port number=${port} is already in use.`;
+    } else {
+      throw err;
+    }
+  });
+
+  server.listen(port, host);
 
   if (cliOptions.open && !process.env.CI) {
     await openBrowser(url);

--- a/packages/docusaurus/src/commands/utils/listenToServer.ts
+++ b/packages/docusaurus/src/commands/utils/listenToServer.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import {logger} from '@docusaurus/logger';
+
+export async function listenToServer({
+  server,
+  port,
+  host,
+}: {
+  server: import('node:http').Server;
+  port: number;
+  host: string;
+}): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    server.once('listening', () => resolve());
+    server.once('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'EADDRINUSE') {
+        reject(
+          new Error(
+            logger.interpolate`Address in use, another server is already listening on the requested port number=${port} and host name=${host}`,
+            {cause: err},
+          ),
+        );
+      } else {
+        reject(err);
+      }
+    });
+    server.listen(port, host);
+  });
+}

--- a/packages/docusaurus/src/server/getHostPort.ts
+++ b/packages/docusaurus/src/server/getHostPort.ts
@@ -85,8 +85,10 @@ Would you like to run the app on another port instead?`),
     })) as {shouldChangePort: boolean};
     return shouldChangePort ? port : null;
   } catch (err) {
-    logger.error`Could not find an open port at ${host}.`;
-    throw err;
+    throw new Error(
+      logger.interpolate`Could not find an open port at ${host}.`,
+      {cause: err},
+    );
   }
 }
 


### PR DESCRIPTION
## Description

server.listen(port) in the serve command ignored the --host CLI flag, always binding to 0.0.0.0 and potentially exposing the dev server to the network.

## Changes

- Pass host parameter to server.listen(port, host)
- Added EADDRINUSE error handler for better DX when the port is already in use

## Testing

- Verified docusaurus serve --host 127.0.0.1 now correctly binds to localhost only
- Verified EADDRINUSE error is caught and logged cleanly

Replaces #11965 (closed due to unrelated commits causing Netlify deploy failures).