### PR TITLE
docs: document that plugin-ideal-image changes imported image types

### DIFF
--- a/website/docs/api/plugins/plugin-ideal-image.mdx
+++ b/website/docs/api/plugins/plugin-ideal-image.mdx
@@ -36,6 +36,25 @@ import thumbnail from './path/to/img.png';
 <Image img={require('./path/to/img.png')} />
 ```
 
+:::note
+
+When `plugin-ideal-image` is installed, importing a supported image file no longer returns a plain URL string. Instead, it returns an object with the shape: `{ preSrc: string, src: { src: string, width: number, height: number } }`.
+
+If you need to use the image in a standard `<img>` tag, access it like this:
+
+```jsx
+<img
+  src={image.src.src}
+  width={image.src.width}
+  height={image.src.height}
+  alt="description"
+/>
+```
+
+To avoid dealing with this object shape directly, it is recommended to use the `<Image>` component provided by this plugin instead.
+
+:::
+
 :::warning
 
 This plugin registers a [Webpack loader](https://webpack.js.org/loaders/) that changes the type of imported/require images:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

This change addresses issue #8684, which reported that `plugin-ideal-image` changes the type of imported images but this behavior was not clearly documented. This PR adds a warning block in the Usage section to make this behavior explicit for users.

## Test Plan

This is a documentation-only change. I verified the changes locally by running `pnpm start` and navigating to the plugin ideal-image docs page to confirm the warning renders correctly.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

Closes #8684
