### PR TITLE
fix(create-docusaurus): init template README should use npm commands by default

### DIFF
--- a/packages/create-docusaurus/templates/shared/README.md
+++ b/packages/create-docusaurus/templates/shared/README.md
@@ -5,13 +5,15 @@ This website is built using [Docusaurus](https://docusaurus.io/), a modern stati
 ## Installation
 
 ```bash
-yarn
+npm install
 ```
+
+**Note**: feel free to use the package manager of your choice.
 
 ## Local Development
 
 ```bash
-yarn start
+npm run start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
@@ -19,7 +21,7 @@ This command starts a local development server and opens up a browser window. Mo
 ## Build
 
 ```bash
-yarn build
+npm run build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
@@ -29,13 +31,13 @@ This command generates static content into the `build` directory and can be serv
 Using SSH:
 
 ```bash
-USE_SSH=true yarn deploy
+USE_SSH=true npm run deploy
 ```
 
 Not using SSH:
 
 ```bash
-GIT_USER=<Your GitHub username> yarn deploy
+GIT_USER=<Your GitHub username> npm run deploy
 ```
 
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+If you are using GitHub Pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.


### PR DESCRIPTION

## Motivation

Fix https://github.com/facebook/docusaurus/issues/12111, I don't think biasing toward Yarn is the best option as of today.

npm remains the default Node package manager, and is improving on security, too.

The alternative is likely to create/copy/generate one distinct README per package manager based on what was used at site init time (using the CLI `--package-manager` arg), but it's unfortunately not easy because the init template `docs` folder also contains npm commands and we'd likely want everything to be consistent...

<img width="3206" height="926" alt="CleanShot 2026-06-12 at 11 11 02@2x" src="https://github.com/user-attachments/assets/501a9ff3-a46f-4de4-b8fa-8f017b1024e9" />


## Test Plan

N/A
