### PR TITLE
refactor: lint/test ignore agent folders

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -20,6 +20,8 @@
     }
   ],
   "ignorePaths": [
+    ".claude",
+    ".codex",
     "**/dist/**",
     "**/lib/**",
     "**/build/**",

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -4,6 +4,8 @@
   "bracketSameLine": true,
   "bracketSpacing": false,
   "ignorePatterns": [
+    ".claude",
+    ".codex",
     "dist",
     "node_modules",
     ".yarn",

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -3,6 +3,8 @@
 !*/
 !*.css
 __tests__/
+.claude
+.codex
 build
 .docusaurus
 coverage

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -52,6 +52,8 @@ const plugins = defineConfig([
 ]);
 
 const ignores = globalIgnores([
+  '.claude',
+  '.codex',
   '**/dist/**',
   '**/lib/**',
   '**/build/**',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,8 @@ process.env.TZ = 'UTC';
 const rootDir = fileURLToPath(new URL('.', import.meta.url));
 
 const ignorePatterns = [
+  '.claude',
+  '.codex',
   '**/node_modules/**',
   '**/__fixtures__/**',
   '**/__mocks__/**',


### PR DESCRIPTION


## Motivation

Agents generally use `.codex` and `.claude` subfolders, possibly adding files and worktrees there


When browsing the "main worktree" we don't want to lint / format / test the workspace files, but only files of the current worktree

## Test Plan

CI
