### PR TITLE
fix(utils): normalize MSYS git paths on Windows

### DIFF
--- a/packages/docusaurus-utils/src/vcs/__tests__/gitUtils.test.ts
+++ b/packages/docusaurus-utils/src/vcs/__tests__/gitUtils.test.ts
@@ -21,6 +21,7 @@ import {
   getGitSubmodulePaths,
   getGitAllRepoRoots,
   getGitRepositoryFilesInfo,
+  normalizeGitPath,
 } from '../gitUtils';
 import {createVcsGitEagerConfig} from '../vcsGitEager';
 
@@ -396,6 +397,33 @@ describe('commit info APIs', () => {
         }
       `);
     });
+  });
+});
+
+describe('normalizeGitPath', () => {
+  it('converts MSYS drive paths to Windows paths on Windows', () => {
+    const oldProcessPlatform = process.platform;
+
+    Object.defineProperty(process, 'platform', {value: 'win32'});
+
+    expect(normalizeGitPath('/p/projets/my-repo')).toBe('P:\\projets\\my-repo');
+    expect(normalizeGitPath('/c')).toBe('C:\\');
+    expect(normalizeGitPath('P:\\projets\\my-repo')).toBe(
+      'P:\\projets\\my-repo',
+    );
+    expect(normalizeGitPath('P:/projets/my-repo')).toBe('P:/projets/my-repo');
+
+    Object.defineProperty(process, 'platform', {value: oldProcessPlatform});
+  });
+
+  it('leaves MSYS-like paths unchanged on non-Windows platforms', () => {
+    const oldProcessPlatform = process.platform;
+
+    Object.defineProperty(process, 'platform', {value: 'linux'});
+
+    expect(normalizeGitPath('/p/projets/my-repo')).toBe('/p/projets/my-repo');
+
+    Object.defineProperty(process, 'platform', {value: oldProcessPlatform});
   });
 });
 

--- a/packages/docusaurus-utils/src/vcs/gitUtils.ts
+++ b/packages/docusaurus-utils/src/vcs/gitUtils.ts
@@ -32,6 +32,22 @@ const GitCommandQueue = new PQueue({
   concurrency: GitCommandConcurrency,
 });
 
+export function normalizeGitPath(gitPath: string): string {
+  if (process.platform !== 'win32') {
+    return gitPath;
+  }
+
+  const msysPathMatch = gitPath.match(/^\/(?<drive>[a-z])(?:\/(?<rest>.*))?$/i);
+  const drive = msysPathMatch?.groups?.drive;
+  if (!drive) {
+    return gitPath;
+  }
+
+  const rest = msysPathMatch?.groups?.rest ?? '';
+  const windowsRest = rest.replace(/\//g, '\\');
+  return `${drive.toUpperCase()}:\\${windowsRest}`;
+}
+
 const realHasGitFn = () => {
   try {
     return execa.sync('git', ['--version']).exitCode === 0;
@@ -303,7 +319,7 @@ The command returned exit code ${logger.code(result.exitCode)}: ${logger.subdue(
     );
   }
 
-  return fs.realpath.native(result.stdout.trim());
+  return fs.realpath.native(normalizeGitPath(result.stdout.trim()));
 }
 
 // A Git "superproject" is a Git repository that contains submodules
@@ -347,7 +363,7 @@ The command returned exit code ${logger.code(result.exitCode)}: ${logger.subdue(
   // this command only works when inside submodules
   // otherwise it doesn't return anything when we are inside the main repo
   if (output) {
-    return fs.realpath.native(output);
+    return fs.realpath.native(normalizeGitPath(output));
   }
   return getGitRepoRoot(cwd);
 }


### PR DESCRIPTION
## Summary
- normalize MSYS-style Git drive paths such as `/p/projets/my-repo` before passing them to `fs.realpath.native` on Windows
- apply the normalization to both repository root and superproject root discovery
- add regression coverage for Windows and non-Windows path handling

Fixes #11920

## Test plan
- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm exec oxfmt packages/docusaurus-utils/src/vcs/gitUtils.ts packages/docusaurus-utils/src/vcs/__tests__/gitUtils.test.ts`
- `corepack pnpm --filter @docusaurus/logger --filter @docusaurus/utils-common --filter @docusaurus/utils build`
- `corepack pnpm vitest run packages/docusaurus-utils/src/vcs/__tests__/gitUtils.test.ts`
- `corepack pnpm --filter @docusaurus/eslint-plugin build`
- `corepack pnpm exec eslint packages/docusaurus-utils/src/vcs/gitUtils.ts packages/docusaurus-utils/src/vcs/__tests__/gitUtils.test.ts`
- `git diff --check`

Note: local Node is `v24.11.1`, while the repo currently requests `>=24.14`; pnpm reported that as an engine warning during the commands above.