### PR TITLE
fix(theme-classic): support nested elements inside inline code

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Code.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Code.tsx
@@ -11,14 +11,24 @@ import CodeBlock from '@theme/CodeBlock';
 import CodeInline from '@theme/CodeInline';
 import type {Props} from '@theme/MDXComponents/Code';
 
+function containsNewline(node: ReactNode): boolean {
+  if (typeof node === 'string') {
+    return node.includes('\n');
+  }
+  if (React.isValidElement(node)) {
+    return React.Children.toArray(
+      (node as React.ReactElement<{children?: ReactNode}>).props.children,
+    ).some(containsNewline);
+  }
+  return false;
+}
+
 function shouldBeInline(props: Props) {
   return (
     // empty code blocks have no props.children,
     // see https://github.com/facebook/docusaurus/pull/9704
     typeof props.children !== 'undefined' &&
-    React.Children.toArray(props.children).every(
-      (el) => typeof el === 'string' && !el.includes('\n'),
-    )
+    React.Children.toArray(props.children).every((el) => !containsNewline(el))
   );
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

When using CommonMark format, wrapping inline content that contains nested HTML elements (like `<var>`) inside a `<code>` tag incorrectly renders as a block code element instead of inline code.

For example, `<code>inline <var>var</var></code>` was being rendered as a `<pre>` block instead of staying inline.

This fixes #10533.

## Test Plan

The `shouldBeInline` function in `MDXComponents/Code.tsx` previously only treated plain strings as inline-safe. This PR introduces a `containsNewline` helper that recursively checks nested React elements for newlines, so elements like `<var>` inside `<code>` are correctly treated as inline as long as they contain no newlines.

To verify: add `This is <code>inline <var>var</var></code>` to any Markdown file with CommonMark enabled and confirm it renders inline instead of as a code block.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

Closes #10533
