### PR TITLE
fix(theme): use native dialog element for mobile sidebar

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/MobileSidebar/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/MobileSidebar/Layout/index.tsx
@@ -5,9 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {type ReactNode} from 'react';
+import React, {useEffect, useRef, type ReactNode} from 'react';
 import clsx from 'clsx';
-import {useNavbarSecondaryMenu} from '@docusaurus/theme-common/internal';
+import {
+  useNavbarMobileSidebar,
+  useNavbarSecondaryMenu,
+} from '@docusaurus/theme-common/internal';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import type {Props} from '@theme/Navbar/MobileSidebar/Layout';
 
@@ -35,13 +38,50 @@ export default function NavbarMobileSidebarLayout({
   primaryMenu,
   secondaryMenu,
 }: Props): ReactNode {
+  const {shown, toggle} = useNavbarMobileSidebar();
   const {shown: secondaryMenuShown} = useNavbarSecondaryMenu();
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) {
+      return;
+    }
+    if (shown && !dialog.open) {
+      dialog.showModal();
+    } else if (!shown && dialog.open) {
+      dialog.close();
+    }
+  }, [shown]);
+
+  function handleBackdropClick(e: React.MouseEvent<HTMLDialogElement>) {
+    const dialog = dialogRef.current;
+    if (!dialog) {
+      return;
+    }
+    const rect = dialog.getBoundingClientRect();
+    const inside =
+      rect.top <= e.clientY &&
+      e.clientY <= rect.top + rect.height &&
+      rect.left <= e.clientX &&
+      e.clientX <= rect.left + rect.width;
+    if (!inside) {
+      toggle();
+    }
+  }
+
   return (
-    <div
+    <dialog
+      ref={dialogRef}
       className={clsx(
         ThemeClassNames.layout.navbar.mobileSidebar.container,
         'navbar-sidebar',
-      )}>
+      )}
+      onClick={handleBackdropClick}
+      onCancel={(e) => {
+        e.preventDefault();
+        toggle();
+      }}>
       {header}
       <div
         className={clsx('navbar-sidebar__items', {
@@ -54,6 +94,6 @@ export default function NavbarMobileSidebarLayout({
           {secondaryMenu}
         </NavbarMobileSidebarPanel>
       </div>
-    </div>
+    </dialog>
   );
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

The mobile sidebar looks like a modal dialog visually, but it was not behaving like one for assistive technologies. Screen reader users could tab outside the dialog while it was open, focus was not trapped inside, and the dialog role was not exposed to the accessibility tree.

This replaces the outer `<div>` with a native HTML `<dialog>` element using `showModal()`, which gives us focus trapping, correct dialog role in the accessibility tree, Escape key handling, and return focus to the trigger element — all for free from the browser.

Closes #9457.

## Test Plan

On a mobile viewport or by zooming in on desktop:
1. Open the mobile sidebar by clicking the hamburger menu
2. Verify the sidebar is announced as a dialog by a screen reader
3. Verify that Tab key cannot move focus outside the sidebar while it is open
4. Verify that pressing Escape closes the sidebar
5. Verify that clicking the backdrop closes the sidebar
6. Verify that focus returns to the hamburger button after closing
7. Verify the drawer animation still works as before

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

Closes #9457
Related to #10706 (previous attempt at this fix)
