### PR TITLE
fix(theme): add aria-hidden and aria-label to sidebar logo for access…

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/index.tsx
@@ -8,6 +8,8 @@
 import React from 'react';
 import clsx from 'clsx';
 import {useThemeConfig} from '@docusaurus/theme-common';
+import {useHideableNavbar} from '@docusaurus/theme-common/internal';
+import {translate} from '@docusaurus/Translate';
 import Logo from '@theme/Logo';
 import CollapseButton from '@theme/DocSidebar/Desktop/CollapseButton';
 import Content from '@theme/DocSidebar/Desktop/Content';
@@ -23,6 +25,8 @@ function DocSidebarDesktop({path, sidebar, onCollapse, isHidden}: Props) {
     },
   } = useThemeConfig();
 
+  const {isNavbarVisible} = useHideableNavbar(hideOnScroll);
+
   return (
     <div
       className={clsx(
@@ -30,7 +34,23 @@ function DocSidebarDesktop({path, sidebar, onCollapse, isHidden}: Props) {
         hideOnScroll && styles.sidebarWithHideableNavbar,
         isHidden && styles.sidebarHidden,
       )}>
-      {hideOnScroll && <Logo tabIndex={-1} className={styles.sidebarLogo} />}
+      {hideOnScroll && (
+        <Logo
+          tabIndex={-1}
+          className={styles.sidebarLogo}
+          aria-hidden={isNavbarVisible}
+          aria-label={
+            !isNavbarVisible
+              ? translate({
+                  id: 'theme.docs.sidebar.logo.ariaLabel',
+                  message: 'Home page',
+                  description:
+                    'The ARIA label for the sidebar logo link when the navbar is hidden',
+                })
+              : undefined
+          }
+        />
+      )}
       <Content path={path} sidebar={sidebar} />
       {hideable && <CollapseButton onClick={onCollapse} />}
     </div>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

The sidebar logo (shown when `hideOnScroll` is enabled) was not accessible to screen readers. When the navbar is visible, the logo is visually hidden behind it but had no `aria-hidden` attribute, causing screen readers like NVDA to unnecessarily announce it. When the navbar scrolls away and the logo becomes visible and interactive, it had no accessible label at all.

This fix adds `aria-hidden={isNavbarVisible}` so the logo is hidden from screen readers when it is not visible, and adds a localized `aria-label` via the `translate()` function when the logo is visible and acting as a real homepage link.

Closes #8429

## Test Plan

1. Enable `hideOnScroll: true` in your Docusaurus site's `themeConfig.navbar` config.
2. Open a docs page that has a sidebar.
3. With the page at the top (navbar visible): inspect the sidebar logo element and confirm it has `aria-hidden="true"` and no `aria-label`.
4. Scroll down until the navbar disappears: inspect the sidebar logo again and confirm `aria-hidden` is gone and `aria-label="Home page"` is present.
5. Test with a screen reader (e.g. NVDA on Windows) to confirm the logo is not announced when hidden, and is announced correctly as "Home page" when visible.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

Closes #8429