### PR TITLE
perf(utils): implement LRU cache for gray-matter to fix SSG memory leaks

### DIFF
--- a/packages/docusaurus-utils/src/markdownUtils.ts
+++ b/packages/docusaurus-utils/src/markdownUtils.ts
@@ -164,6 +164,13 @@ export function createExcerpt(fileString: string): string | undefined {
   return undefined;
 }
 
+const frontMatterCache = new Map<
+  string,
+  {data: {[key: string]: unknown}; content: string}
+>();
+
+const MAX_CACHE_SIZE = 1000;
+
 /**
  * Takes a raw Markdown file content, and parses the front matter using
  * gray-matter. Worth noting that gray-matter accepts TOML and other markup
@@ -182,20 +189,39 @@ export function parseFileContentFrontMatter(fileContent: string): {
   /** The remaining content, trimmed. */
   content: string;
 } {
-  // TODO Docusaurus v4: replace gray-matter by a better lib
-  // gray-matter is unmaintained, not flexible, and the code doesn't look good
-  const {data, content} = matter(fileContent);
+  let parsed = frontMatterCache.get(fileContent);
+
+  if (!parsed) {
+    // TODO Docusaurus v4: replace gray-matter by a better lib
+    // gray-matter is unmaintained, not flexible, and the code doesn't look good
+    // Passing {} as options disables gray-matter's internal leaking cache
+    const result = matter(fileContent, {});
+
+    parsed = {
+      data: result.data,
+      content: result.content,
+    };
+
+    if (frontMatterCache.size >= MAX_CACHE_SIZE) {
+      const oldestKey = frontMatterCache.keys().next().value;
+      if (oldestKey !== undefined) {
+        frontMatterCache.delete(oldestKey);
+      }
+    }
+
+    frontMatterCache.set(fileContent, parsed);
+  }
 
   // gray-matter has an undocumented front matter caching behavior
   // https://github.com/jonschlinkert/gray-matter/blob/ce67a86dba419381db0dd01cc84e2d30a1d1e6a5/index.js#L39
   // Unfortunately, this becomes a problem when we mutate returned front matter
   // We want to make it possible as part of the parseFrontMatter API
   // So we make it safe to mutate by always providing a deep copy
-  const frontMatter = structuredClone(data);
+  const frontMatter = structuredClone(parsed.data);
 
   return {
     frontMatter,
-    content: content.trim(),
+    content: parsed.content.trim(),
   };
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

### Motivation and Context
Fixes #10944 

During SSG builds with multiple locales (i18n), the internal caching mechanism of `gray-matter` leaks memory by retaining references to parsed files in a plain object, causing OOM (Out of Memory) issues on large sites.

### Description
As discussed and suggested by @slorber in the original issue, this PR introduces a custom memory-safe cache for front matter parsing. 
    
1. **Bypassed `gray-matter` leak:** Passed `{}` as options to `matter()` to completely disable its internal caching behavior.
2. **Implemented LRU-style Map Cache:** Replaced the legacy behavior with a controlled `Map` cache (`frontMatterCache`) bounded by a `MAX_CACHE_SIZE` of 1000. Once the limit is reached, it deletes the oldest entry, ensuring safe Garbage Collection.
3. **Safe references:** We maintain the `structuredClone` behavior at the return statement to ensure that plugins mutating the front matter do not corrupt the internal cache.

This architectural change ensures that memory is properly released between locale loops while maintaining the performance benefits of caching repeated front matter inputs.

### How Has This Been Tested?
- Passed existing `markdownUtils.test.ts` and `frontMatter.test.ts` test suites.
- Verified that returning a deep clone prevents cache mutation regressions.