### PR TITLE
fix(mdx-loader): report vfile messages from Remark plugins

### DIFF
--- a/packages/docusaurus-mdx-loader/src/processor.ts
+++ b/packages/docusaurus-mdx-loader/src/processor.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import logger from '@docusaurus/logger';
 import headings from './remark/headings';
 import contentTitle from './remark/contentTitle';
 import toc from './remark/toc';
@@ -26,6 +27,7 @@ import type {PluginOptions as ResolveMarkdownLinksOptions} from './remark/resolv
 import type {PluginOptions as TransformLinksOptions} from './remark/transformLinks';
 import type {PluginOptions as TransformImageOptions} from './remark/transformImage';
 import type {ProcessorOptions} from '@mdx-js/mdx';
+import type {VFileMessage} from 'vfile-message';
 
 // TODO as of April 2023, no way to import/re-export this ESM type easily :/
 // This might change soon, likely after TS 5.2
@@ -210,10 +212,20 @@ async function createProcessorFactory() {
             compilerName,
           },
         });
-        return mdxProcessor.process(vfile).then((result) => ({
-          content: result.toString(),
-          data: result.data,
-        }));
+        return mdxProcessor.process(vfile).then((result) => {
+          // Report warnings/errors that Remark plugins attached to the vfile
+          result.messages.forEach((message: VFileMessage) => {
+            if (message.fatal) {
+              logger.error(String(message));
+            } else {
+              logger.warn(String(message));
+            }
+          });
+          return {
+            content: result.toString(),
+            data: result.data,
+          };
+        });
       },
     };
   }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #9953) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

This fixes #9953.

When Remark plugins attach warning or error messages to a vfile using `vfile.message()`, Docusaurus silently ignores them after processing. This means plugin authors have no way to surface warnings or errors to users during the build.

This change reads `result.messages` after processing each mdx file and reports them using `@docusaurus/logger`, which is already a dependency of the mdx-loader package.

## Test Plan

Added a test Remark plugin to `website/docusaurus.config.ts` that calls `vfile.message('This is a test warning from a Remark plugin')` on every file. Running `pnpm start` confirmed that `[WARNING]` messages now appear in the terminal for every processed mdx file, including the file path and line/column number.

Before this fix, no messages appeared at all.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

Closes #9953