### PR TITLE
docs: improve useIsBrowser section, clarify hydration vs DOM availabi…

### DIFF
--- a/website/docs/docusaurus-core.mdx
+++ b/website/docs/docusaurus-core.mdx
@@ -409,13 +409,28 @@ The `siteConfig` object only contains **serializable values** (values that are p
 
 ### `useIsBrowser` {/* #useIsBrowser */}
 
-Returns `true` when the React app has successfully hydrated in the browser.
+Returns `true` after initial hydration completes in the browser.
 
 :::warning
 
-Use this hook instead of `typeof windows !== 'undefined'` in React rendering logic.
+Use this hook instead of `typeof window !== 'undefined'` in React rendering logic.
 
-The first client-side render output (in the browser) **must be exactly the same** as the server-side render output (Node.js). Not following this rule can lead to unexpected hydration behaviors, as described in [The Perils of Rehydration](https://www.joshwcomeau.com/react/the-perils-of-rehydration/).
+The initial render output must be consistent between server and client — components should not depend on browser-only state during the initial render. See [The Perils of Rehydration](https://www.joshwcomeau.com/react/the-perils-of-rehydration/).
+
+:::
+
+:::caution
+
+`useIsBrowser()` and `ExecutionEnvironment.canUseDOM` serve different purposes:
+
+- **`useIsBrowser()`** — tracks hydration state. Use it to gate UI behavior that should only activate after initial hydration.
+- **`ExecutionEnvironment.canUseDOM`** — detects the runtime environment. Use it when you need to check DOM availability outside of React rendering logic.
+
+| Context | `useIsBrowser()` | `ExecutionEnvironment.canUseDOM` |
+| --- | --- | --- |
+| Node.js / SSR | `false` | `false` |
+| During initial client render | `false` | `true` (DOM is available) |
+| After initial hydration | `true` | `true` |
 
 :::
 
@@ -426,12 +441,28 @@ import React from 'react';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 
 const MyComponent = () => {
-  // highlight-start
   const isBrowser = useIsBrowser();
-  // highlight-end
-  return <div>{isBrowser ? 'Client' : 'Server'}</div>;
+  return <div>{isBrowser ? 'Browser' : 'Server'}</div>;
 };
 ```
+
+:::note
+
+Avoid using `useIsBrowser()` to access `window` or DOM APIs. It returns `false` during the initial client render, which can cause code to silently fall back to unexpected values.
+
+```jsx
+// ❌ Wrong — testUrl is undefined during the initial render, even in the browser
+const isBrowser = useIsBrowser();
+const testUrl = isBrowser ? new URL(window.location.href) : null;
+
+// ✅ Correct — use ExecutionEnvironment for environment detection
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+const testUrl = ExecutionEnvironment.canUseDOM
+  ? new URL(window.location.href)
+  : null;
+```
+
+:::
 
 ### `useBaseUrl` {/* #useBaseUrl */}
 

--- a/website/docs/docusaurus-core.mdx
+++ b/website/docs/docusaurus-core.mdx
@@ -421,12 +421,12 @@ The initial render output must be consistent between server and client — compo
 
 :::caution
 
-`useIsBrowser()` and `ExecutionEnvironment.canUseDOM` serve different purposes:
+`useIsBrowser()` and `typeof window !== 'undefined'` serve different purposes:
 
 - **`useIsBrowser()`** — tracks hydration state. Use it to gate UI behavior that should only activate after initial hydration.
-- **`ExecutionEnvironment.canUseDOM`** — detects the runtime environment. Use it when you need to check DOM availability outside of React rendering logic.
+- **`typeof window !== 'undefined'`** — detects the runtime environment. Use it when you need to check DOM availability outside of React rendering logic.
 
-| Context | `useIsBrowser()` | `ExecutionEnvironment.canUseDOM` |
+| Context | `useIsBrowser()` | `typeof window !== 'undefined'` |
 | --- | --- | --- |
 | Node.js / SSR | `false` | `false` |
 | During initial client render | `false` | `true` (DOM is available) |

--- a/website/docs/docusaurus-core.mdx
+++ b/website/docs/docusaurus-core.mdx
@@ -446,24 +446,6 @@ const MyComponent = () => {
 };
 ```
 
-:::note
-
-Avoid using `useIsBrowser()` to access `window` or DOM APIs. It returns `false` during the initial client render, which can cause code to silently fall back to unexpected values.
-
-```jsx
-// ❌ Wrong — testUrl is undefined during the initial render, even in the browser
-const isBrowser = useIsBrowser();
-const testUrl = isBrowser ? new URL(window.location.href) : null;
-
-// ✅ Correct — use ExecutionEnvironment for environment detection
-import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
-const testUrl = ExecutionEnvironment.canUseDOM
-  ? new URL(window.location.href)
-  : null;
-```
-
-:::
-
 ### `useBaseUrl` {/* #useBaseUrl */}
 
 React hook to prepend your site `baseUrl` to a string.

--- a/website/docs/docusaurus-core.mdx
+++ b/website/docs/docusaurus-core.mdx
@@ -417,10 +417,6 @@ Use this hook instead of `typeof window !== 'undefined'` in React rendering logi
 
 The initial render output must be consistent between server and client — components should not depend on browser-only state during the initial render. See [The Perils of Rehydration](https://www.joshwcomeau.com/react/the-perils-of-rehydration/).
 
-:::
-
-:::caution
-
 `useIsBrowser()` and `typeof window !== 'undefined'` serve different purposes:
 
 - **`useIsBrowser()`** — tracks hydration state. Use it to gate UI behavior that should only activate after initial hydration.


### PR DESCRIPTION
…lity (#8678)

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

Improves the `useIsBrowser` section to clarify the difference between hydration state and DOM availability. Addresses the confusion described in #8678.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

Closes #8678
