### PR TITLE
chore(deps): migrate to `@11ty/gray-matter`

### DIFF
--- a/packages/docusaurus-utils/package.json
+++ b/packages/docusaurus-utils/package.json
@@ -25,7 +25,7 @@
     "file-loader": "^6.2.0",
     "fs-extra": "^11.2.0",
     "github-slugger": "^2.0.0",
-    "gray-matter": "^4.0.3",
+    "@11ty/gray-matter": "^1.0.0",
     "jiti": "^2.7.0",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",

--- a/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
@@ -895,9 +895,11 @@ describe('parseMarkdownFile', () => {
       ---
       `),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
-      [YAMLException: incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line at line 2, column 7:
-          foo: f: a
-                ^]
+      [YAMLException: bad indentation of a mapping entry (2:7)
+
+       1 | 
+       2 | foo: f: a
+      -----------^]
     `);
   });
 });

--- a/packages/docusaurus-utils/src/markdownUtils.ts
+++ b/packages/docusaurus-utils/src/markdownUtils.ts
@@ -6,7 +6,7 @@
  */
 
 import logger from '@docusaurus/logger';
-import matter from 'gray-matter';
+import matter from '@11ty/gray-matter';
 import type {
   ParseFrontMatter,
   DefaultParseFrontMatter,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1904,6 +1904,9 @@ importers:
 
   packages/docusaurus-utils:
     dependencies:
+      '@11ty/gray-matter':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@docusaurus/logger':
         specifier: 3.10.1
         version: link:../docusaurus-logger
@@ -1925,9 +1928,6 @@ importers:
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
-      gray-matter:
-        specifier: ^4.0.3
-        version: 4.0.3
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
@@ -2217,6 +2217,10 @@ importers:
         version: 2.17.3
 
 packages:
+
+  '@11ty/gray-matter@1.0.0':
+    resolution: {integrity: sha512-7mJJl+wf1AByoT0PknQiQfOPnVNT4fevGrUBVWO4HXsnYn1aQPyRyrELYrNUFleUBM++KzMKN6QaxHPk0t/6/g==}
+    engines: {node: '>=11'}
 
   '@actions/core@3.0.1':
     resolution: {integrity: sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==}
@@ -8639,10 +8643,6 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  gray-matter@4.0.3:
-    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
-    engines: {node: '>=6.0'}
-
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
@@ -13441,6 +13441,13 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@11ty/gray-matter@1.0.0':
+    dependencies:
+      js-yaml: 4.2.0
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
 
   '@actions/core@3.0.1':
     dependencies:
@@ -20629,13 +20636,6 @@ snapshots:
   graceful-fs@4.2.10: {}
 
   graceful-fs@4.2.11: {}
-
-  gray-matter@4.0.3:
-    dependencies:
-      js-yaml: 3.14.2
-      kind-of: 6.0.3
-      section-matter: 1.0.0
-      strip-bom-string: 1.0.0
 
   hachure-fill@0.5.2: {}
 


### PR DESCRIPTION
## Motivation

Fix https://github.com/facebook/docusaurus/issues/12174

Migrate from unmaintained `gray-matter` to `@11ty/gray-matter`, as suggested by @onyb here: https://github.com/facebook/docusaurus/issues/11719#issuecomment-4715389463

Using v1 for now to be more conservative so that I can backport this in a patch release of Docusaurus v3

A follow-up PR upgrades to v2, which removes JavaScript front matter support (somewhat a breaking change?)
=> https://github.com/facebook/docusaurus/pull/12182

cc @zachleat thanks for the fork 👍 

## Test Plan

CI

### Test links

https://deploy-preview-12181--docusaurus-2.netlify.app/

