### PR TITLE
test(blog): add simple regression test for trailingSlash (AI-assisted)

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/__tests__/feed.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/feed.test.ts
@@ -10,7 +10,7 @@ import path from 'path';
 import fs from 'fs-extra';
 import {
   DEFAULT_PARSE_FRONT_MATTER,
-  DEFAULT_VCS_CONFIG,
+  TEST_VCS as DEFAULT_VCS_CONFIG,
 } from '@docusaurus/utils';
 import {fromPartial} from '@total-typescript/shoehorn';
 import {
@@ -38,6 +38,9 @@ const DefaultI18N: I18n = {
       htmlLang: 'en',
       calendar: 'gregory',
       path: 'en',
+      translate: true,
+      url: 'https://docusaurus.io',
+      baseUrl: '/',
     },
   },
 };
@@ -345,9 +348,16 @@ describe.each(['atom', 'rss', 'json'] as const)('%s', (feedType) => {
       },
     );
 
-    expect(
-      fsMock.mock.calls.map((call) => call[1] as string),
-    ).toMatchSnapshot();
+    const outputs = fsMock.mock.calls.map((call) => call[1] as string);
+    expect(outputs).toMatchSnapshot();
+
+    // Regression test for https://github.com/facebook/docusaurus/issues/7656
+    // Feed URLs should have trailing slashes when trailingSlash: true
+    outputs.forEach((output) => {
+      expect(output).toContain(
+        'https://docusaurus.io/myBaseUrl/blog/blog-with-links/',
+      );
+    });
   });
 
   it('has xslt files for feed', async () => {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Fixes #7656.

This PR adds a simple string match regression check to the existing test suite to verify that `trailingSlash: true` correctly applies to blog feeds. 

This explicitly addresses the previous maintainer feedback that PR #12022 was overly complex, achieving the exact same regression coverage in just 4 lines of code without requiring dynamic XML/JSON parsing.

*(AI-assisted)*

## Test Plan

Ran `pnpm test` over the entire repository. The new assertion in `packages/docusaurus-plugin-content-blog/src/__tests__/feed.test.ts` fails loudly if `applyTrailingSlash` is ever accidentally removed from the feed generator logic, but passes cleanly with the current correct behavior.

Additionally, I fixed two hidden TypeScript compilation errors inside `feed.test.ts` (a broken `DEFAULT_VCS_CONFIG` import and an outdated `I18nLocaleConfig` mock) that were incorrectly being skipped by `__tests__` exclusions in the TS config.

### Test links

N/A - Unit test change only.

## Related issues/PRs

Fixes #7656 
Supersedes #12022
