### PR TITLE
perf: exclude node_modules from content globbing in monorepos

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/index.ts
@@ -43,6 +43,7 @@ export function resolveSidebarPathOption(
 async function readCategoriesMetadata(contentPath: string) {
   const categoryFiles = await Globby('**/_category_.{json,yml,yaml}', {
     cwd: contentPath,
+    ignore: ['**/node_modules/**'],
   });
   const categoryToFile = _.groupBy(categoryFiles, path.dirname);
   return combinePromises(

--- a/packages/docusaurus-utils/src/__tests__/globUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/globUtils.test.ts
@@ -27,6 +27,14 @@ describe('isTranslatableSourceFile', () => {
 });
 
 describe('createMatcher', () => {
+  it('match default exclude node_modules correctly', () => {
+    const matcher = createMatcher(GlobExcludeDefault);
+    expect(matcher('node_modules/pkg/doc.md')).toBe(true);
+    expect(matcher('node_modules/pkg/index.js')).toBe(true);
+    expect(matcher('category/node_modules/pkg/doc.md')).toBe(true);
+    expect(matcher('category/node_modules/@scope/pkg/doc.md')).toBe(true);
+  });
+
   it('match default exclude MD/MDX partials correctly', () => {
     const matcher = createMatcher(GlobExcludeDefault);
     expect(matcher('doc.md')).toBe(false);
@@ -115,8 +123,15 @@ describe('createAbsoluteFilePathMatcher', () => {
     expect(matcher('/root/_docs/_category/myDoc.mdx')).toBe(true);
   });
 
+  it('match default exclude node_modules correctly', () => {
+    expect(matcher('/_root/docs/node_modules/pkg/doc.md')).toBe(true);
+    expect(matcher('/_root/docs/node_modules/@scope/pkg/doc.md')).toBe(true);
+    expect(
+      matcher('/_root/docs/category/node_modules/pkg/index.js'),
+    ).toBe(true);
+  });
+
   it('match default exclude tests correctly', () => {
-    expect(matcher('/__test__/website/src/xyz.js')).toBe(false);
     expect(matcher('/__test__/website/src/__test__/xyz.js')).toBe(true);
     expect(matcher('/__test__/website/src/xyz.test.js')).toBe(true);
   });

--- a/packages/docusaurus-utils/src/__tests__/globUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/globUtils.test.ts
@@ -33,6 +33,10 @@ describe('createMatcher', () => {
     expect(matcher('node_modules/pkg/index.js')).toBe(true);
     expect(matcher('category/node_modules/pkg/doc.md')).toBe(true);
     expect(matcher('category/node_modules/@scope/pkg/doc.md')).toBe(true);
+    // When contentPath is inside node_modules, relative paths of content
+    // files do NOT contain node_modules, so they should NOT be excluded.
+    expect(matcher('intro.md')).toBe(false);
+    expect(matcher('guide/setup.mdx')).toBe(false);
   });
 
   it('match default exclude MD/MDX partials correctly', () => {
@@ -131,7 +135,30 @@ describe('createAbsoluteFilePathMatcher', () => {
     ).toBe(true);
   });
 
+  // Ensures that when contentPath is inside node_modules (e.g.,
+  // node_modules/@myCompany/docs), content files at that root are NOT
+  // excluded, because their relative paths don't contain node_modules.
+  it('does not exclude content when root folder is inside node_modules', () => {
+    const nmMatcher = createAbsoluteFilePathMatcher(GlobExcludeDefault, [
+      '/project/node_modules/@myCompany/docs',
+    ]);
+    // Content at the root should NOT be excluded
+    expect(
+      nmMatcher('/project/node_modules/@myCompany/docs/intro.md'),
+    ).toBe(false);
+    expect(
+      nmMatcher('/project/node_modules/@myCompany/docs/guide/setup.mdx'),
+    ).toBe(false);
+    // But nested node_modules inside that root SHOULD be excluded
+    expect(
+      nmMatcher(
+        '/project/node_modules/@myCompany/docs/node_modules/dep/file.md',
+      ),
+    ).toBe(true);
+  });
+
   it('match default exclude tests correctly', () => {
+    expect(matcher('/__test__/website/src/xyz.js')).toBe(false);
     expect(matcher('/__test__/website/src/__test__/xyz.js')).toBe(true);
     expect(matcher('/__test__/website/src/xyz.test.js')).toBe(true);
   });

--- a/packages/docusaurus-utils/src/__tests__/globUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/globUtils.test.ts
@@ -6,12 +6,52 @@
  */
 
 import {describe, expect, it} from 'vitest';
+import fs from 'fs-extra';
+import {mkdtempDisposable, realpath} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
 import {
+  Globby,
   GlobExcludeDefault,
   createMatcher,
   createAbsoluteFilePathMatcher,
   isTranslatableSourceFile,
 } from '../globUtils';
+
+describe('Globby', () => {
+  it('keeps content sourced from node_modules', async () => {
+    await using tempDir = await mkdtempDisposable(
+      join(await realpath(tmpdir()), 'docusaurus-tmp-'),
+    );
+    const contentPath = join(
+      tempDir.path,
+      'node_modules',
+      '@myCompany',
+      'docs',
+    );
+    await Promise.all([
+      fs.outputFile(join(contentPath, '_category_.json'), '{}'),
+      fs.outputFile(
+        join(contentPath, 'guide', '_category_.yml'),
+        'label: Guide',
+      ),
+      fs.outputFile(
+        join(contentPath, 'node_modules', 'dependency', '_category_.yaml'),
+        'label: Dependency',
+      ),
+    ]);
+
+    const categoryFiles = await Globby('**/_category_.{json,yml,yaml}', {
+      cwd: contentPath,
+      ignore: ['**/node_modules/**'],
+    });
+
+    expect(categoryFiles.sort()).toEqual([
+      '_category_.json',
+      'guide/_category_.yml',
+    ]);
+  });
+});
 
 describe('isTranslatableSourceFile', () => {
   it('works', () => {
@@ -130,31 +170,9 @@ describe('createAbsoluteFilePathMatcher', () => {
   it('match default exclude node_modules correctly', () => {
     expect(matcher('/_root/docs/node_modules/pkg/doc.md')).toBe(true);
     expect(matcher('/_root/docs/node_modules/@scope/pkg/doc.md')).toBe(true);
-    expect(
-      matcher('/_root/docs/category/node_modules/pkg/index.js'),
-    ).toBe(true);
-  });
-
-  // Ensures that when contentPath is inside node_modules (e.g.,
-  // node_modules/@myCompany/docs), content files at that root are NOT
-  // excluded, because their relative paths don't contain node_modules.
-  it('does not exclude content when root folder is inside node_modules', () => {
-    const nmMatcher = createAbsoluteFilePathMatcher(GlobExcludeDefault, [
-      '/project/node_modules/@myCompany/docs',
-    ]);
-    // Content at the root should NOT be excluded
-    expect(
-      nmMatcher('/project/node_modules/@myCompany/docs/intro.md'),
-    ).toBe(false);
-    expect(
-      nmMatcher('/project/node_modules/@myCompany/docs/guide/setup.mdx'),
-    ).toBe(false);
-    // But nested node_modules inside that root SHOULD be excluded
-    expect(
-      nmMatcher(
-        '/project/node_modules/@myCompany/docs/node_modules/dep/file.md',
-      ),
-    ).toBe(true);
+    expect(matcher('/_root/docs/category/node_modules/pkg/index.js')).toBe(
+      true,
+    );
   });
 
   it('match default exclude tests correctly', () => {

--- a/packages/docusaurus-utils/src/globUtils.ts
+++ b/packages/docusaurus-utils/src/globUtils.ts
@@ -26,6 +26,7 @@ export const Globby = Tinyglobby.glob;
  * - Ignore tests
  */
 export const GlobExcludeDefault = [
+  '**/node_modules/**',
   '**/_*.{js,jsx,ts,tsx,md,mdx}',
   '**/_*/**',
   '**/*.test.{js,jsx,ts,tsx}',


### PR DESCRIPTION
## Motivation

Fixes #12128

In monorepo setups with hoisted/linked workspace dependencies (pnpm, yarn workspaces), Globby scans through \
ode_modules\ directories when sourcing docs/blog/pages content. This causes extreme startup slowness — the reporter measured **34 seconds** reduced to **330ms** after adding node_modules to the ignore list.

## Changes

1. **\packages/docusaurus-utils/src/globUtils.ts\**: Add \'**/node_modules/**'\ to \GlobExcludeDefault\, which is used by the docs, blog, and pages plugins when globbing content files.

2. **\packages/docusaurus-plugin-content-docs/src/sidebars/index.ts\**: Add \ignore: ['**/node_modules/**']\ to \eadCategoriesMetadata()\ — this Globby call had **no ignore patterns at all**, meaning it scanned every \_category_.{json,yml,yaml}\ inside \
ode_modules\.

3. **\packages/docusaurus-utils/src/__tests__/globUtils.test.ts\**: Add test coverage for node_modules exclusion in both \createMatcher\ and \createAbsoluteFilePathMatcher\.

## Test Plan

- Added unit tests verifying node_modules paths are excluded by the default glob patterns
- No behavioral change for users without node_modules inside their content directories