### PR TITLE
fix(core): resolve relative links with trailing slash URLs

### DIFF
--- a/packages/docusaurus/src/client/exports/Link.tsx
+++ b/packages/docusaurus/src/client/exports/Link.tsx
@@ -12,7 +12,7 @@ import React, {
   type ComponentType,
   type ReactNode,
 } from 'react';
-import {NavLink, Link as RRLink} from 'react-router-dom';
+import {NavLink, Link as RRLink, useLocation} from 'react-router-dom';
 import {applyTrailingSlash} from '@docusaurus/utils-common';
 import useDocusaurusContext from './useDocusaurusContext';
 import isInternalUrl from './isInternalUrl';
@@ -27,6 +27,21 @@ import type {Props} from '@docusaurus/Link';
 // this is because useBaseUrl() actually transforms relative links
 // like "introduction" to "/baseUrl/introduction" => bad behavior to fix
 const shouldAddBaseUrlAutomatically = (to: string) => to.startsWith('/');
+
+const isPathRelativeUrl = (url: string) =>
+  !url.startsWith('/') && !url.startsWith('#') && !url.startsWith('?');
+
+function getPathnameWithoutTrailingSlash(pathname: string): string {
+  return pathname === '/' ? pathname : pathname.replace(/\/$/, '');
+}
+
+function resolvePathRelativeUrl(url: string, currentPathname: string): string {
+  const base = `https://docusaurus.local${getPathnameWithoutTrailingSlash(
+    currentPathname,
+  )}`;
+  const resolvedUrl = new URL(url, base);
+  return `${resolvedUrl.pathname}${resolvedUrl.search}${resolvedUrl.hash}`;
+}
 
 function Link({
   isNavLink,
@@ -44,6 +59,7 @@ function Link({
   const {withBaseUrl} = useBaseUrlUtils();
   const brokenLinks = useBrokenLinks();
   const innerRef = useRef<HTMLAnchorElement | null>(null);
+  const location = useLocation();
 
   useImperativeHandle(props.ref, () => innerRef.current!);
 
@@ -86,6 +102,15 @@ function Link({
   // unfortunately we can't really make the difference :/
   if (router === 'hash' && targetLink?.startsWith('./')) {
     targetLink = targetLink?.slice(1);
+  }
+
+  if (
+    router === 'browser' &&
+    targetLink &&
+    isInternal &&
+    isPathRelativeUrl(targetLink)
+  ) {
+    targetLink = resolvePathRelativeUrl(targetLink, location.pathname);
   }
 
   if (targetLink && isInternal) {

--- a/packages/docusaurus/src/client/exports/__tests__/Link.test.tsx
+++ b/packages/docusaurus/src/client/exports/__tests__/Link.test.tsx
@@ -213,6 +213,30 @@ describe('<Link>', () => {
       `);
     });
 
+    it('can render relative links when the current location has a trailing slash', () => {
+      const {container} = render(<Link to="../features/multi-layer" />, {
+        currentLocation: '/docs/getting-started/quick-start/',
+      });
+      expect(container.firstElementChild).toMatchInlineSnapshot(`
+        <a
+          data-test-link-type="react-router"
+          href="/docs/features/multi-layer"
+        />
+      `);
+    });
+
+    it('can render path-relative links when the current location has a trailing slash', () => {
+      const {container} = render(<Link to="relativeDoc" />, {
+        currentLocation: '/sub/category/currentPathname/',
+      });
+      expect(container.firstElementChild).toMatchInlineSnapshot(`
+        <a
+          data-test-link-type="react-router"
+          href="/sub/category/relativeDoc"
+        />
+      `);
+    });
+
     it("can render 'https://example.com/xyz'", () => {
       const {container} = render(<Link to="https://example.com/xyz" />);
       expect(container.firstElementChild).toMatchInlineSnapshot(`


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: N/A, this is a scoped bug fix for an existing issue.

## Motivation

Fixes #12209.

Path-relative internal links such as `../features/multi-layer` are currently passed through to React Router unchanged. When the browser URL has a trailing slash after hydration, React Router resolves `..` against that slash-terminated URL and keeps one extra path segment, so a link that should navigate to `/docs/features/multi-layer` can navigate to `/docs/getting-started/features/multi-layer` instead.

This PR resolves path-relative internal links in the Docusaurus `Link` component before passing them to React Router. It trims only the current pathname's trailing slash before resolving, preserving the existing no-trailing-slash SSR behavior and still applying Docusaurus' configured trailing slash handling afterward.

## Test Plan

- `pnpm install --frozen-lockfile`
- `pnpm vitest run packages/docusaurus/src/client/exports/__tests__/Link.test.tsx` — 24 tests passed
- `pnpm exec oxfmt --list-different packages/docusaurus/src/client/exports/Link.tsx packages/docusaurus/src/client/exports/__tests__/Link.test.tsx` — no output
- `pnpm exec eslint packages/docusaurus/src/client/exports/Link.tsx packages/docusaurus/src/client/exports/__tests__/Link.test.tsx` — 0 errors, 1 existing `experimental_router` camelcase warning in the test helper
- `pnpm --filter @docusaurus/core build`

### Test links

Deploy preview: https://deploy-preview-12211--docusaurus-2.netlify.app/

## Related issues/PRs

Fixes #12209

## AI assistance

This PR was prepared with Codex assistance. I reviewed the diff and ran the validation commands listed above.