### PR TITLE
fix(sitemap): don't drop lastmod for an epoch (0) timestamp

### DIFF
--- a/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemapItem.test.ts
+++ b/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemapItem.test.ts
@@ -108,6 +108,15 @@ describe('createSitemapItem', () => {
                   }
               `);
       });
+
+      it('lastmod from epoch (0) timestamp is not dropped', async () => {
+        await expect(
+          test({
+            options: {lastmod: 'date'},
+            route: {metadata: {lastUpdatedAt: 0}, path: '/routePath'},
+          }),
+        ).resolves.toMatchObject({lastmod: '1970-01-01'});
+      });
     });
 
     describe('read from git', () => {

--- a/packages/docusaurus-plugin-sitemap/src/createSitemapItem.ts
+++ b/packages/docusaurus-plugin-sitemap/src/createSitemapItem.ts
@@ -21,7 +21,7 @@ async function getRouteLastUpdatedAt(
   if (route.metadata?.lastUpdatedAt === null) {
     return null;
   }
-  if (route.metadata?.lastUpdatedAt) {
+  if (route.metadata?.lastUpdatedAt != null) {
     return route.metadata?.lastUpdatedAt;
   }
   if (route.metadata?.sourceFilePath) {
@@ -59,7 +59,7 @@ async function getRouteLastmod({
     return null;
   }
   const lastUpdatedAt = (await getRouteLastUpdatedAt(route, vcs)) ?? null;
-  return lastUpdatedAt ? formatLastmod(lastUpdatedAt, lastmod) : null;
+  return lastUpdatedAt != null ? formatLastmod(lastUpdatedAt, lastmod) : null;
 }
 
 export async function createSitemapItem({


### PR DESCRIPTION
## Motivation

`createSitemapItem` decides a route's `<lastmod>` from `route.metadata.lastUpdatedAt` (a numeric timestamp, e.g. derived from front matter `last_update: {date: ...}`). Two checks use truthiness on that number:

```ts
// getRouteLastUpdatedAt
if (route.metadata?.lastUpdatedAt) { ... }            // 0 is falsy → skipped
// getRouteLastmod
return lastUpdatedAt ? formatLastmod(...) : null;      // 0 → null
```

So a legitimate timestamp of `0` (1970-01-01T00:00:00Z) is treated as "no value" and the `<lastmod>` is silently omitted. The adjacent `=== null` early-return already shows the intent to distinguish *absent* from *present* — the truthiness checks defeat that for `0`.

## Fix

Use `!= null` in both places so `0` is preserved (while still treating `null`/`undefined` as absent).

## Test plan

```
pnpm vitest run packages/docusaurus-plugin-sitemap
```
Added a regression test (`lastUpdatedAt: 0` → `lastmod: '1970-01-01'`) that fails before this change and passes after. Full sitemap package: 53 tests pass.