### PR TITLE
fix(utils): stop createExcerpt leaking a multi-line JSX element into the description

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
@@ -174,6 +174,18 @@ describe('createExcerpt', () => {
     ).toBe('Lorem ipsum dolor sit amet, consectetur adipiscing elit.');
   });
 
+  it('creates excerpt after a multi-line JSX element', () => {
+    expect(
+      createExcerpt(dedent`
+          <MyComponent
+            prop={{a: 'b'}}
+          />
+
+          Lorem ipsum dolor sit amet.
+        `),
+    ).toBe('Lorem ipsum dolor sit amet.');
+  });
+
   it('creates excerpt after multi-line imports', () => {
     expect(
       createExcerpt(dedent`

--- a/packages/docusaurus-utils/src/markdownUtils.ts
+++ b/packages/docusaurus-utils/src/markdownUtils.ts
@@ -92,6 +92,7 @@ export function createExcerpt(fileString: string): string | undefined {
     .split(/\r?\n/);
   let inCode = false;
   let inImport = false;
+  let inHTML = false;
   let lastCodeFence = '';
 
   for (const fileLine of fileLines) {
@@ -124,6 +125,20 @@ export function createExcerpt(fileString: string): string | undefined {
       }
       continue;
     } else if (inCode) {
+      continue;
+    }
+
+    // Skip lines inside a multi-line JSX/HTML element. An opening "<Tag ..."
+    // with no ">" on the same line would otherwise leak into the excerpt
+    // (e.g. "<MyComponent"). Skip until the element's tag closes.
+    if (inHTML) {
+      if (fileLine.includes('>')) {
+        inHTML = false;
+      }
+      continue;
+    }
+    if (/^\s*<[A-Za-z][^>]*$/.test(fileLine)) {
+      inHTML = true;
       continue;
     }
 

--- a/packages/docusaurus-utils/src/markdownUtils.ts
+++ b/packages/docusaurus-utils/src/markdownUtils.ts
@@ -137,7 +137,7 @@ export function createExcerpt(fileString: string): string | undefined {
       }
       continue;
     }
-    if (/^\s*<[A-Za-z][^>]*$/.test(fileLine)) {
+    if (/^\s*<[a-z][^>]*$/i.test(fileLine)) {
       inHTML = true;
       continue;
     }


### PR DESCRIPTION
## Motivation

Fixes #12214.

`createExcerpt` builds the auto `description` / `og:description` by scanning a doc line by line. It strips HTML/JSX with `/<[^>]*>/g`, which only matches a tag that opens and closes on the same line. When the first content node is a multi-line JSX/MDX element, only its first line is seen (e.g. `<MyComponent`), the regex finds no `>`, nothing is stripped, and that partial tag becomes the page description — e.g. `<meta name="description" content="<MyComponent">`.

This adds an `inHTML` state next to the existing `inImport` / `inCode` handling: when a line opens a tag with no `>` on the same line, skip lines until it closes. Single-line and self-closing tags are unchanged (the existing regex still handles them). The guard only triggers when a line starts (after whitespace) with `<Tag` and has no `>`, so it doesn't touch prose or current behavior.

## Test Plan

Added `creates excerpt after a multi-line JSX element` in `markdownUtils.test.ts`. It fails before the change (excerpt is `<MyComponent`) and passes after. Runs with the existing `docusaurus-utils` unit tests.



## AI assistance

This PR was written with AI assistance (Claude). The change is small and scoped to the reported bug; I understand and take responsibility for every line.
