### PR TITLE
fix(utils-common): keep dollar signs when applying trailing slash

### DIFF
--- a/packages/docusaurus-utils-common/src/__tests__/applyTrailingSlash.test.ts
+++ b/packages/docusaurus-utils-common/src/__tests__/applyTrailingSlash.test.ts
@@ -90,6 +90,13 @@ describe('applyTrailingSlash', () => {
     expect(applyTrailingSlash('/abc/', params(undefined))).toBe('/abc/');
   });
 
+  it('keeps dollar signs in the pathname', () => {
+    expect(applyTrailingSlash('/docs/a$$b', params(true))).toBe('/docs/a$$b/');
+    expect(applyTrailingSlash('/docs/a$&b', params(true))).toBe('/docs/a$&b/');
+    expect(applyTrailingSlash("/docs/a$'b", params(true))).toBe("/docs/a$'b/");
+    expect(applyTrailingSlash('/docs/a$$b/', params(false))).toBe('/docs/a$$b');
+  });
+
   it('applies to path with #anchor', () => {
     expect(applyTrailingSlash('/abc#anchor', params(true))).toBe(
       '/abc/#anchor',

--- a/packages/docusaurus-utils-common/src/__tests__/applyTrailingSlash.test.ts
+++ b/packages/docusaurus-utils-common/src/__tests__/applyTrailingSlash.test.ts
@@ -91,6 +91,8 @@ describe('applyTrailingSlash', () => {
   });
 
   it('keeps dollar signs in the pathname', () => {
+    // Regression test for edge case bug
+    // see https://github.com/facebook/docusaurus/pull/12219
     expect(applyTrailingSlash('/docs/a$$b', params(true))).toBe('/docs/a$$b/');
     expect(applyTrailingSlash('/docs/a$&b', params(true))).toBe('/docs/a$&b/');
     expect(applyTrailingSlash("/docs/a$'b", params(true))).toBe("/docs/a$'b/");

--- a/packages/docusaurus-utils-common/src/applyTrailingSlash.ts
+++ b/packages/docusaurus-utils-common/src/applyTrailingSlash.ts
@@ -51,7 +51,7 @@ export default function applyTrailingSlash(
     ? pathname
     : handleTrailingSlash(pathname, trailingSlash);
 
-  return path.replace(pathname, newPathname);
+  return newPathname + path.slice(pathname.length);
 }
 
 /** Appends a leading slash to `str`, if one doesn't exist. */

--- a/packages/docusaurus-utils-common/src/applyTrailingSlash.ts
+++ b/packages/docusaurus-utils-common/src/applyTrailingSlash.ts
@@ -40,6 +40,7 @@ export default function applyTrailingSlash(
 
   // The trailing slash should be handled before the ?search#hash !
   const [pathname] = path.split(/[#?]/) as [string, ...string[]];
+  const queryHash = path.slice(pathname.length);
 
   // Never transform '/' to ''
   // Never remove the baseUrl trailing slash!
@@ -51,7 +52,7 @@ export default function applyTrailingSlash(
     ? pathname
     : handleTrailingSlash(pathname, trailingSlash);
 
-  return newPathname + path.slice(pathname.length);
+  return `${newPathname}${queryHash}`;
 }
 
 /** Appends a leading slash to `str`, if one doesn't exist. */


### PR DESCRIPTION
`applyTrailingSlash` builds its result with `path.replace(pathname, newPathname)`.
`String.prototype.replace(string, string)` treats `$` sequences in the
replacement string specially, and `$` is a valid pathname character. So a
pathname containing `$` followed by `$`, `&`, backtick or a quote gets corrupted
when a trailing slash is added or removed.

For example, with `trailingSlash: true`:

    /docs/a$$b   becomes  /docs/a$b/
    /docs/a$&b   becomes  /docs/a/docs/a$&bb/

`applyTrailingSlash` runs on real user-facing links through `<Link>`, canonical
URLs, the sitemap, feeds and client redirects, so the corruption reaches
navigation and the metadata output when `trailingSlash` is set.

The fix concatenates `newPathname` with the rest of the original path
(`newPathname + path.slice(pathname.length)`). `pathname` is always the prefix
`path.split(/[#?]/)[0]`, so this preserves the search and hash and avoids any
`$` interpretation. Added a test for pathnames containing `$`.

This change was prepared with AI assistance, disclosed per the contributing guide.
