### PR TITLE
fix(core): render base URL suggestion as text (AI-assisted)

### DIFF
--- a/packages/docusaurus/src/client/BaseUrlIssueBanner/index.tsx
+++ b/packages/docusaurus/src/client/BaseUrlIssueBanner/index.tsx
@@ -61,7 +61,7 @@ function insertBanner() {
   var suggestedBaseUrl = actualHomePagePath.substr(-1) === '/'
         ? actualHomePagePath
         : actualHomePagePath + '/';
-  suggestionContainer.innerHTML = suggestedBaseUrl;
+  suggestionContainer.textContent = suggestedBaseUrl;
 }
 `;
 }

--- a/packages/docusaurus/src/client/__tests__/BaseUrlIssueBanner.test.ts
+++ b/packages/docusaurus/src/client/__tests__/BaseUrlIssueBanner.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {readFileSync} from 'node:fs';
+import {describe, expect, it} from 'vitest';
+
+const baseUrlIssueBannerSource = readFileSync(
+  new URL('../BaseUrlIssueBanner/index.tsx', import.meta.url),
+  'utf8',
+);
+
+describe('BaseUrlIssueBanner', () => {
+  it('renders the suggested baseUrl as text instead of HTML', () => {
+    expect(baseUrlIssueBannerSource).toContain(
+      'suggestionContainer.textContent = suggestedBaseUrl;',
+    );
+    expect(baseUrlIssueBannerSource).not.toContain(
+      'suggestionContainer.innerHTML = suggestedBaseUrl;',
+    );
+  });
+});


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] This is not a new API or substantial change.

## Motivation

(AI-assisted)

Closes #12216.

The base URL issue banner currently writes the suggested `baseUrl` with `innerHTML`, even though the value is intended to be displayed as plain text from `window.location.pathname`.

Using `textContent` keeps the rendered output the same for normal paths while avoiding an unnecessary HTML sink in the inline banner script.

## Test Plan

(AI-assisted)

- Added a regression test that checks the suggested `baseUrl` assignment uses `textContent` and does not use `innerHTML`.
- Verified the source and regression test with a focused Node check.
- `git diff --check HEAD~1 HEAD -- packages/docusaurus/src/client/BaseUrlIssueBanner/index.tsx packages/docusaurus/src/client/__tests__/BaseUrlIssueBanner.test.ts`
- `npm exec --yes --package oxfmt@0.47.0 --call "oxfmt --check packages/docusaurus/src/client/BaseUrlIssueBanner/index.tsx packages/docusaurus/src/client/__tests__/BaseUrlIssueBanner.test.ts"`

### Test links

Deploy preview: https://deploy-preview-12220--docusaurus-2.netlify.app/

## Related issues/PRs

Closes #12216.
