### PR TITLE
fix: prevent code blocks flash in dark mode (AI-assisted)

### DIFF
--- a/packages/docusaurus-theme-classic/src/index.ts
+++ b/packages/docusaurus-theme-classic/src/index.ts
@@ -38,7 +38,11 @@ export default function themeClassic(
   const {
     announcementBar,
     colorMode,
-    prism: {additionalLanguages},
+    prism: {
+      additionalLanguages,
+      theme: prismLightTheme,
+      darkTheme: prismDarkTheme,
+    },
   } = themeConfig;
   const {customCss} = options;
   const {direction} = localeConfigs[currentLocale]!;
@@ -120,7 +124,25 @@ export default function themeClassic(
     },
 
     injectHtmlTags() {
+      const lightTheme = prismLightTheme;
+      const darkTheme = prismDarkTheme || lightTheme;
+      const prismCssStyle = `
+[data-theme='light'] {
+  --prism-background-color: ${lightTheme.plain.backgroundColor || 'inherit'};
+  --prism-color: ${lightTheme.plain.color || 'inherit'};
+}
+[data-theme='dark'] {
+  --prism-background-color: ${darkTheme.plain.backgroundColor || 'inherit'};
+  --prism-color: ${darkTheme.plain.color || 'inherit'};
+}
+`;
       return {
+        headTags: [
+          {
+            tagName: 'style',
+            innerHTML: prismCssStyle,
+          },
+        ],
         preBodyTags: [
           {
             tagName: 'svg',

--- a/packages/docusaurus-theme-classic/src/index.ts
+++ b/packages/docusaurus-theme-classic/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 import path from 'path';
+import fs from 'fs/promises';
 import rtlcss from 'rtlcss';
 import {readDefaultCodeTranslationMessages} from '@docusaurus/theme-translations';
 import {getTranslationFiles, translateThemeConfig} from './translations';
@@ -19,6 +20,88 @@ import type {LoadContext, Plugin} from '@docusaurus/types';
 import type {ThemeConfig} from '@docusaurus/theme-common';
 import type {Plugin as PostCssPlugin} from 'postcss';
 import type {PluginOptions} from '@docusaurus/theme-classic';
+import type {PrismTheme} from 'prism-react-renderer';
+
+// Converts a single PrismThemeEntry style object to CSS declarations.
+function styleEntryToCSS(style: PrismTheme['plain']): string {
+  const cssPropertyMap: Record<string, string> = {
+    color: 'color',
+    backgroundColor: 'background-color',
+    fontStyle: 'font-style',
+    fontWeight: 'font-weight',
+    textDecorationLine: 'text-decoration-line',
+    opacity: 'opacity',
+  };
+  return Object.entries(style)
+    .filter(([, v]) => v != null)
+    .map(([key, value]) => {
+      const prop =
+        cssPropertyMap[key] ??
+        key.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`);
+      return `  ${prop}: ${value};`;
+    })
+    .join('\n');
+}
+
+/**
+ * Generates a complete CSS string for both light and dark Prism themes.
+ *
+ * Includes:
+ * - CSS custom properties (--prism-background-color, --prism-color) used by the
+ *   CodeBlock container and pre elements.
+ * - Per-token CSS rules scoped under [data-theme='light|dark'] so that syntax
+ *   highlighting colors are driven by CSS selectors instead of inline styles.
+ *
+ * Because the CSS bundle is render-blocking (loaded via <link> in <head>),
+ * and Docusaurus sets [data-theme] via an inline script before the body
+ * renders, both the container background and token colors are correct from
+ * the very first paint — preventing the dark-mode flash (issue #11566).
+ *
+ * The generated file is bundled into the site CSS (loaded once, cached by the
+ * browser) instead of being inlined into every HTML page.
+ */
+function generatePrismCSS(
+  lightTheme: PrismTheme,
+  darkTheme: PrismTheme,
+): string {
+  function tokenRules(theme: PrismTheme, dataTheme: string): string {
+    const rules: string[] = [];
+    const themeSelector = `[data-theme='${dataTheme}']`;
+    for (const {types, style, languages} of theme.styles) {
+      const cssDeclarations = styleEntryToCSS(style);
+      if (!cssDeclarations) {
+        continue;
+      }
+      if (languages && languages.length > 0) {
+        for (const lang of languages) {
+          const selectors = types
+            .map((type) => `${themeSelector} .language-${lang} .token.${type}`)
+            .join(',\n');
+          rules.push(`${selectors} {\n${cssDeclarations}\n}`);
+        }
+      } else {
+        const selectors = types
+          .map((type) => `${themeSelector} .token.${type}`)
+          .join(',\n');
+        rules.push(`${selectors} {\n${cssDeclarations}\n}`);
+      }
+    }
+    return rules.join('\n');
+  }
+
+  return `
+[data-theme='light'] {
+  --prism-background-color: ${lightTheme.plain.backgroundColor || 'inherit'};
+  --prism-color: ${lightTheme.plain.color || 'inherit'};
+}
+[data-theme='dark'] {
+  --prism-background-color: ${darkTheme.plain.backgroundColor || 'inherit'};
+  --prism-color: ${darkTheme.plain.color || 'inherit'};
+}
+${tokenRules(lightTheme, 'light')}
+${tokenRules(darkTheme, 'dark')}
+`;
+}
 
 function getInfimaCSSFile(direction: string) {
   return `infima/dist/css/default/default${
@@ -47,8 +130,27 @@ export default function themeClassic(
   const {customCss} = options;
   const {direction} = localeConfigs[currentLocale]!;
 
+  // The path is computed upfront so getClientModules() can return it
+  // synchronously. The file itself is written asynchronously in loadContent().
+  const generatedPrismCSSPath = path.join(
+    context.generatedFilesDir,
+    'docusaurus-theme-classic',
+    'prism-theme.css',
+  );
+
   return {
     name: 'docusaurus-theme-classic',
+
+    async loadContent() {
+      // Write the generated Prism CSS file asynchronously. This hook
+      // runs before bundling, so the file is ready when getClientModules()
+      // paths are processed by the bundler.
+      await fs.mkdir(path.dirname(generatedPrismCSSPath), {recursive: true});
+      await fs.writeFile(
+        generatedPrismCSSPath,
+        generatePrismCSS(prismLightTheme, prismDarkTheme || prismLightTheme),
+      );
+    },
 
     getThemePath() {
       return '../lib/theme';
@@ -78,6 +180,10 @@ export default function themeClassic(
         require.resolve(getInfimaCSSFile(direction)),
         './prism-include-languages',
         './nprogress',
+        // The generated Prism CSS is bundled here so it is included once
+        // in the site CSS bundle (cached by the browser) rather than
+        // inlined in every HTML page.
+        generatedPrismCSSPath,
       ];
 
       modules.push(...customCss.map((p) => path.resolve(context.siteDir, p)));
@@ -124,25 +230,7 @@ export default function themeClassic(
     },
 
     injectHtmlTags() {
-      const lightTheme = prismLightTheme;
-      const darkTheme = prismDarkTheme || lightTheme;
-      const prismCssStyle = `
-[data-theme='light'] {
-  --prism-background-color: ${lightTheme.plain.backgroundColor || 'inherit'};
-  --prism-color: ${lightTheme.plain.color || 'inherit'};
-}
-[data-theme='dark'] {
-  --prism-background-color: ${darkTheme.plain.backgroundColor || 'inherit'};
-  --prism-color: ${darkTheme.plain.color || 'inherit'};
-}
-`;
       return {
-        headTags: [
-          {
-            tagName: 'style',
-            innerHTML: prismCssStyle,
-          },
-        ],
         preBodyTags: [
           {
             tagName: 'svg',

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Container/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Container/index.tsx
@@ -7,21 +7,17 @@
 
 import React, {type ComponentProps, type ReactNode} from 'react';
 import clsx from 'clsx';
-import {ThemeClassNames, usePrismTheme} from '@docusaurus/theme-common';
-import {getPrismCssVariables} from '@docusaurus/theme-common/internal';
+import {ThemeClassNames} from '@docusaurus/theme-common';
 import styles from './styles.module.css';
 
 export default function CodeBlockContainer<T extends 'div' | 'pre'>({
   as: As,
   ...props
 }: {as: T} & ComponentProps<T>): ReactNode {
-  const prismTheme = usePrismTheme();
-  const prismCssVariables = getPrismCssVariables(prismTheme);
   return (
     <As
       // Polymorphic components are hard to type, without `oneOf` generics
       {...(props as any)}
-      style={prismCssVariables}
       className={clsx(
         props.className,
         styles.codeBlockContainer,

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/index.tsx
@@ -57,11 +57,10 @@ export default function CodeBlockContent({
   const {code, language, lineNumbersStart, lineClassNames} = metadata;
   return (
     <Highlight theme={prismTheme} code={code} language={language}>
-      {({className, style, tokens: lines, getLineProps, getTokenProps}) => (
+      {({className, tokens: lines, getLineProps, getTokenProps}) => (
         <Pre
           ref={wordWrap.codeBlockRef}
-          className={clsx(classNameProp, className)}
-          style={style}>
+          className={clsx(classNameProp, className)}>
           <Code>
             {lines.map((line, i) => (
               <Line

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/index.tsx
@@ -5,15 +5,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {type ComponentProps, type ReactNode} from 'react';
+import {type ComponentProps, type ReactNode} from 'react';
 import clsx from 'clsx';
 import {useCodeBlockContext} from '@docusaurus/theme-common/internal';
-import {usePrismTheme} from '@docusaurus/theme-common';
-import {Highlight} from 'prism-react-renderer';
+import {Highlight, type PrismTheme} from 'prism-react-renderer';
 import type {Props} from '@theme/CodeBlock/Content';
 import Line from '@theme/CodeBlock/Line';
 
 import styles from './styles.module.css';
+
+// A bare theme with no colors so that prism-react-renderer does NOT
+// inject inline styles on each token span. Token classnames (e.g.
+// `token keyword`) are still applied by Prism.js regardless of theme.
+// Actual syntax-highlight colors are provided by the CSS generated in
+// loadContent() and bundled via getClientModules(), scoped under
+// [data-theme='light|dark']. This prevents the flash of wrong colors
+// in dark mode (issue #11566).
+const BARE_PRISM_THEME: PrismTheme = {plain: {}, styles: []};
 
 function Pre({className, ref, ...props}: ComponentProps<'pre'>) {
   return (
@@ -53,10 +61,9 @@ export default function CodeBlockContent({
   className: classNameProp,
 }: Props): ReactNode {
   const {metadata, wordWrap} = useCodeBlockContext();
-  const prismTheme = usePrismTheme();
   const {code, language, lineNumbersStart, lineClassNames} = metadata;
   return (
-    <Highlight theme={prismTheme} code={code} language={language}>
+    <Highlight theme={BARE_PRISM_THEME} code={code} language={language}>
       {({className, tokens: lines, getLineProps, getTokenProps}) => (
         <Pre
           ref={wordWrap.codeBlockRef}

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, {isValidElement, type ReactNode} from 'react';
-import useIsBrowser from '@docusaurus/useIsBrowser';
 import ElementContent from '@theme/CodeBlock/Content/Element';
 import StringContent from '@theme/CodeBlock/Content/String';
 import type {Props} from '@theme/CodeBlock';
@@ -29,17 +28,8 @@ export default function CodeBlock({
   children: rawChildren,
   ...props
 }: Props): ReactNode {
-  // The Prism theme on SSR is always the default theme but the site theme can
-  // be in a different mode. React hydration doesn't update DOM styles that come
-  // from SSR. Hence force a re-render after mounting to apply the current
-  // relevant styles.
-  const isBrowser = useIsBrowser();
   const children = maybeStringifyChildren(rawChildren);
   const CodeBlockComp =
     typeof children === 'string' ? StringContent : ElementContent;
-  return (
-    <CodeBlockComp key={String(isBrowser)} {...props}>
-      {children as string}
-    </CodeBlockComp>
-  );
+  return <CodeBlockComp {...props}>{children as string}</CodeBlockComp>;
 }

--- a/packages/docusaurus-theme-common/src/internal.ts
+++ b/packages/docusaurus-theme-common/src/internal.ts
@@ -41,7 +41,6 @@ export {useAlternatePageUtils} from './utils/useAlternatePageUtils';
 export {
   type CodeBlockMetadata,
   createCodeBlockMetadata,
-  getPrismCssVariables,
   CodeBlockContextProvider,
   useCodeBlockContext,
 } from './utils/codeBlockUtils';

--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.tsx
@@ -5,12 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {CSSProperties, ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import {createContext, useContext, useMemo} from 'react';
 import clsx from 'clsx';
 import rangeParser from 'parse-numeric-range';
 import {ReactContextError} from './reactUtils';
-import type {PrismTheme, PrismThemeEntry} from 'prism-react-renderer';
 import type {WordWrap} from '../hooks/useCodeWordWrap';
 
 const codeBlockTitleRegex = /title=(?<quote>["'])(?<title>.*?)\1/;
@@ -443,22 +442,6 @@ export function createCodeBlockMetadata(params: {
     lineNumbersStart,
     lineClassNames,
   };
-}
-
-export function getPrismCssVariables(prismTheme: PrismTheme): CSSProperties {
-  const mapping: PrismThemeEntry = {
-    color: '--prism-color',
-    backgroundColor: '--prism-background-color',
-  };
-
-  const properties: {[key: string]: string} = {};
-  Object.entries(prismTheme.plain).forEach(([key, value]) => {
-    const varName = mapping[key as keyof PrismThemeEntry];
-    if (varName && typeof value === 'string') {
-      properties[varName] = value;
-    }
-  });
-  return properties;
 }
 
 type CodeBlockContextValue = {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Fixes #11566

When loading a page in dark mode, code blocks briefly flash with light theme colors before switching to the correct dark colors. This happens because `prism-react-renderer`'s `<Highlight>` applies syntax colors as **inline styles** on every token `<span>` (e.g. `style="color: #e3116c"`). Inline styles have higher specificity than any CSS selector, so the `[data-theme="dark"]` attribute — already set by Docusaurus's blocking inline script before hydration — could not override them.

This is a follow-up to #11967, which was closed after review. This PR addresses the two issues raised by @slorber:

1. **Token colors still flashed** — the previous PR only fixed the container background via CSS variables, but left token colors driven by inline styles.
2. **CSS was inlined in every HTML page** — the previous PR injected a `<style>` tag via `injectHtmlTags()`, adding weight to every SSR page even those without code blocks.

### What changed (AI-assisted)

**`packages/docusaurus-theme-classic/src/index.ts`**

- Added `generatePrismCSS()`, which produces CSS rules for both themes:
  - CSS custom properties (`--prism-background-color`, `--prism-color`) for the container.
  - Per-token rules scoped under `[data-theme='light'] .token.<type>` and `[data-theme='dark'] .token.<type>`.
- The file is written **asynchronously** in `loadContent()` to `generatedFilesDir/docusaurus-theme-classic/prism-theme.css`.
- The path is registered in `getClientModules()` so the bundler includes it in the site CSS bundle — loaded once and cached by the browser, not repeated in every HTML page.
- The `injectHtmlTags()` `headTags` with the inline `<style>` was removed entirely.

**`packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/index.tsx`**

- Introduced `BARE_PRISM_THEME = {plain: {}, styles: []}` passed to `<Highlight theme={BARE_PRISM_THEME}>`. This suppresses all inline styles on token spans while preserving Prism's token class names (e.g. `token keyword`), which the generated CSS then targets.

**`packages/docusaurus-theme-common/src/utils/codeBlockUtils.tsx`** and **`src/internal.ts`**

- Removed `getPrismCssVariables` and its re-export, as it is no longer used anywhere.
- Removed the now-unused `PrismThemeEntry`, `CSSProperties`, and `PrismTheme` imports from `codeBlockUtils.tsx`.

## Test Plan

1. Configure a Docusaurus site with different light and dark Prism themes:
   ```js
   prism: {
     theme: prismThemes.oneLight,
     darkTheme: prismThemes.oneDark,
   }
   ```
2. Switch the site to dark mode.
3. Hard-reload any page containing code blocks.
4. Observe that code blocks render immediately with the correct dark colors — no flash of light theme colors.
5. Navigate to a page with no code blocks and confirm via DevTools that no Prism CSS is inlined in the HTML — it is only present in the bundled CSS file.

### Test links

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/
//then i'll edit this, dw

## Related issues/PRs

- Closes #11566
- Follow-up to #11967 (previous attempt, closed after review)
- Related: #7986, #9629, #11296