### PR TITLE
fix(core): allow boolean headTags attributes

### DIFF
--- a/packages/docusaurus/src/server/__tests__/configValidation.test.ts
+++ b/packages/docusaurus/src/server/__tests__/configValidation.test.ts
@@ -284,6 +284,23 @@ describe('headTags', () => {
     }).not.toThrow();
   });
 
+  it('accepts headTags with boolean attributes', () => {
+    expect(() => {
+      normalizeConfig({
+        headTags: [
+          {
+            tagName: 'script',
+            attributes: {
+              src: '/analytics.js',
+              async: true,
+              defer: false,
+            },
+          },
+        ],
+      });
+    }).not.toThrow();
+  });
+
   it("throws error if headTags doesn't have tagName", () => {
     expect(() => {
       normalizeConfig({
@@ -330,21 +347,21 @@ describe('headTags', () => {
     ).not.toThrow();
   });
 
-  it("throws error if headTags doesn't have string attributes", () => {
+  it('throws error if headTags has non-string/boolean attributes', () => {
     expect(() => {
       normalizeConfig({
         headTags: [
           {
             tagName: 'link',
             attributes: {
-              rel: false,
+              rel: 42,
               href: 'img/docusaurus.png',
             },
           },
         ],
       });
     }).toThrowErrorMatchingInlineSnapshot(`
-      [Error: "headTags[0].attributes.rel" must be a string
+      [Error: "headTags[0].attributes.rel" must be one of [string, boolean]
       ]
     `);
   });

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -148,6 +148,11 @@ export const DEFAULT_MARKDOWN_CONFIG: MarkdownConfig = {
   hooks: DEFAULT_MARKDOWN_HOOKS,
 };
 
+const HtmlTagAttributeValueSchema = Joi.alternatives().try(
+  Joi.string().strict(),
+  Joi.boolean().strict(),
+);
+
 export const DEFAULT_CONFIG: Pick<
   DocusaurusConfig,
   | 'i18n'
@@ -469,7 +474,7 @@ export const ConfigSchema = Joi.object<DocusaurusConfig>({
           is: Joi.valid(true),
           then: Joi.optional(),
           otherwise: Joi.object()
-            .pattern(/[\w-]+/, Joi.string())
+            .pattern(/[\w-]+/, HtmlTagAttributeValueSchema)
             .required(),
         }),
         customElement: Joi.bool().default(false),


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

## Summary

Fixes https://github.com/facebook/docusaurus/issues/12233.

Allows `headTags.attributes` values to be `string | boolean`, matching the existing `HtmlTagObject` type and renderer behavior for boolean HTML attributes.

The validation remains narrow and still rejects unsupported attribute value types.

(AI-assisted)

## Test Plan

```bash
./node_modules/.bin/vitest run packages/docusaurus/src/server/__tests__/configValidation.test.ts