### PR TITLE
fix(ci): fix dependabot cooldown delays

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,5 +25,6 @@ updates:
     cooldown:
       default-days: 5
       semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 7
+      # +1d compared to pnpm cutoff, otherwise Dependabot opens PRs too early
+      semver-minor-days: 8
+      semver-patch-days: 8

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,5 +26,6 @@ updates:
       default-days: 5
       semver-major-days: 30
       # +1d compared to pnpm cutoff, otherwise Dependabot opens PRs too early
+      # See https://github.com/facebook/docusaurus/pull/12241
       semver-minor-days: 8
       semver-patch-days: 8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,7 @@ overrides:
   # See https://sharp.pixelplumbing.com/changelog/v0.35.0/
   sharp: ^0.35.1
 
-minimumReleaseAge: 10080
+minimumReleaseAge: 10080 # 7 days in minutes
 minimumReleaseAgeStrict: true
 minimumReleaseAgeIgnoreMissingTime: false
 minimumReleaseAgeExclude:


### PR DESCRIPTION


## Motivation

On https://github.com/facebook/docusaurus/pull/12239 CI logs, we can see that Dependabot opens PRs a few hours too early, and pnpm release cooldown config rejects it:


```
  [ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification:
    picomatch@4.0.5 was published at 2026-07-02T16:47:23.026Z, within the minimumReleaseAge cutoff (2026-07-02T10:17:23.421Z)
```

It seems that a 7-day cooldown for Dependabot doesn't mean exactly the same thing as a `minimumReleaseAge: 10080 # 7 days in minutes` from the pnpm config. For that reason, I'm adding an extra day to the Dependabot cooldown so that we are sure pnpm accepts the dependency upgrades

## Test Plan

CI
