### PR TITLE
docs: fix versionPersistence default value in theme config table

### DIFF
--- a/website/docs/api/themes/theme-configuration.mdx
+++ b/website/docs/api/themes/theme-configuration.mdx
@@ -170,7 +170,7 @@ Our [main themes](./overview.mdx) offer additional theme configuration options f
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| `versionPersistence` | `'localStorage' \| 'none'` | `undefined` | Defines the browser persistence of the preferred docs version. |
+| `versionPersistence` | `'localStorage' \| 'none'` | `'localStorage'` | Defines the browser persistence of the preferred docs version. |
 | `sidebar.hideable` | `boolean` | `false` | Show a hide button at the bottom of the sidebar. |
 | `sidebar.autoCollapseCategories` | `boolean` | `false` | Automatically collapse all sibling categories of the one you navigate to. |
 


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

The theme configuration API table documents the default for `docs.versionPersistence` as `undefined`, but the applied default is `'localStorage'`:

- `packages/docusaurus-theme-classic/src/options.ts` sets `DEFAULT_DOCS_CONFIG.versionPersistence = 'localStorage'`, and the Joi schema applies it via `.default(DEFAULT_DOCS_CONFIG.versionPersistence)`, so omitting the option yields `'localStorage'`.
- The `DocsVersionPersistence` type (`'localStorage' | 'none'`) does not include `undefined`, so `undefined` is not even a possible value.
- The **Example configuration** block on the same page already shows `versionPersistence: 'localStorage'` as the default, contradicting the table.

This one-cell fix aligns the documented default with the real applied default, consistent with how the sibling rows (`sidebar.hideable` → `false`, etc.) list their actual defaults.

## Test Plan

Documentation-only change to a single table cell. No code affected.

### Test links

- Updated doc page: `website/docs/api/themes/theme-configuration.mdx` — "themeConfig" → `docs.versionPersistence` row.

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/docs/api/themes/configuration

## Related issues/PRs

None.
