### PR TITLE
fix(ci): fix Netlify parallel git backfill not propagating cmd exit code

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -16,6 +16,7 @@ atrule
 autogenerating
 autohide
 Autolinks
+backgrounded
 Bartosz
 beforeinstallprompt
 Bhatt

--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -16,15 +16,18 @@ NODE_OPTIONS = "--max_old_space_size=8192"
 # Note, we run build:packages and git backfill in parallel to speed up builds
 # We run "git backfill" here to ensure the full Git history is available fast
 # See https://github.com/facebook/docusaurus/pull/11553
+# Only git backfill is backgrounded; build:packages runs in the foreground so
+# && catches its failure, and "wait $!" propagates the backfill's exit code
+# (bare "wait" always exits 0, which would swallow failures)
 
 [context.production]
-command = "(echo 'Build packages start' && pnpm --dir .. build:packages && echo 'Build packages end') & (echo 'Git backfill start' && git backfill && echo 'Git backfill end' ) & wait && pnpm netlify:build:production"
+command = "(echo 'Git backfill start' && git backfill && echo 'Git backfill end') & (echo 'Build packages start' && pnpm --dir .. build:packages && echo 'Build packages end') && wait $! && pnpm netlify:build:production"
 
 [context.branch-deploy]
-command = "(echo 'Build packages start' && pnpm --dir .. build:packages && echo 'Build packages end') & (echo 'Git backfill start' && git backfill && echo 'Git backfill end' ) & wait && pnpm netlify:build:branchDeploy"
+command = "(echo 'Git backfill start' && git backfill && echo 'Git backfill end') & (echo 'Build packages start' && pnpm --dir .. build:packages && echo 'Build packages end') && wait $! && pnpm netlify:build:branchDeploy"
 
 [context.deploy-preview]
-command = "(echo 'Build packages start' && pnpm --dir .. build:packages && echo 'Build packages end') & (echo 'Git backfill start' && git backfill && echo 'Git backfill end' ) & wait && pnpm netlify:build:deployPreview"
+command = "(echo 'Git backfill start' && git backfill && echo 'Git backfill end') & (echo 'Build packages start' && pnpm --dir .. build:packages && echo 'Build packages end') && wait $! && pnpm netlify:build:deployPreview"
 
 [[plugins]]
 package = "netlify-plugin-cache"


### PR DESCRIPTION


## Motivation

In https://github.com/facebook/docusaurus/pull/12205 Netlify deploy logs, I noticed that a `pnpm build:packages` failure doesn't stop the build fail-fast: it continues and fails later on `docusaurus build`

This is because `wait` always returns 0 exit code. Using `wait $!` exists with the awaited process exit code instead, correctly propagating the failure.


## Test Plan

CI

local:

```bash
echo START && (echo start1 && whatever && echo end1) & (echo start2 && echo 2 && echo end2) && wait $! && echo END
```

