### PR TITLE
fix(core): fix BaseUrlIssueBanner little security issue

### DIFF
--- a/packages/docusaurus/src/client/BaseUrlIssueBanner/index.tsx
+++ b/packages/docusaurus/src/client/BaseUrlIssueBanner/index.tsx
@@ -61,7 +61,7 @@ function insertBanner() {
   var suggestedBaseUrl = actualHomePagePath.substr(-1) === '/'
         ? actualHomePagePath
         : actualHomePagePath + '/';
-  suggestionContainer.innerHTML = suggestedBaseUrl;
+  suggestionContainer.textContent = suggestedBaseUrl;
 }
 `;
 }


### PR DESCRIPTION

## Motivation

The attack vector is quite limited, but still useful to do this change so that nobody can inject malicious content into the page by crafting/sharing a malicious URL

fix https://github.com/facebook/docusaurus/issues/12216



## Test Plan

CI + local test

Keeps working as before:

<img width="1354" height="592" alt="CleanShot 2026-07-09 at 16 47 56@2x" src="https://github.com/user-attachments/assets/99780aaa-027e-4c93-b6fe-d4ce003f1cdc" />
