### PR TITLE
fix(utils): getGitRepoRoot should convert MSYS/Git-Bash paths on Windows

### DIFF
--- a/packages/docusaurus-utils/src/vcs/__tests__/gitUtils.test.ts
+++ b/packages/docusaurus-utils/src/vcs/__tests__/gitUtils.test.ts
@@ -17,6 +17,7 @@ import {
   getGitLastUpdate,
   getGitCreation,
   getGitRepoRoot,
+  gitPosixDrivePathToWindows,
   getGitSuperProjectRoot,
   getGitSubmodulePaths,
   getGitAllRepoRoots,
@@ -451,6 +452,34 @@ describe('getGitRepoRoot', () => {
     await expect(getGitRepoRoot(cwd)).rejects.toThrow(
       /Couldn't find the git repository root directory/,
     );
+  });
+});
+
+describe('gitPosixDrivePathToWindows', () => {
+  it('converts Git-Bash / Cygwin drive paths to native Windows paths', () => {
+    expect(gitPosixDrivePathToWindows('/p/projects/my-repo')).toBe(
+      'P:\\projects\\my-repo',
+    );
+    expect(gitPosixDrivePathToWindows('/c/Users/me/website')).toBe(
+      'C:\\Users\\me\\website',
+    );
+  });
+
+  it('handles a drive root with no remaining segments', () => {
+    expect(gitPosixDrivePathToWindows('/d/')).toBe('D:\\');
+  });
+
+  it('leaves native Windows paths unchanged', () => {
+    expect(gitPosixDrivePathToWindows('C:/already/windows')).toBe(
+      'C:/already/windows',
+    );
+  });
+
+  it('leaves non-drive-mount POSIX paths unchanged', () => {
+    expect(gitPosixDrivePathToWindows('/home/user/repo')).toBe(
+      '/home/user/repo',
+    );
+    expect(gitPosixDrivePathToWindows('/usr/local/lib')).toBe('/usr/local/lib');
   });
 });
 

--- a/packages/docusaurus-utils/src/vcs/gitUtils.ts
+++ b/packages/docusaurus-utils/src/vcs/gitUtils.ts
@@ -275,6 +275,21 @@ export async function isGitInsideWorktree(cwd: string): Promise<boolean> {
   }
 }
 
+// Git (via Git Bash / Cygwin on Windows) can report POSIX-style drive
+// paths such as `/c/Users/me/repo` instead of `C:\Users\me\repo`. Node would
+// interpret the leading `/c/` as drive-relative and resolve it to `C:\c\...`,
+// which breaks `fs.realpath` with an ENOENT. Convert these to native Windows
+// paths first. Exported for testing; callers gate on `process.platform`.
+// See https://github.com/facebook/docusaurus/issues/11920
+export function gitPosixDrivePathToWindows(gitPath: string): string {
+  const posixDriveMatch = /^\/(?<drive>[a-z])\/(?<rest>.*)$/i.exec(gitPath);
+  if (!posixDriveMatch?.groups) {
+    return gitPath;
+  }
+  const {drive = '', rest = ''} = posixDriveMatch.groups;
+  return path.win32.join(`${drive.toUpperCase()}:\\`, rest);
+}
+
 export async function getGitRepoRoot(cwd: string): Promise<string> {
   const createErrorMessageBase = () => {
     return `Couldn't find the git repository root directory
@@ -303,7 +318,12 @@ The command returned exit code ${logger.code(result.exitCode)}: ${logger.subdue(
     );
   }
 
-  return fs.realpath.native(result.stdout.trim());
+  const repoRoot = result.stdout.trim();
+  return fs.realpath.native(
+    process.platform === 'win32'
+      ? gitPosixDrivePathToWindows(repoRoot)
+      : repoRoot,
+  );
 }
 
 // A Git "superproject" is a Git repository that contains submodules


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests to fully verify the new behavior.

## Motivation

Fixes #11920.

On Windows under Git Bash / MSYS, `git rev-parse --show-toplevel` returns a POSIX-style drive path such as `/p/projets/my-repo`. `getGitRepoRoot` (`packages/docusaurus-utils/src/vcs/gitUtils.ts`) passes that string directly to `fs.realpath.native`. Node interprets the leading `/p/` as relative to the current drive root and resolves it to `P:\p\projets\my-repo`, so `realpath` throws:

```
ENOENT: no such file or directory, realpath 'P:\p\projets\my-repo'
```

and the build fails. This is reachable through the eager Git VCS logic (`future.faster.gitEagerVcs`).

## Test Plan

Fix: convert MSYS/Git-Bash POSIX drive paths (`/c/...` → `C:\...`) to native Windows paths before resolving, via a small pure helper `gitPosixDrivePathToWindows`. It's applied in `getGitRepoRoot` only when `process.platform === 'win32'`, so real POSIX paths on macOS/Linux are untouched.

New unit tests in `gitUtils.test.ts` cover the helper:

- `/p/projets/my-repo` → `P:\projets\my-repo`, `/c/Users/me/website` → `C:\Users\me\website`
- drive root only: `/d/` → `D:\`
- native Windows paths (`C:/already/windows`) and non-drive-mount POSIX paths (`/home/user/repo`, `/usr/local/lib`) pass through unchanged

The existing `getGitRepoRoot` suite still passes (44 tests total). `pnpm build` (tsc) and ESLint are clean.

### Test links

n/a — internal Git path handling, no UI change.

Deploy preview: n/a
