### PR TITLE
fix(theme-classic): improve code block Copy/word-wrap button contrast (#10821)

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Buttons/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Buttons/styles.module.css
@@ -17,9 +17,11 @@
 .buttonGroup button {
   display: flex;
   align-items: center;
-  background: var(--prism-background-color);
+  /* Opaque, neutral background so the buttons stand out against the code
+     instead of blending into it (see #10821). */
+  background: var(--ifm-color-emphasis-200);
   color: var(--prism-color);
-  border: 1px solid var(--ifm-color-emphasis-300);
+  border: 1px solid var(--ifm-color-emphasis-400);
   border-radius: var(--ifm-global-radius);
   padding: 0.4rem;
   line-height: 0;
@@ -30,8 +32,10 @@
 .buttonGroup button:focus-visible,
 .buttonGroup button:hover {
   opacity: 1 !important;
+  background: var(--ifm-color-emphasis-300);
 }
 
 :global(.theme-code-block:hover) .buttonGroup button {
-  opacity: 0.4;
+  /* Fully opaque on hover so code no longer shows through the buttons. */
+  opacity: 1;
 }


### PR DESCRIPTION
## Motivation

The "Copy" and "Toggle word wrap" buttons on code blocks are hard to see in the default classic theme. On hover they render at `opacity: 0.4` over a background that matches the code area, so the code behind them shows through and the icons nearly vanish, especially over busy lines. That's #10821, where the low contrast was confirmed and an opaque background was suggested.

## Fix

In `CodeBlock/Buttons/styles.module.css`:

- The buttons now use an opaque, neutral background (`--ifm-color-emphasis-200`) instead of the semi-transparent code-area color, so they read as a distinct chip instead of blending in.
- A slightly stronger border (`--ifm-color-emphasis-400`) for a clearer edge.
- On code-block hover the buttons are fully opaque (`opacity: 1`) instead of `0.4`, so the code no longer shows through them.
- Direct hover/focus darkens the button to `--ifm-color-emphasis-300` for clearer feedback.

It all uses existing Infima tokens, so it adapts to light and dark themes and to custom theme colors without any hardcoded values. The buttons are still hidden at rest and only appear when you hover the code block, so nothing changes except that they are now legible.

Closes #10821
