### PR TITLE
Remove superfluous role=region from skip-to-content link

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/skipToContentUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/skipToContentUtils.tsx
@@ -94,10 +94,7 @@ export function SkipToContentLink(props: SkipToContentLinkProps): ReactNode {
   const linkLabel = props.children ?? DefaultSkipToContentLabel;
   const {containerRef, onClick} = useSkipToContent();
   return (
-    <div
-      ref={containerRef}
-      role="region"
-      aria-label={DefaultSkipToContentLabel}>
+    <div ref={containerRef}>
       {/* eslint-disable-next-line @docusaurus/no-html-links */}
       <a
         {...props}


### PR DESCRIPTION
## Summary

Fixes #8418

Removes the extra `role="region"` / `aria-label` wrapper around the skip-to-content link.

That wrapper was added in #6252 to satisfy automated accessibility scanners, but it hurts real screen reader navigation: NVDA announces *"skip to main content region, link skip to main content, out of region"* instead of just *"link skip to main content"*. The reporter in #8418 explains this better than I can — the region doubles the speech and inserts a line break in the rotor view.

The skip link itself is unchanged. Only the redundant landmark wrapper is removed.

## Test plan

**Preview:** https://deploy-preview-12280--docusaurus-2.netlify.app/docs/introduction

**What you need:** Chrome (or Firefox), a keyboard, and a screen reader. I used NVDA on Windows; VoiceOver on macOS is fine too.

### 1. Keyboard — skip link still works

1. Open the preview URL above.
2. Click once on the page (browsers often ignore Tab until the page has focus).
3. Press **Tab** once.
4. A **"Skip to main content"** link should appear at the top-left.
5. Press **Enter**.
6. Focus should jump into the main doc content (page heading / first paragraph), not stay in the navbar.

### 2. NVDA — this is the fix

Install NVDA (free): https://www.nvaccess.org/download/

1. Start NVDA, open Chrome, load the preview URL.
2. Press **Tab** once to focus the skip link.
3. Listen to the announcement.

**On current docusaurus.io (without this PR):** NVDA says something like *"skip to main content region … link skip to main content … out of region"* — the extra words come from `role="region"` on the wrapper `<div>`.

**With this PR:** NVDA should announce only the link, e.g. *"Skip to main content, link"* — no region enter/exit chatter.

### 3. VoiceOver (macOS alternative)

1. Safari → preview URL.
2. Press **VO + Right Arrow** (or Tab) until focus reaches the skip link.
3. VoiceOver should read the link without wrapping it in a separate region announcement.

### 4. axe DevTools (optional sanity check)

1. Install [axe DevTools](https://www.deque.com/axe/devtools/) for Chrome.
2. Open DevTools → **axe DevTools** → **Scan ALL of my page**.

This change may still trigger informational "region" notices from automated rules — that is expected. The goal here is the screen reader behavior described in #8418, not passing every axe informational hint. Confirm there are no new **errors** vs. scanning the same page on main.

### What proves the fix

If step 2 (or 3) shows the skip link announced **without** a dedicated region label, the change does what #8418 asks for.