### PR TITLE
fix(mermaid): Mermaid lazy render when tab becomes visible

### DIFF
--- a/packages/docusaurus-theme-mermaid/src/client/index.ts
+++ b/packages/docusaurus-theme-mermaid/src/client/index.ts
@@ -34,7 +34,8 @@ export function useMermaidConfig(): MermaidConfig {
 
 // Random client-only id, we don't care much but mermaid want an id so...
 function useMermaidId(): string {
-  return useId();
+  // Mermaid marker IDs must be unique per diagram; sanitize React useId().
+  return useId().replace(/[^a-zA-Z0-9_-]/g, '');
 }
 
 async function renderMermaid({
@@ -81,9 +82,11 @@ async function renderMermaid({
 export function useMermaidRenderResult({
   text,
   config: providedConfig,
+  enabled = true,
 }: {
   text: string;
   config?: MermaidConfig;
+  enabled?: boolean;
 }): RenderResult | null {
   const [result, setResult] = useState<RenderResult | null>(null);
   const id = useMermaidId();
@@ -96,6 +99,9 @@ export function useMermaidRenderResult({
   const config = providedConfig ?? defaultMermaidConfig;
 
   useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
     renderMermaid({id, text, config})
       // TODO maybe try to use Suspense here and throw the promise?
       // See also https://github.com/pmndrs/suspend-react
@@ -107,7 +113,7 @@ export function useMermaidRenderResult({
           throw e;
         });
       });
-  }, [id, text, config]);
+  }, [id, text, config, enabled]);
 
   return result;
 }

--- a/packages/docusaurus-theme-mermaid/src/theme/Mermaid/index.tsx
+++ b/packages/docusaurus-theme-mermaid/src/theme/Mermaid/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useEffect, useRef, type ReactNode} from 'react';
+import React, {useEffect, useRef, useState, type ReactNode} from 'react';
 import ErrorBoundary from '@docusaurus/ErrorBoundary';
 import {ErrorBoundaryErrorMessageFallback} from '@docusaurus/theme-common';
 import {
@@ -39,11 +39,32 @@ function MermaidRenderResult({
 }
 
 function MermaidRenderer({value}: Props): ReactNode {
-  const renderResult = useMermaidRenderResult({text: value});
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) {
+      return undefined;
+    }
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        setIsVisible(true);
+      }
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  const renderResult = useMermaidRenderResult({text: value, enabled: isVisible});
   if (renderResult === null) {
-    return null;
+    return <div ref={containerRef} />;
   }
-  return <MermaidRenderResult renderResult={renderResult} />;
+  return (
+    <div ref={containerRef}>
+      <MermaidRenderResult renderResult={renderResult} />
+    </div>
+  );
 }
 
 export default function Mermaid(props: Props): ReactNode {


### PR DESCRIPTION
## Summary

Fixes #8357

Mermaid diagrams inside inactive tab panels render with missing arrow markers. The root cause is rendering while the SVG is hidden (zero-size container), not a Mermaid syntax issue.

**Note:** @slorber's review pointed out that the IntersectionObserver approach here is too narrow (tabs only) and does not address concurrent renders of multiple visible diagrams ([#8357 comment](https://github.com/facebook/docusaurus/issues/8357#issuecomment-1582229887)). I am keeping this PR open while I rework the approach. The test plan below documents how to reproduce the original bug and how I verified the tab case locally.

## Reproducing the bug (on main)

**Known-good reference on docusaurus.io:** https://docusaurus.io/tests/pages/diagrams#mermaid-in-tabs

**To reproduce in a fresh site:**

1. Enable `@docusaurus/theme-mermaid` in `docusaurus.config.js`.
2. Create a docs page with non-lazy tabs and a diagram in each tab:

````mdx
import Tabs from '@theme/Tabs';
import TabItem from '@theme/TabItem';

<Tabs>
  <TabItem value="a" label="Tab A">

```mermaid
graph LR
  a --> c(10)
  b --> c(10)
```

  </TabItem>
  <TabItem value="b" label="Tab B" default>

```mermaid
graph LR
  d --> z(42)
  e --> z(42)
```

  </TabItem>
</Tabs>
````

3. Run `npm start` and open the page in **Chrome**.
4. Open **Tab B** (or whichever tab was hidden on first load).
5. **Bug:** arrow heads on the edges are missing or broken. Tab A (visible on first paint) looks fine.

### What to look for in DevTools

1. Right-click a broken arrow → **Inspect**.
2. In the SVG, look for `<marker>` definitions in `<defs>` and `marker-end` attributes on `<path>` elements.
3. On the broken tab, markers are often missing or reference IDs that were not defined because Mermaid ran while the container had `display: none` / zero size.

## Test plan for this PR's approach (tab visibility)

**Preview:** deploy preview for PR #12281 (Netlify bot comment on the PR)

1. Open the preview at the same mermaid-in-tabs test page (or the repro MDX above if added to the preview build).
2. Load the page with **Tab B** hidden, then click **Tab B**.
3. **Expected with fix:** both tabs show intact arrow heads on all edges.
4. Compare side-by-side with main on the same page.

### Side-by-side diagrams (concurrency case — known gap)

@slorber noted two diagrams entering the viewport at once can still race. To check that case:

1. Put two Mermaid `graph LR` diagrams in the same tab, one above the other (no tabs).
2. Reload the page and scroll so both enter the viewport in the same frame.
3. Inspect both SVGs for arrow markers.

I have **not** claimed this PR fixes that concurrency case — only the hidden-tab render timing.

## Status

- [ ] Rework to a generalized fix per maintainer feedback
- [ ] Remove `useId()` sanitization unless a concrete repro is shown (per inline review)
