### PR TITLE
docs: add @agentreadyweb/docusaurus-plugin to community AI/Agents plugins

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -1,6 +1,7 @@
 # Project Words - DO NOT TOUCH - This is updated through CI
 abernathyca
 Adriaan
+agentreadyweb
 alexbdebrie
 Alexey
 algoliasearch

--- a/website/community/2-resources.mdx
+++ b/website/community/2-resources.mdx
@@ -59,6 +59,7 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [docusaurus-plugin-llms](https://github.com/rachfop/docusaurus-plugin-llms) - Generates `llms.txt` and `llms-full.txt` files from your docs, following the [llmstxt.org](https://llmstxt.org/) standard.
 - [docusaurus-plugin-llms-txt](https://github.com/din0s/docusaurus-plugin-llms-txt) - Generates a concatenated Markdown `llms.txt` file from your documentation.
 - [expose-markdown-docusaurus-plugin](https://github.com/FlyNumber/markdown_docusaurus_plugin) - Exposes your /docs Markdown files as raw `.md` URLs (for LLM consumption).
+- [@agentreadyweb/docusaurus-plugin](https://github.com/AshutoshRaj97/agentready-mcp/tree/main/docusaurus-plugin) - Auto-indexes your docs in [AgentReady](https://www.agentready.it.com) after every build, making them instantly queryable by AI agents (Claude, Cursor, Windsurf) via MCP with cited answers.
 
 ### Features {/* #features */}
 


### PR DESCRIPTION
## What this adds

Adds `@agentreadyweb/docusaurus-plugin` to the **AI / Agents** section of the community plugins page.

**npm:** https://www.npmjs.com/package/@agentreadyweb/docusaurus-plugin  
**Source:** https://github.com/AshutoshRaj97/agentready-mcp/tree/main/docusaurus-plugin

## What it does

The plugin hooks into Docusaurus's `postBuild` lifecycle and automatically submits the docs site to [AgentReady](https://www.agentready.it.com) for indexing after every build. Once indexed, the docs are instantly queryable by AI agents (Claude, Cursor, Windsurf, and any MCP client) with cited, multi-page answers — no extra config needed by end users.

```js
// docusaurus.config.js
plugins: [
  ['@agentreadyweb/docusaurus-plugin', { domain: 'docs.yoursite.com' }]
]
```

After each `docusaurus build`:
```
[AgentReady] ✓ Indexed! Agents can now query your docs at:
  MCP:  https://www.agentready.it.com/api/mcp
```

## Why it fits the AI/Agents section

- Complements the existing `llms.txt` generators (static discoverability) by adding live queryability via MCP
- Zero config for end users — AI agents query through AgentReady's hosted MCP server
- Different from search plugins: answers are generated with RAG + source citations, not keyword results