### PR TITLE
fix(theme): improve docs sidebar accessibility

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocRoot/Layout/Sidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocRoot/Layout/Sidebar/index.tsx
@@ -49,7 +49,7 @@ export default function DocRootLayoutSidebar({
   }, [setHiddenSidebarContainer, hiddenSidebar]);
 
   return (
-    <aside
+    <div
       className={clsx(
         ThemeClassNames.docs.docSidebarContainer,
         styles.docSidebarContainer,
@@ -79,6 +79,6 @@ export default function DocRootLayoutSidebar({
           {hiddenSidebar && <ExpandButton toggleSidebar={toggleSidebar} />}
         </div>
       </ResetOnSidebarChange>
-    </aside>
+    </div>
   );
 }

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/Content/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/Content/index.tsx
@@ -12,7 +12,6 @@ import {
   useAnnouncementBar,
   useScrollPosition,
 } from '@docusaurus/theme-common/internal';
-import {translate} from '@docusaurus/Translate';
 import DocSidebarItems from '@theme/DocSidebarItems';
 import type {Props} from '@theme/DocSidebar/Desktop/Content';
 
@@ -41,12 +40,7 @@ export default function DocSidebarDesktopContent({
   const showAnnouncementBar = useShowAnnouncementBar();
 
   return (
-    <nav
-      aria-label={translate({
-        id: 'theme.docs.sidebar.navAriaLabel',
-        message: 'Docs sidebar',
-        description: 'The ARIA label for the sidebar navigation',
-      })}
+    <div
       className={clsx(
         'menu thin-scrollbar',
         styles.menu,
@@ -56,6 +50,6 @@ export default function DocSidebarDesktopContent({
       <ul className={clsx(ThemeClassNames.docs.docSidebarMenu, 'menu__list')}>
         <DocSidebarItems items={sidebar} activePath={path} level={1} />
       </ul>
-    </nav>
+    </div>
   );
 }

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/index.tsx
@@ -5,9 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {useState} from 'react';
 import clsx from 'clsx';
 import {useThemeConfig} from '@docusaurus/theme-common';
+import {useScrollPosition} from '@docusaurus/theme-common/internal';
+import {translate} from '@docusaurus/Translate';
 import Logo from '@theme/Logo';
 import CollapseButton from '@theme/DocSidebar/Desktop/CollapseButton';
 import Content from '@theme/DocSidebar/Desktop/Content';
@@ -22,18 +24,49 @@ function DocSidebarDesktop({path, sidebar, onCollapse, isHidden}: Props) {
       sidebar: {hideable},
     },
   } = useThemeConfig();
+  const [isNavbarVisible, setIsNavbarVisible] = useState(hideOnScroll);
+
+  useScrollPosition(
+    ({scrollY}) => {
+      if (hideOnScroll) {
+        setIsNavbarVisible(scrollY === 0);
+      }
+    },
+    [hideOnScroll],
+  );
 
   return (
-    <div
+    <nav
+      aria-label={translate({
+        id: 'theme.docs.sidebar.navAriaLabel',
+        message: 'Docs sidebar',
+        description: 'The ARIA label for the sidebar navigation',
+      })}
       className={clsx(
         styles.sidebar,
         hideOnScroll && styles.sidebarWithHideableNavbar,
         isHidden && styles.sidebarHidden,
       )}>
-      {hideOnScroll && <Logo tabIndex={-1} className={styles.sidebarLogo} />}
+      {hideOnScroll && (
+        <Logo
+          tabIndex={-1}
+          className={styles.sidebarLogo}
+          aria-hidden={isNavbarVisible || undefined}
+          aria-label={
+            isNavbarVisible
+              ? undefined
+              : translate({
+                  id: 'theme.docs.sidebar.logoHomeAriaLabel',
+                  message: 'Home page',
+                  description:
+                    'The ARIA label for the sidebar logo home link',
+                })
+          }
+        />
+      )}
       <Content path={path} sidebar={sidebar} />
       {hideable && <CollapseButton onClick={onCollapse} />}
-    </div>
+    </nav>
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes #8429 (landmark structure only)

The docs sidebar currently nests landmarks: an outer `<aside>` (complementary) wraps an inner `<nav aria-label="Docs sidebar">`. NVDA announces both before you reach any doc link — *"complementary landmark … docs sidebar navigation landmark …"*.

This PR:

- Replaces the outer `<aside>` with a plain `<div>` container (no complementary landmark)
- Moves the single `<nav aria-label="Docs sidebar">` to wrap the logo, menu, and collapse button together

Issue #8429 also mentions hiding the duplicate sidebar logo from screen readers when `navbar.hideOnScroll` is on. I left that out of this PR on purpose — I will open a separate follow-up for it so reviewers can evaluate one concern at a time.

## Test plan

**Preview:** https://deploy-preview-12283--docusaurus-2.netlify.app/docs/introduction

**Compare against main:** https://docusaurus.io/docs/introduction

**Tools:** Chrome, NVDA (Windows) or VoiceOver (macOS), DevTools

### 1. Inspect the DOM (Chrome DevTools)

1. Open the **deploy preview** docs page.
2. Right-click the left doc sidebar → **Inspect**.
3. Walk up the tree from a sidebar menu link.

**Expected after this PR:**

```html
<div class="...docSidebarContainer...">
  <div class="...sidebarViewport...">
    <nav aria-label="Docs sidebar" class="...sidebar...">
      <!-- logo (if hideOnScroll), menu <ul>, collapse button -->
    </nav>
  </div>
</div>
```

**On main today:**

```html
<aside class="...docSidebarContainer...">
  ...
    <div class="...sidebar...">
      <nav aria-label="Docs sidebar"> ... </nav>
    </div>
  ...
</aside>
```

The point: one `navigation` landmark for the sidebar, not `complementary` + `navigation`.

### 2. NVDA landmark list

1. Install NVDA: https://www.nvaccess.org/download/
2. Open the preview URL in Chrome with NVDA running.
3. Press **NVDA + F7** → **Landmarks** tab.

| Check | Main (docusaurus.io) | This PR preview |
|-------|----------------------|-----------------|
| Complementary landmark for docs sidebar | Yes (`<aside>`) | No |
| Navigation landmark "Docs sidebar" | Yes (nested inside complementary) | Yes (standalone) |

### 3. Keyboard navigation still works

1. Press **Tab** repeatedly through the sidebar links.
2. All doc links should be reachable in the same order as before.
3. If your site config has a collapsible sidebar, the collapse button should still work.

### 4. VoiceOver spot check (macOS)

1. Safari → preview URL.
2. **VO + U** → **Landmarks** rotor.
3. Confirm there is a **Docs sidebar** navigation landmark and no extra complementary landmark for the sidebar column.

### 5. axe DevTools (optional)

Scan the page with [axe DevTools](https://www.deque.com/axe/devtools/). Removing a redundant `<aside>` should not introduce new violations. Landmark-related informational notices are fine — compare against main rather than expecting zero notices.

### What proves the fix

Steps 1–2 show the sidebar is exposed as **one** navigation landmark instead of complementary + navigation stacked together. That matches the structure requested in #8429.
