### PR TITLE
docs: update project structure listing to match current classic template

### DIFF
--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -70,27 +70,31 @@ Assuming you chose the classic template and named your site `my-website`, you wi
 ```bash
 my-website
 ├── blog
-│   ├── 2019-05-28-hola.mdx
-│   ├── 2019-05-29-hello-world.mdx
-│   └── 2020-05-30-welcome.mdx
+│   ├── 2019-05-28-first-blog-post.mdx
+│   ├── 2019-05-29-long-blog-post.mdx
+│   ├── 2021-08-01-mdx-blog-post.mdx
+│   ├── 2021-08-26-welcome
+│   ├── authors.yml
+│   └── tags.yml
 ├── docs
-│   ├── doc1.mdx
-│   ├── doc2.mdx
-│   ├── doc3.mdx
-│   └── mdx.mdx
+│   ├── intro.mdx
+│   ├── tutorial-basics
+│   └── tutorial-extras
 ├── src
+│   ├── components
 │   ├── css
 │   │   └── custom.css
 │   └── pages
-│       ├── styles.module.css
-│       └── index.js
+│       ├── index.js
+│       ├── index.module.css
+│       └── markdown-page.mdx
 ├── static
 │   └── img
+├── .gitignore
 ├── docusaurus.config.js
 ├── package.json
 ├── README.md
-├── sidebars.js
-└── yarn.lock
+└── sidebars.js
 ```
 
 ### Project structure rundown {/* #project-structure-rundown */}


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

I followed the [installation guide](https://docusaurus.io/docs/next/installation) as a first-time user would. The [Project structure](https://docusaurus.io/docs/next/installation#project-structure) section says *"you will see the following files generated"*, but the tree it shows (`docs/doc1.mdx`, `blog/2019-05-28-hola.mdx`, `yarn.lock`, …) is from the early v2-alpha template and hasn't matched the output of `npx create-docusaurus@latest my-website classic` since the `intro` + `tutorial-basics` template shipped in 2021.

**Who this affects:** brand-new users, at the single most confidence-sensitive moment of adoption. You scaffold a site, open the folder next to the docs, and *none* of the listed files exist — while files the docs don't mention (`docs/tutorial-basics/`, `blog/authors.yml`, `src/components/`) do. The natural first reaction is "did I run the wrong command / wrong template?", not "the docs are stale". Since this is the page CONTRIBUTING.md points newcomers at first, the mismatch also undercuts trust in the rest of the guide.

This PR updates the tree to what the classic (JavaScript) template actually generates today. Notable corrections beyond filenames:

- `yarn.lock` removed — the scaffold itself writes no lockfile; which one appears after install depends on the package manager used.
- `.gitignore`, `blog/authors.yml`, `blog/tags.yml`, `src/components/`, and the `docs/tutorial-*` folders added — these are generated and previously undocumented here.
- Depth kept close to the original listing so the "Project structure rundown" below (which is still accurate) continues to line up.

The same stale tree exists in every `versioned_docs/version-*/installation.mdx` back to 2.x. Per the CONTRIBUTING guidance on not editing versioned docs, I've left those untouched — happy to also patch the latest version's copy in this PR if you'd prefer, since that's the page most visitors actually read.

## Test Plan

- Ran `npx create-docusaurus@latest my-website classic` (create-docusaurus / `@docusaurus/core` 3.10.2, Node 22) and compared `find my-website -type f` output against the new tree — matches.
- Confirmed the current `main` templates (`packages/create-docusaurus/templates/classic` + `shared`) generate the same set of files, so the listing is correct for `next` as well.
- `npm install` + `npm run build` on the scaffolded site complete successfully (verifying the surrounding sections of the page still hold).
- `oxfmt --list-different website/docs/installation.mdx` reports no issues.

### Test links

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/docs/next/installation#project-structure
