### PR TITLE
docs: add docusaurus-plugin-rangefind to community search resources

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -236,6 +236,7 @@ Quickwit
 quickwit
 rachelnabors
 Ramón
+rangefind
 reactjs
 rearchitecture
 Recma

--- a/website/community/2-resources.mdx
+++ b/website/community/2-resources.mdx
@@ -45,6 +45,7 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [@orama/plugin-docusaurus-v3](https://github.com/askorama/orama/tree/main/packages/plugin-docusaurus-v3) - [Orama](https://askorama.ai/) plugin for Docusaurus v3
 - [@getcanary/docusaurus-theme-search-pagefind](https://getcanary.dev/docs/integrations/docusaurus.html) - Create [Pagefind](https://pagefind.app/) index and use [Canary](https://github.com/fastrepl/canary) as UI primitives.
 - [docusaurus-biel](https://github.com/TechDocsStudio/docusaurus-biel) - Docusaurus plugin to add an AI chatbot and AI search with source-cited answers, powered by [Biel.ai](https://biel.ai)
+- [docusaurus-plugin-rangefind](https://github.com/xjodoin/rangefind/tree/main/packages/docusaurus-plugin-rangefind) - Local/offline search over a static [rangefind](https://rangefind.dev) index queried with HTTP range requests — BM25F relevance, typo correction, autocomplete; no search server
 
 ### Integrations {/* #integrations */}
 


### PR DESCRIPTION
## Motivation

Adds [docusaurus-plugin-rangefind](https://www.npmjs.com/package/docusaurus-plugin-rangefind) to the Search section of community resources — a local/offline search option in the same family as the lunr/local-search entries.

The plugin indexes the built site (postBuild) into a [rangefind](https://rangefind.dev) static index and injects a search widget. Distinctive property: the browser fetches only the byte ranges a query needs via HTTP range requests, so relevance-ranked search (BM25F, typo correction, search-as-you-type) works on large docs sites from any static host with no search server or SaaS.

MIT licensed, published on npm with provenance, tested end-to-end against a real Docusaurus build in CI.

## Test plan

Docs-only change to `website/community/2-resources.mdx`, matching the existing entry format.