### PR TITLE
fix(ci): fix TS6 upgrade + prepare for TS7

### DIFF
--- a/packages/create-docusaurus/bin/index.js
+++ b/packages/create-docusaurus/bin/index.js
@@ -15,7 +15,7 @@ import {logger} from '@docusaurus/logger';
 import semver from 'semver';
 import {program} from 'commander';
 
-const packageJson = /** @type {import("../package.json")} */ (
+const packageJson = /** @type {typeof import("../package.json")} */ (
   createRequire(import.meta.url)('../package.json')
 );
 const requiredVersion = packageJson.engines.node;

--- a/packages/docusaurus/bin/beforeCli.mjs
+++ b/packages/docusaurus/bin/beforeCli.mjs
@@ -17,7 +17,7 @@ import updateNotifier from 'update-notifier';
 import boxen from 'boxen';
 import {DOCUSAURUS_VERSION} from '@docusaurus/utils';
 
-const packageJson = /** @type {import("../package.json")} */ (
+const packageJson = /** @type {typeof import("../package.json")} */ (
   createRequire(import.meta.url)('../package.json')
 );
 /** @type {Record<string, any>} */

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -46,7 +46,6 @@
     /* Handled by ESLint */
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "importsNotUsedAsValues": "remove",
 
     /* Module Resolution */
     "moduleResolution": "NodeNext",

--- a/website/docs/typescript-support.mdx
+++ b/website/docs/typescript-support.mdx
@@ -6,7 +6,7 @@ description: Docusaurus is written in TypeScript and provides first-class TypeSc
 
 Docusaurus is written in TypeScript and provides first-class TypeScript support.
 
-The minimum required version is **TypeScript 5.1**.
+The minimum required version is **TypeScript 6.0**.
 
 ## Initialization {/* #initialization */}
 
@@ -31,9 +31,7 @@ Then add `tsconfig.json` to your project root with the following content:
 ```json title="tsconfig.json"
 {
   "extends": "@docusaurus/tsconfig",
-  "compilerOptions": {
-    "baseUrl": "."
-  }
+  "compilerOptions": {}
 }
 ```
 
@@ -59,7 +57,6 @@ Alternatively, add the package to the `types` compiler option of your `tsconfig.
 {
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
-    "baseUrl": ".",
     // highlight-next-line
     "types": ["@docusaurus/theme-live-codeblock"]
   }

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -3,7 +3,6 @@
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
     "lib": ["DOM", "ESNext"],
-    "baseUrl": ".",
     "resolveJsonModule": true,
     "allowArbitraryExtensions": true,
 

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "lib": ["DOM", "ESNext"],
     "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
     "resolveJsonModule": true,
     "allowArbitraryExtensions": true,
 
@@ -28,7 +27,6 @@
     "useUnknownInCatchVariables": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "importsNotUsedAsValues": "remove",
 
     // This is important. We run `pnpm tsc` in website so we can catch issues
     // with our declaration files (mostly names that are forgotten to be


### PR DESCRIPTION


## Motivation

After upgrading to TS6, I forgot to reactivate deprecation warnings, and remove `baseUrl` (deprecated): https://github.com/facebook/docusaurus/pull/11915

Now that TS7 is out, we also want to upgrade to it, however it's likely blocked due to TS-ESLint until v7.1 is out: https://github.com/facebook/docusaurus/pull/12264

Even if we keep our monorepo on TS6 for now, our CI still type-checks Docusaurus website against TS7 (without running lints), so this PR also adjust our code so that it can pass typechecks on both TS6 + TS7, reducing the scope of the TS7 upgrade PR

## Test Plan

CI
