### PR TITLE
docs: add docusaurus-theme-zoom-image to community resources

### DIFF
--- a/website/community/2-resources.mdx
+++ b/website/community/2-resources.mdx
@@ -76,6 +76,7 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [docusaurus-prince-pdf](https://github.com/signcl/docusaurus-prince-pdf) - Generate PDF with PrinceXML for better font subsetting and ToC features. Support Docusaurus sites
 - [redocusaurus](https://github.com/rohit-gohri/redocusaurus) - A Docusaurus preset for integrating OpenAPI documentation into your docs with [Redoc](https://github.com/redocly/redoc)
 - [plugin-image-zoom](https://github.com/flexanalytics/plugin-image-zoom) - An Image Zoom plugin for Docusaurus
+- [docusaurus-theme-zoom-image](https://github.com/rmaacario/docusaurus-theme-zoom-image) - Zero-dependency theme that makes every Markdown image zoomable: hover magnifier badge + full-screen lightbox
 - [docusaurus-plugin-typedoc](https://github.com/tgreyuk/typedoc-plugin-markdown/tree/master/packages/docusaurus-plugin-typedoc) - A Docusaurus plugin to build documentation with [TypeDoc](https://typedoc.org/)
 - [docusaurus-openapi-docs](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs) - A Docusaurus plugin and theme for generating interactive OpenAPI docs
 - [docusaurus-post-generator](https://github.com/moojing/docusaurus-post-generator) - A command line tool for user to add a blog/doc file quickly by command like `yarn gen-post new [template] [post_name]`.


### PR DESCRIPTION
## Summary

Adds docusaurus-theme-zoom-image to the community resources feature list.

The zero-dependency theme makes Markdown images zoomable with a hover magnifier badge and full-screen lightbox.

## Test plan

- Verified the MDX diff with git diff --check.