### PR TITLE
fix(theme-classic): prevent Firefox clipping sidebar label descenders

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Category/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Category/styles.module.css
@@ -23,4 +23,6 @@ TODO merge this logic back in Infima?
   line-clamp: 2;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
+  /* Firefox on Windows clips glyph descenders (g/p/q/y) with line-clamp */
+  padding-bottom: 1px;
 }

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Link/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Link/styles.module.css
@@ -15,4 +15,6 @@
   line-clamp: 2;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
+  /* Firefox on Windows clips glyph descenders (g/p/q/y) with line-clamp */
+  padding-bottom: 1px;
 }


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Fixes Firefox-on-Windows clipping of glyph descenders (`g`, `p`, `q`, `y`) in documentation sidebar link and category labels.

Those labels use `line-clamp: 2` with `overflow: hidden` and Infima's `line-height: 1.25`. Firefox paints the `-webkit-box` clip boundary differently from Chromium, so descenders get cut off. Chromium and Firefox-on-macOS are fine.

## Test Plan

- Open docs sidebar in Firefox on Windows and confirm descenders on labels like "Getting started" / "Configuring" are no longer clipped
- Confirm two-line truncation for long labels still works
- Spot-check Chromium to confirm no visual regression

### Test links

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

Affected styles:
- `packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Link/styles.module.css`
- `packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Category/styles.module.css`

## Related issues/PRs

Closes #12299
