### PR TITLE
docs: add docusaurus-plugin-dhub to community integrations

### DIFF
--- a/website/community/2-resources.mdx
+++ b/website/community/2-resources.mdx
@@ -53,6 +53,7 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [posthog-docusaurus](https://github.com/PostHog/posthog-docusaurus) - Integrate [PostHog](https://posthog.com/) product analytics with Docusaurus
 - [docusaurus-plugin-moesif](https://github.com/Moesif/docusaurus-plugin-moesif) - Adds [Moesif API Analytics](https://www.moesif.com/) to track user behavior and pinpoint where developers drop off in your activation funnel.
 - [docusaurus-plugin-yandex-metrica](https://github.com/sgromkov/docusaurus-plugin-yandex-metrica) - Adds [Yandex Metrika](https://metrika.yandex.ru/) counter for evaluating site traffic and analyzing user behavior.
+- [docusaurus-plugin-dhub](https://github.com/dhub-dev/docusaurus-plugin-dhub) - Adds edit links that open a page's source file in the [Dhub](https://dhub.dev/docusaurus) visual MDX editor, and emits a `dhub.json` manifest mapping every route to its source file.
 
 ### AI / Agents {/* #ai-agents */}
 


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).

## Motivation

Adds `docusaurus-plugin-dhub` to the community plugins → Integrations list.

The plugin adds edit links that open a page's source file in the Dhub visual MDX editor, and emits a `dhub.json` manifest mapping every route to its repo-relative source file (docs including versioned docs, blog posts, and pages). MIT-licensed, published on npm, supports Docusaurus 3.5+ with the classic theme.

## Test Plan

Docs-only change — a single entry added to `website/community/2-resources.mdx`. Ran the website locally and confirmed the entry renders in the Integrations section with working links.

### Test links

Deploy preview: https://deploy-preview-12302--docusaurus-2.netlify.app/community/resources#integrations