### PR TITLE
docs: add @deskcrew/docusaurus-plugin to community resources

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -41,6 +41,7 @@
     "admin/scripts",
     "website/src/data/users.tsx",
     "website/src/data/tweets.tsx",
+    "website/community/2-resources.mdx",
     "website/docusaurus.config.localized.json",
     "website/_dogfooding/_pages tests/diagrams.mdx",
     "*.xyz",

--- a/project-words.txt
+++ b/project-words.txt
@@ -1,7 +1,6 @@
 # Project Words - DO NOT TOUCH - This is updated through CI
 abernathyca
 Adriaan
-agentreadyweb
 alexbdebrie
 Alexey
 algoliasearch
@@ -70,7 +69,6 @@ Dogfooding
 dogfooding
 Dyte
 dyte
-easyops
 Endi
 endi
 Endi's
@@ -87,7 +85,6 @@ Français
 froms
 gabrielcsapo
 gclid
-getcanary
 Gifs
 gingergeek
 gingergeekuk
@@ -132,8 +129,6 @@ Lifecycles
 lifecycles
 lightningcss
 Linkify
-llms
-llmstxt
 longlonglonglonglonglonglonglonglonglonglonglong
 Lorber
 lorber
@@ -144,8 +139,6 @@ lunrjs
 Marcey
 marcey
 Marcey's
-Markprompt
-markprompt
 Massoud
 mathjax
 maxlynch
@@ -156,14 +149,10 @@ MDXAST
 MDXHAST
 Mdxjs
 mdxjs
-Meilisearch
-meilisearch
 merveilleuse
 metadatum
 Metastring
 metastring
-metrica
-Metrika
 microdata
 Milnes
 Mindmap
@@ -172,8 +161,6 @@ mkdirs
 mkdn
 mkdocs
 mkdown
-Moesif
-moesif
 Nabors
 Nakagawa
 nand
@@ -190,8 +177,6 @@ npmjs
 opensearch
 opensearchdescription
 opensource
-Orama
-orama
 Orta
 orta
 osascript
@@ -218,7 +203,6 @@ playbtn
 Plushie
 plushie
 plushies
-posthog
 precached
 precaching
 prerendered
@@ -226,7 +210,6 @@ printfn
 producthunt
 Profilo
 profilo
-protobuffet
 PRPL
 Pyltsyn
 QJPUV
@@ -237,7 +220,6 @@ Quickwit
 quickwit
 rachelnabors
 Ramón
-rangefind
 reactjs
 rearchitecture
 Recma
@@ -293,7 +275,6 @@ styl
 sublabel
 sublicensable
 sublist
-subsetting
 subsubcategory
 subsubfolder
 subsubsection

--- a/website/community/2-resources.mdx
+++ b/website/community/2-resources.mdx
@@ -53,6 +53,7 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [posthog-docusaurus](https://github.com/PostHog/posthog-docusaurus) - Integrate [PostHog](https://posthog.com/) product analytics with Docusaurus
 - [docusaurus-plugin-moesif](https://github.com/Moesif/docusaurus-plugin-moesif) - Adds [Moesif API Analytics](https://www.moesif.com/) to track user behavior and pinpoint where developers drop off in your activation funnel.
 - [docusaurus-plugin-yandex-metrica](https://github.com/sgromkov/docusaurus-plugin-yandex-metrica) - Adds [Yandex Metrika](https://metrika.yandex.ru/) counter for evaluating site traffic and analyzing user behavior.
+- [@deskcrew/docusaurus-plugin](https://github.com/webmilmind1/docusaurus-deskcrew) - Adds AI live chat, a help center and ticketing from [DeskCrew](https://deskcrew.io) to every docs page. Answers reader questions from your own help articles, and files a support ticket when it cannot.
 
 ### AI / Agents {/* #ai-agents */}
 

--- a/website/community/2-resources.mdx
+++ b/website/community/2-resources.mdx
@@ -55,7 +55,6 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [docusaurus-plugin-yandex-metrica](https://github.com/sgromkov/docusaurus-plugin-yandex-metrica) - Adds [Yandex Metrika](https://metrika.yandex.ru/) counter for evaluating site traffic and analyzing user behavior.
 - [docusaurus-plugin-dhub](https://github.com/dhub-dev/docusaurus-plugin-dhub) - Adds edit links that open a page's source file in the [Dhub](https://dhub.dev/docusaurus) visual MDX editor, and emits a `dhub.json` manifest mapping every route to its source file.
 
-
 ### AI / Agents {/* #ai-agents */}
 
 - [docusaurus-plugin-copy-page-button](https://github.com/portdeveloper/docusaurus-plugin-copy-page-button) - Adds a "Copy page" button that exports doc pages as clean Markdown for use with ChatGPT, Claude, and Gemini. Used by Ethereum, Sui, Monad, and Flare docs.


### PR DESCRIPTION
Adds the official DeskCrew plugin to the Integrations section.

It adds a support widget (live chat, answers drawn from your own help articles, and a help center) to every docs page via `injectHtmlTags`, and files a support ticket when it cannot answer.

Published as `@deskcrew/docusaurus-plugin` on npm, MIT licensed, supports Docusaurus 2 and 3.

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Docs sites lose readers at the moment they cannot find an answer. This plugin catches that moment: it answers from the knowledge base the site owner publishes, and opens a support ticket when it has no grounded answer.

It sits in Integrations alongside the other third-party service plugins (PostHog, Moesif, Yandex Metrica) rather than AI / Agents, since that section is for plugins that make docs consumable by LLMs (llms.txt generation, Markdown export, MCP indexing) rather than plugins that add a service to the rendered site.

## Test Plan

Documentation-only change: one entry appended to the Integrations list.

- The added line follows the exact `- [name](repo) - Description` format of the surrounding entries.
- Both links in the entry resolve (repository and product site).
- No other line in the file is modified; the diff is +1 / -0.

## Test links

Deploy preview: <!-- the bot fills this in -->

## Related issues/PRs

None.
