### PR TITLE
fix(utils): skip h1 headings with hashes in excerpts

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
@@ -47,6 +47,26 @@ describe('createExcerpt', () => {
     );
   });
 
+  it('skips h1 headings containing # in their text', () => {
+    expect(
+      createExcerpt(dedent`
+
+          # C# Programming Guide
+
+          This paragraph should become the description.
+        `),
+    ).toBe('This paragraph should become the description.');
+
+    expect(
+      createExcerpt(dedent`
+
+          # F# Programming Guide #
+
+          This paragraph should also become the description.
+        `),
+    ).toBe('This paragraph should also become the description.');
+  });
+
   it('creates excerpt for regular content with alternate title', () => {
     expect(
       createExcerpt(dedent`

--- a/packages/docusaurus-utils/src/markdownUtils.ts
+++ b/packages/docusaurus-utils/src/markdownUtils.ts
@@ -145,8 +145,8 @@ export function createExcerpt(fileString: string): string | undefined {
     const cleanedLine = fileLine
       // Remove HTML tags.
       .replace(/<[^>]*>/g, '')
-      // Remove Title headers
-      .replace(/^#[^#]+#?/gm, '')
+      // Remove H1/Title headers
+      .replace(/^#[ \t][^\r\n]*$/gm, '')
       // Remove Markdown + ATX-style headers
       .replace(/^#{1,6}\s*(?<text>[^#]*?)\s*#{0,6}/gm, '$1')
       // Remove emphasis.


### PR DESCRIPTION
Fixes #12305

## Motivation

Docusaurus skips H1 headings when deriving automatic page descriptions, but the H1-stripping regex stopped at an additional `#` inside heading text like `C#` or `F#`. That left the rest of the heading as the generated description.

## Test Plan

- `pnpm vitest run packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts`
- `pnpm exec eslint packages/docusaurus-utils/src/markdownUtils.ts packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts`
- `pnpm exec oxfmt --check packages/docusaurus-utils/src/markdownUtils.ts packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts`
- `git diff --check`

Environment note: local Node is `v22.22.2`; repo packages warn they prefer `>=24.14`, but the targeted tests/lint/format checks passed.
