### PR TITLE
docs: Oxford comma in linking guide

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-links.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-links.mdx
@@ -17,7 +17,7 @@ URL paths are unprocessed by Docusaurus, and you can see them as directly render
 
 If you want to reference another Markdown file **included by the same plugin**, you could use the relative path of the document you want to link to. Docusaurus' Markdown loader will convert the file path to the target file's URL path (and hence remove the `.md` extension).
 
-For example, if you are in `docs/folder/doc1.md` and you want to reference `docs/folder/doc2.md`, `docs/folder/subfolder/doc3.md` and `docs/otherFolder/doc4.md`:
+For example, if you are in `docs/folder/doc1.md` and you want to reference `docs/folder/doc2.md`, `docs/folder/subfolder/doc3.md`, and `docs/otherFolder/doc4.md`:
 
 ```md title="docs/folder/doc1.md"
 I am referencing a [document](doc2.mdx).


### PR DESCRIPTION
This page later uses an Oxford comma:

> usually `docs/`, `blog/`, or [localized ones](../../i18n/i18n-tutorial.mdx)

I think it makes the introduction to the code block example much clearer. You have easy context for an example coming up with exactly three case studies.