### PR TITLE
feat(create-docusaurus): add nub package manager support

### DIFF
--- a/packages/create-docusaurus/bin/index.js
+++ b/packages/create-docusaurus/bin/index.js
@@ -32,7 +32,7 @@ program
   .arguments('[siteName] [template] [rootDir]')
   .option(
     '-p, --package-manager <manager>',
-    'The package manager used to install dependencies. One of yarn, npm, pnpm, and bun.',
+    'The package manager used to install dependencies. One of yarn, npm, pnpm, bun, and nub.',
   )
   .option(
     '-s, --skip-install',

--- a/packages/create-docusaurus/src/__tests__/utils.test.ts
+++ b/packages/create-docusaurus/src/__tests__/utils.test.ts
@@ -6,7 +6,7 @@
  */
 
 import {describe, expect, it} from 'vitest';
-import {siteNameToPackageName} from '../utils';
+import {packageManagerScriptCommand, siteNameToPackageName} from '../utils';
 
 describe('siteNameToPackageName', () => {
   it('converts simple cases', () => {
@@ -39,5 +39,24 @@ describe('siteNameToPackageName', () => {
 
   it('skips !!!', () => {
     expect(siteNameToPackageName('!!!')).toEqual('!!!');
+  });
+});
+
+describe('packageManagerScriptCommand', () => {
+  it('adds "run" to every nub script (nub has no implicit shortcut)', () => {
+    expect(packageManagerScriptCommand('nub', 'start')).toBe('nub run start');
+    expect(packageManagerScriptCommand('nub', 'build')).toBe('nub run build');
+  });
+
+  it('keeps "start" bare for npm/bun but adds "run" to other scripts', () => {
+    expect(packageManagerScriptCommand('npm', 'start')).toBe('npm start');
+    expect(packageManagerScriptCommand('npm', 'build')).toBe('npm run build');
+    expect(packageManagerScriptCommand('bun', 'start')).toBe('bun start');
+    expect(packageManagerScriptCommand('bun', 'build')).toBe('bun run build');
+  });
+
+  it('never adds "run" for yarn/pnpm', () => {
+    expect(packageManagerScriptCommand('yarn', 'start')).toBe('yarn start');
+    expect(packageManagerScriptCommand('pnpm', 'build')).toBe('pnpm build');
   });
 });

--- a/packages/create-docusaurus/src/commands.ts
+++ b/packages/create-docusaurus/src/commands.ts
@@ -72,11 +72,13 @@ export async function getAvailablePackageManagers(): Promise<PackageManager[]> {
 export async function runPackageManagerInstallCommand(
   pkgManager: PackageManager,
 ): Promise<boolean> {
+  // bun and nub don't accept "--color always" and color their output based on
+  // the terminal / FORCE_COLOR (set below) instead.
   const installCommand =
     pkgManager === 'yarn'
       ? 'yarn'
-      : pkgManager === 'bun'
-        ? 'bun install'
+      : pkgManager === 'bun' || pkgManager === 'nub'
+        ? `${pkgManager} install`
         : `${pkgManager} install --color always`;
 
   return (

--- a/packages/create-docusaurus/src/constants.ts
+++ b/packages/create-docusaurus/src/constants.ts
@@ -15,6 +15,7 @@ export const LockfileNames = {
   yarn: 'yarn.lock',
   pnpm: 'pnpm-lock.yaml',
   bun: 'bun.lockb',
+  nub: 'nub.lock',
 };
 
 export type PackageManager = keyof typeof LockfileNames;

--- a/packages/create-docusaurus/src/utils.ts
+++ b/packages/create-docusaurus/src/utils.ts
@@ -48,6 +48,19 @@ export async function pathExists(filePath: string): Promise<boolean> {
     .catch(() => false);
 }
 
+// The command that runs a package.json script. nub has no implicit script
+// shortcut, so every script needs an explicit "run". npm/bun need it too,
+// except for the "start" lifecycle script; yarn/pnpm never need it.
+export function packageManagerScriptCommand(
+  pkgManager: PackageManager,
+  script: string,
+): string {
+  const needsRun =
+    pkgManager === 'nub' ||
+    ((pkgManager === 'npm' || pkgManager === 'bun') && script !== 'start');
+  return `${pkgManager} ${needsRun ? 'run ' : ''}${script}`;
+}
+
 export function printPackageManagerHelp({
   pkgManager,
   cdpath,
@@ -55,28 +68,27 @@ export function printPackageManagerHelp({
   pkgManager: PackageManager;
   cdpath: string;
 }) {
-  const useNpm = pkgManager === 'npm';
-  const useBun = pkgManager === 'bun';
-  const run = useNpm || useBun ? 'run ' : '';
+  const script = (name: string) =>
+    packageManagerScriptCommand(pkgManager, name);
   logger.success`Created name=${cdpath}.`;
   logger.info`Inside that directory, you can run several commands:
 
-  code=${`${pkgManager} start`}
+  code=${script('start')}
     Starts the development server.
 
-  code=${`${pkgManager} ${run}build`}
+  code=${script('build')}
     Bundles your website into static files for production.
 
-  code=${`${pkgManager} ${run}serve`}
+  code=${script('serve')}
     Serves the built website locally.
 
-  code=${`${pkgManager} ${run}deploy`}
+  code=${script('deploy')}
     Publishes the website to GitHub pages.
 
 We recommend that you begin by typing:
 
   code=${`cd ${cdpath}`}
-  code=${`${pkgManager} start`}
+  code=${script('start')}
 
 Happy building awesome websites!
 `;

--- a/website/docs/api/misc/create-docusaurus.mdx
+++ b/website/docs/api/misc/create-docusaurus.mdx
@@ -47,7 +47,7 @@ Used when the template argument is a git repo. It needs to be one of:
 
 ### `-p, --package-manager` {/* #package-manager */}
 
-Value should be one of `npm`, `yarn`, `pnpm`, or `bun`. If it's not explicitly provided, Docusaurus will infer one based on:
+Value should be one of `npm`, `yarn`, `pnpm`, `bun`, or `nub`. If it's not explicitly provided, Docusaurus will infer one based on:
 
 - The lockfile already present in the CWD (e.g. if you are setting up website in an existing project)
 - The command used to invoke `create-docusaurus` (e.g. `npm init`, `npx`, `yarn create`, `bunx`, etc.)


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Adds [nub](https://github.com/nubjs/nub) as a selectable package manager in `create-docusaurus`, alongside npm/yarn/pnpm/bun. nub is pnpm-CLI-compatible and writes a `nub.lock` lockfile.

- **`constants.ts`** — add `nub: 'nub.lock'` to `LockfileNames`. Everything else derives from this map: lockfile detection, the `--package-manager nub` flag, the interactive prompt, and the `PackageManager` type all pick nub up automatically.
- **`utils.ts`** — the script tips relied on npm/yarn/pnpm/bun's implicit `start` shortcut (e.g. `pnpm start`). nub has no implicit script shortcut — `nub start` is an error — so every tip for nub is explicit: `nub run start`, `nub run build`, and so on. The run-prefix logic moved into a small `packageManagerScriptCommand` helper; output for the existing package managers is unchanged.
- **`commands.ts`** — nub uses the bun-style `nub install` and colors from the terminal / `FORCE_COLOR`; it does not accept the space-separated `--color always` form the generic branch passes.

## Test Plan

- Added unit tests for `packageManagerScriptCommand`: nub gets an explicit `run` on every script; npm/bun keep `start` bare but prefix `run` elsewhere; yarn/pnpm never prefix `run`.
- Verified against nub 0.4.13: `nub.lock` lockfile detection, user-agent detection (`npm_config_user_agent` is `nub/0.4.13 npm/? node/…`, matched by the existing `startsWith`), `nub --version` for the availability prompt, `nub install` succeeds, and `nub install --color always` fails (the reason for the bun-style branch).
