### PR TITLE
Make PendingNavigation.tsx strict-mode-compatible

### DIFF
--- a/packages/docusaurus/src/client/PendingNavigation.tsx
+++ b/packages/docusaurus/src/client/PendingNavigation.tsx
@@ -10,7 +10,6 @@ import {Route} from 'react-router-dom';
 import ClientLifecyclesDispatcher, {
   dispatchLifecycleAction,
 } from './ClientLifecyclesDispatcher';
-import ExecutionEnvironment from './exports/ExecutionEnvironment';
 import preload from './preload';
 import type {Location} from 'history';
 
@@ -39,12 +38,10 @@ class PendingNavigation extends React.Component<Props, State> {
   }
 
   override componentDidMount(): void {
-    if (ExecutionEnvironment.canUseDOM) {
-      this.routeUpdateCleanupCb = dispatchLifecycleAction('onRouteUpdate', {
-        previousLocation: null,
-        location: this.props.location,
-      });
-    }
+    this.routeUpdateCleanupCb = dispatchLifecycleAction('onRouteUpdate', {
+      previousLocation: null,
+      location: this.props.location,
+    });
   }
 
   // Intercept location updates in commit phase and still show old route
@@ -53,15 +50,13 @@ class PendingNavigation extends React.Component<Props, State> {
     if (this.props.location !== prevProps.location) {
       this.routeUpdateCleanupCb();
 
-      // props.location being different means the router is trying to navigate to
-      // a new route. We will preload the new route.
+      // props.location being different means the router is trying to navigate
+      // to a new route. We will preload the new route.
       const nextLocation = this.props.location;
-      this.routeUpdateCleanupCb = ExecutionEnvironment.canUseDOM
-        ? dispatchLifecycleAction('onRouteUpdate', {
-            previousLocation: prevProps.location,
-            location: nextLocation,
-          })
-        : () => {};
+      this.routeUpdateCleanupCb = dispatchLifecycleAction('onRouteUpdate', {
+        previousLocation: prevProps.location,
+        location: nextLocation,
+      });
 
       // Load data while the old screen remains. Force preload instead of using
       // `window.docusaurus`, because we want to avoid loading screen even when

--- a/packages/docusaurus/src/client/PendingNavigation.tsx
+++ b/packages/docusaurus/src/client/PendingNavigation.tsx
@@ -25,6 +25,8 @@ type State = {
 class PendingNavigation extends React.Component<Props, State> {
   private previousLocation: Location | null;
   private routeUpdateCleanupCb: () => void;
+  // Guard variable to prevent double-execution in Strict Mode
+  private pendingLocation: Location | null = null;
 
   constructor(props: Props) {
     super(props);
@@ -54,8 +56,21 @@ class PendingNavigation extends React.Component<Props, State> {
     // props.location being different means the router is trying to navigate to
     // a new route. We will preload the new route.
     const nextLocation = nextProps.location;
+
+    // If shouldComponentUpdate is double-invoked with the
+    // exact same target location, return false immediately
+    // to bypass side effects
+    if (this.pendingLocation === nextLocation) {
+      return false;
+    }
+
     // Save the location first.
+    this.pendingLocation = nextLocation; // guard against double-triggers
     this.previousLocation = this.props.location;
+
+    // Clear an active transition if one was already registered
+    this.routeUpdateCleanupCb();
+
     this.setState({nextRouteHasLoaded: false});
     this.routeUpdateCleanupCb = dispatchLifecycleAction('onRouteUpdate', {
       previousLocation: this.previousLocation,
@@ -67,8 +82,13 @@ class PendingNavigation extends React.Component<Props, State> {
     // user is on saveData
     preload(nextLocation.pathname)
       .then(() => {
-        this.routeUpdateCleanupCb();
-        this.setState({nextRouteHasLoaded: true});
+        // Only finalize the transition
+        // if the user hasn't started preloading a newer location
+        if (this.pendingLocation === nextLocation) {
+          this.pendingLocation = null;
+          this.routeUpdateCleanupCb();
+          this.setState({nextRouteHasLoaded: true});
+        }
       })
       .catch((e: unknown) => {
         console.warn(e);

--- a/packages/docusaurus/src/client/PendingNavigation.tsx
+++ b/packages/docusaurus/src/client/PendingNavigation.tsx
@@ -19,96 +19,93 @@ type Props = {
   readonly children: ReactNode;
 };
 type State = {
-  nextRouteHasLoaded: boolean;
+  renderedLocation: Location;
+  previousLocation: Location | null;
 };
 
 class PendingNavigation extends React.Component<Props, State> {
-  private previousLocation: Location | null;
-  private routeUpdateCleanupCb: () => void;
-  // Guard variable to prevent double-execution in Strict Mode
-  private pendingLocation: Location | null = null;
+  private routeUpdateCleanupCb: () => void = () => {};
+  private isUnmounted = false;
 
   constructor(props: Props) {
     super(props);
 
-    // previousLocation doesn't affect rendering, hence not stored in state.
-    this.previousLocation = null;
-    this.routeUpdateCleanupCb = ExecutionEnvironment.canUseDOM
-      ? dispatchLifecycleAction('onRouteUpdate', {
-          previousLocation: null,
-          location: this.props.location,
-        })
-      : () => {};
+    // Store renderedLocation in state so the old screen stays visible
+    // while the new route is being preloaded.
     this.state = {
-      nextRouteHasLoaded: true,
+      renderedLocation: props.location,
+      previousLocation: null,
     };
   }
 
-  // Intercept location update and still show current route until next route
-  // is done loading.
-  override shouldComponentUpdate(nextProps: Props, nextState: State): boolean {
-    if (nextProps.location === this.props.location) {
-      // `nextRouteHasLoaded` is false means there's a pending route transition.
-      // Don't update until it's done.
-      return nextState.nextRouteHasLoaded;
-    }
-
-    // props.location being different means the router is trying to navigate to
-    // a new route. We will preload the new route.
-    const nextLocation = nextProps.location;
-
-    // If shouldComponentUpdate is double-invoked with the
-    // exact same target location, return false immediately
-    // to bypass side effects
-    if (this.pendingLocation === nextLocation) {
-      return false;
-    }
-
-    // Save the location first.
-    this.pendingLocation = nextLocation; // guard against double-triggers
-    this.previousLocation = this.props.location;
-
-    // Clear an active transition if one was already registered
-    this.routeUpdateCleanupCb();
-
-    this.setState({nextRouteHasLoaded: false});
-    this.routeUpdateCleanupCb = dispatchLifecycleAction('onRouteUpdate', {
-      previousLocation: this.previousLocation,
-      location: nextLocation,
-    });
-
-    // Load data while the old screen remains. Force preload instead of using
-    // `window.docusaurus`, because we want to avoid loading screen even when
-    // user is on saveData
-    preload(nextLocation.pathname)
-      .then(() => {
-        // Only finalize the transition
-        // if the user hasn't started preloading a newer location
-        if (this.pendingLocation === nextLocation) {
-          this.pendingLocation = null;
-          this.routeUpdateCleanupCb();
-          this.setState({nextRouteHasLoaded: true});
-        }
-      })
-      .catch((e: unknown) => {
-        console.warn(e);
-        // If chunk loading failed, it could be because the path to a chunk
-        // no longer exists due to a new deployment. Force refresh the page
-        // instead of just not navigating.
-        window.location.reload();
+  override componentDidMount(): void {
+    if (ExecutionEnvironment.canUseDOM) {
+      this.routeUpdateCleanupCb = dispatchLifecycleAction('onRouteUpdate', {
+        previousLocation: null,
+        location: this.props.location,
       });
-    return false;
+    }
+  }
+
+  // Intercept location updates in commit phase and still show old route
+  // until next route is done loading.
+  override componentDidUpdate(prevProps: Props): void {
+    if (this.props.location !== prevProps.location) {
+      this.routeUpdateCleanupCb();
+
+      // props.location being different means the router is trying to navigate to
+      // a new route. We will preload the new route.
+      const nextLocation = this.props.location;
+      this.routeUpdateCleanupCb = ExecutionEnvironment.canUseDOM
+        ? dispatchLifecycleAction('onRouteUpdate', {
+            previousLocation: prevProps.location,
+            location: nextLocation,
+          })
+        : () => {};
+
+      // Load data while the old screen remains. Force preload instead of using
+      // `window.docusaurus`, because we want to avoid loading screen even when
+      // user is on saveData
+      preload(nextLocation.pathname)
+        .then(() => {
+          if (this.isUnmounted) {
+            return;
+          }
+          this.routeUpdateCleanupCb();
+          this.setState({
+            renderedLocation: nextLocation,
+            previousLocation: prevProps.location,
+          });
+        })
+        .catch((e: unknown) => {
+          if (this.isUnmounted) {
+            return;
+          }
+          console.warn(e);
+          // If chunk loading failed, it could be because the path to a chunk
+          // no longer exists due to a new deployment. Force refresh the page
+          // instead of just not navigating.
+          window.location.reload();
+        });
+    }
+  }
+
+  override componentWillUnmount(): void {
+    this.isUnmounted = true;
+    this.routeUpdateCleanupCb();
   }
 
   override render(): ReactNode {
-    const {children, location} = this.props;
+    const {children} = this.props;
+    const {renderedLocation, previousLocation} = this.state;
+
     // Use a controlled <Route> to trick all descendants into rendering the old
     // location.
     return (
       <ClientLifecyclesDispatcher
-        previousLocation={this.previousLocation}
-        location={location}>
-        <Route location={location} render={() => children} />
+        previousLocation={previousLocation}
+        location={renderedLocation}>
+        <Route location={renderedLocation} render={() => children} />
       </ClientLifecyclesDispatcher>
     );
   }


### PR DESCRIPTION
We found that PendingNavigation.tsx was NOT strict-mode-compatible out of the box.

As `shouldComponentUpdate` (and thus `dispatchLifecycleAction(...)`) is double-invoked in development-mode
(when we export StrictMode as default in src/theme/Root.js), this would be a terrible experience during development mode (even though it does not affect production builds).

(For example, the progress bar is still displayed at the top even though navigation was finished because that lifecycle method was double-invoked.)

To address this problem, we use a field `this.pendingLocation` to track the location that is being preloaded.
During the second synchronous render pass (when StrictMode in development), we compare the `nextProps.location` against `this.pendingLocation` and if they match, this returns `false` immediately, which causes the `dispatchLifecycleAction(...)` to not run more than one time.

Beyond this fix, this commit also has the added benefit of the following:

Checking `if (this.pendingLocation === nextLocation)` inside the asynchronous `.then()` block acts as an **abort-and-debounce guard**.

If a user rapidly double-clicks different links (e.g., navigating to Page A and then quickly to Page B), the preloading of Page A will resolve but won't trigger state updates or prematurely (for example) dismiss the progress bar for Page B.

NOTE: parts of these code changes and/or the text of this commit were made using AI

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [X] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

Alternate fix for https://github.com/facebook/docusaurus/pull/10037