### PR TITLE
fix(utils): escape every heading id token on a line

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/markdownHeadingIdUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownHeadingIdUtils.test.ts
@@ -229,6 +229,14 @@ describe('escapeMarkdownHeadingIds', () => {
     );
   });
 
+  it('escapes every heading id on the same line', () => {
+    // parseMarkdownHeadingId supports multiple {#id} on a single heading, so
+    // all of them must be escaped for MDX, not just the first one.
+    expect(escapeMarkdownHeadingIds('## Some heading {#id1} {#id2}')).toBe(
+      '## Some heading \\{#id1} \\{#id2}',
+    );
+  });
+
   it('can escape level 1-6 heading ids', () => {
     expect(
       escapeMarkdownHeadingIds(dedent`

--- a/packages/docusaurus-utils/src/markdownHeadingIdUtils.ts
+++ b/packages/docusaurus-utils/src/markdownHeadingIdUtils.ts
@@ -73,9 +73,9 @@ export function escapeMarkdownHeadingIds(content: string): string {
   return content.replaceAll(markdownHeadingRegexp, (substring) =>
     // TODO probably not the most efficient impl...
     substring
-      .replace('{#', '\\{#')
+      .replaceAll('{#', '\\{#')
       // prevent duplicate escaping
-      .replace('\\\\{#', '\\{#'),
+      .replaceAll('\\\\{#', '\\{#'),
   );
 }
 


### PR DESCRIPTION
### Problem

`escapeMarkdownHeadingIds` escapes MDX-breaking `{#…}` tokens in headings, but
uses `String.prototype.replace`, which replaces only the **first** occurrence:

```ts
substring
  .replace('{#', '\\{#')
  .replace('\\\\{#', '\\{#'),
```

So a heading containing more than one `{#…}` token gets only the first escaped:

```ts
escapeMarkdownHeadingIds('## Some heading {#id1} {#id2}');
// '## Some heading \{#id1} {#id2}'   ← second {# left unescaped
```

Multiple ids on a heading is a supported input: `parseMarkdownHeadingId` has an
explicit test for it (`## Some heading {#id1} {#id2}` → text `## Some heading
{#id1}`, id `id2`), so the leading `{#id1}` stays as literal heading text
alongside the real anchor. The leftover unescaped `{#` then defeats this
function's sole purpose — `mdx1Compat.headingIds` is on by default, and MDX v2
treats the unescaped `{` as a JS expression → "Could not parse expression with
acorn" build failure, exactly the error this function exists to prevent.

### Fix

Use `replaceAll` so every `{#` on the heading line is escaped.

### Test

Added a case asserting `## Some heading {#id1} {#id2}` escapes **both** tokens.
Fails on `main`; passes with the fix. The existing 58 tests (including the
already-escaped idempotency case and the multi-heading realistic example) still
pass.
