### PR TITLE
fix(utils): do not read a query from a "?" inside the URL hash

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/urlUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/urlUtils.test.ts
@@ -277,6 +277,15 @@ describe('toURLPath', () => {
       hash: '',
     });
   });
+
+  it('pathname + hash containing a question mark (no query)', () => {
+    const url = parseURLOrPath('/pathname#hash?notquery');
+    expect(toURLPath(url)).toEqual({
+      pathname: '/pathname',
+      search: undefined,
+      hash: 'hash?notquery',
+    });
+  });
 });
 
 describe('parseLocalURLPath', () => {

--- a/packages/docusaurus-utils/src/urlUtils.ts
+++ b/packages/docusaurus-utils/src/urlUtils.ts
@@ -177,13 +177,17 @@ export type URLPath = {pathname: string; search?: string; hash?: string};
 export function toURLPath(url: URL): URLPath {
   const {pathname} = url;
 
+  // Only the part before the fragment can contain the query string. A "?"
+  // inside the hash (e.g. "/foo#bar?baz") must not be read as an empty query.
+  const beforeHash = url.hash ? url.href.slice(0, -url.hash.length) : url.href;
+
   // Fixes annoying url.search behavior
   // "" => undefined
   // "?" => ""
   // "?param => "param"
   const search = url.search
     ? url.search.slice(1)
-    : url.href.includes('?')
+    : beforeHash.includes('?')
       ? ''
       : undefined;
 


### PR DESCRIPTION
## Motivation

`toURLPath` needs to tell "no query" apart from an empty query (`/foo` vs `/foo?`). Since the WHATWG URL API reports both as `url.search === ''`, it falls back to `url.href.includes('?')`. But `url.href` also contains the fragment, so a `?` that only appears **inside the hash** is mistaken for an empty query.

```js
toURLPath(new URL('https://example.com/foo#bar?baz'))
// before: { pathname: '/foo', search: '', hash: 'bar?baz' }   <- wrong
// after:  { pathname: '/foo', search: undefined, hash: 'bar?baz' }
```

This is not just cosmetic. `serializeURLPath` turns an empty `search` into a literal `?`, so round-tripping corrupts the URL:

```js
serializeURLPath(parseURLPath('/foo#bar?baz'))
// before: '/foo?#bar?baz'   <- spurious "?"
// after:  '/foo#bar?baz'
```

## The fix

Only look for the query in the part of the href before the fragment:

```js
const beforeHash = url.hash ? url.href.slice(0, -url.hash.length) : url.href;
const search = url.search ? url.search.slice(1) : beforeHash.includes('?') ? '' : undefined;
```

All existing behavior is preserved (real query, empty query `/foo?`, empty query before hash `/foo?#`, plain path, hash only). Added a regression test for a hash that contains a `?`.

## Test Plan

`yarn jest urlUtils` in `packages/docusaurus-utils`. The new case covers `/pathname#hash?notquery`, and the existing `toURLPath` cases still pass.
