### PR TITLE
docs: add docusaurus-plugin-pagefind to community search resources

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -191,6 +191,8 @@ O’Shannessy
 paas
 Palenight
 palenight
+Pagefind
+pagefind
 Paletton
 Palo
 Paraiso

--- a/website/community/2-resources.mdx
+++ b/website/community/2-resources.mdx
@@ -46,6 +46,7 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [@getcanary/docusaurus-theme-search-pagefind](https://getcanary.dev/docs/integrations/docusaurus.html) - Create [Pagefind](https://pagefind.app/) index and use [Canary](https://github.com/fastrepl/canary) as UI primitives.
 - [docusaurus-biel](https://github.com/TechDocsStudio/docusaurus-biel) - Docusaurus plugin to add an AI chatbot and AI search with source-cited answers, powered by [Biel.ai](https://biel.ai)
 - [docusaurus-plugin-rangefind](https://github.com/xjodoin/rangefind/tree/main/packages/docusaurus-plugin-rangefind) - Local/offline search over a static [rangefind](https://rangefind.dev) index queried with HTTP range requests — BM25F relevance, typo correction, autocomplete; no search server
+- [docusaurus-plugin-pagefind](https://github.com/toasty-kj/docusaurus-plugin-pagefind) - Local/offline search using a static [Pagefind](https://pagefind.app) index
 
 ### Integrations {/* #integrations */}
 


### PR DESCRIPTION
## Summary
Add [docusaurus-plugin-pagefind](https://github.com/toasty-kj/docusaurus-plugin-pagefind) to the community search resources.

## Motivation
The `@getcanary/docusaurus-theme-search-pagefind` repository has not been updated for [two years](https://www.npmjs.com/package/@getcanary/docusaurus-theme-search-pagefind?activeTab=versions), and its documentation site is currently reported as unavailable. This plugin provides an actively maintained alternative for integrating [Pagefind](https://pagefind.app) with Docusaurus v3.

## Test plan
Docs-only change to website/community/2-resources.mdx, matching the existing entry format.
