### PR TITLE
fix: memory leak in i18n builds

### DIFF
--- a/packages/docusaurus/src/webpack/plugins/ChunkAssetPlugin.ts
+++ b/packages/docusaurus/src/webpack/plugins/ChunkAssetPlugin.ts
@@ -56,13 +56,26 @@ ${DocusaurusGetChunkAssetFn} = function(chunkId) { chunkId = ${JSON.stringify(
  */
 export default class ChunkAssetPlugin {
   apply(compiler: Compiler): void {
+    const runtimeModules = new Set<ChunkAssetRuntimeModule>();
+
     compiler.hooks.thisCompilation.tap(PluginName, (compilation) => {
+      runtimeModules.clear();
       compilation.hooks.additionalTreeRuntimeRequirements.tap(
         PluginName,
         (chunk) => {
-          compilation.addRuntimeModule(chunk, new ChunkAssetRuntimeModule());
+          const runtimeModule = new ChunkAssetRuntimeModule();
+          runtimeModules.add(runtimeModule);
+          compilation.addRuntimeModule(chunk, runtimeModule);
         },
       );
+    });
+
+    compiler.hooks.shutdown.tap(PluginName, () => {
+      // Rspack keeps runtime module generator callbacks alive after shutdown.
+      runtimeModules.forEach((runtimeModule) =>
+        runtimeModule.clearCompilationReferences(),
+      );
+      runtimeModules.clear();
     });
   }
 }
@@ -77,5 +90,11 @@ class ChunkAssetRuntimeModule extends webpack.RuntimeModule {
   }
   override generate() {
     return generateGetChunkAssetRuntimeCode(this.chunk!);
+  }
+
+  clearCompilationReferences() {
+    this.compilation = undefined;
+    this.chunk = undefined;
+    this.chunkGraph = undefined;
   }
 }

--- a/packages/docusaurus/src/webpack/plugins/__tests__/ChunkAssetPlugin.test.ts
+++ b/packages/docusaurus/src/webpack/plugins/__tests__/ChunkAssetPlugin.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {describe, expect, it, vi} from 'vitest';
+import {fromPartial} from '@total-typescript/shoehorn';
+import ChunkAssetPlugin from '../ChunkAssetPlugin';
+import type webpack from 'webpack';
+
+function createHook<Args extends unknown[]>() {
+  const handlers: ((...args: Args) => void)[] = [];
+  return {
+    call: (...args: Args) => handlers.forEach((handler) => handler(...args)),
+    hook: {
+      tap: (_name: string, handler: (...args: Args) => void) => {
+        handlers.push(handler);
+      },
+    },
+  };
+}
+
+describe('ChunkAssetPlugin', () => {
+  it('detaches runtime modules when the compiler shuts down', () => {
+    const thisCompilation = createHook<[webpack.Compilation]>();
+    const shutdown = createHook<[]>();
+    const additionalTreeRuntimeRequirements = createHook<[webpack.Chunk]>();
+    const chunk = fromPartial<webpack.Chunk>({});
+    const chunkGraph = fromPartial<webpack.ChunkGraph>({});
+    const addRuntimeModule = vi.fn();
+    const compilation = fromPartial<webpack.Compilation>({
+      addRuntimeModule,
+      hooks: {
+        additionalTreeRuntimeRequirements:
+          additionalTreeRuntimeRequirements.hook,
+      },
+    });
+    addRuntimeModule.mockImplementation(
+      (runtimeChunk: webpack.Chunk, runtimeModule: webpack.RuntimeModule) => {
+        runtimeModule.attach(compilation, runtimeChunk, chunkGraph);
+      },
+    );
+    const compiler = fromPartial<webpack.Compiler>({
+      hooks: {
+        shutdown: shutdown.hook,
+        thisCompilation: thisCompilation.hook,
+      },
+    });
+
+    new ChunkAssetPlugin().apply(compiler);
+    thisCompilation.call(compilation);
+    additionalTreeRuntimeRequirements.call(chunk);
+
+    const runtimeModule = addRuntimeModule.mock
+      .calls[0]![1] as webpack.RuntimeModule;
+    expect(runtimeModule.compilation).toBe(compilation);
+    expect(runtimeModule.chunk).toBe(chunk);
+    expect(runtimeModule.chunkGraph).toBe(chunkGraph);
+
+    shutdown.call();
+
+    expect(runtimeModule.compilation).toBeUndefined();
+    expect(runtimeModule.chunk).toBeUndefined();
+    expect(runtimeModule.chunkGraph).toBeUndefined();
+  });
+});


### PR DESCRIPTION
fix #10944

### Details

Rspack keeps each custom chunk-asset runtime module's bound generator alive after compiler shutdown. Its compilation, chunk, and chunk graph references retain the complete compiler graph across localized builds.

### Change

Track the current compilation's chunk-asset runtime modules and clear their compiler graph references during shutdown.

### Before

When the fresh Docusaurus i18n build scenario runs six locale builds in one process, retained compiler hooks, stats, and MDX processors grow:

<img width="1400" height="7540" alt="docusaurus-i18n-build-before" src="https://github.com/user-attachments/assets/0bbe54bb-cf32-4ec0-a407-5e98df6d46bf" />


### After

No more retained Docusaurus compiler graphs are detected.
<img width="1400" height="240" alt="docusaurus-i18n-build-after" src="https://github.com/user-attachments/assets/24d4f961-2f6b-440f-9c39-efd8fbc540f9" />

### Additional Info

- PR is AI-generated
- Model: Codex (GPT-5.6)
- Worktime: 1 hour, 14 minutes, 15 seconds
