### PR TITLE
docs: add Doc Bridge to community resources

### DIFF
--- a/website/community/2-resources.mdx
+++ b/website/community/2-resources.mdx
@@ -63,6 +63,7 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [expose-markdown-docusaurus-plugin](https://github.com/FlyNumber/markdown_docusaurus_plugin) - Exposes your /docs Markdown files as raw `.md` URLs (for LLM consumption).
 - [@agentreadyweb/docusaurus-plugin](https://github.com/AshutoshRaj97/agentready-mcp/tree/main/docusaurus-plugin) - Auto-indexes your docs in [AgentReady](https://www.agentready.it.com) after every build, making them instantly queryable by AI agents (Claude, Cursor, Windsurf) via MCP with cited answers.
 - [@deskcrew/docusaurus-plugin](https://github.com/webmilmind1/docusaurus-deskcrew) - Adds AI live chat, a help center and ticketing from [DeskCrew](https://deskcrew.io) to every docs page. Answers reader questions from your own help articles, and files a support ticket when it cannot.
+- [Doc Bridge](https://github.com/AgentsKit-io/doc-bridge) - Indexes Docusaurus docs and sidebars into deterministic, package-scoped handoffs for coding agents, with freshness and coverage gates.
 
 ### Features {/* #features */}
 


### PR DESCRIPTION
## Summary

Add Doc Bridge to the **AI / Agents** section of the Docusaurus community resources.

## Motivation

Docusaurus gives teams a strong human documentation surface, but coding agents still need repository-specific context: where to start, which paths they may edit, what checks they must run, and which human docs govern the change. Doc Bridge indexes Docusaurus docs, sidebars, and ownership metadata into deterministic, package-scoped handoffs and gates them for freshness and coverage.

This is a discovery-only documentation change. It does not add a Docusaurus runtime dependency, hosted inference service, or model-provider requirement.

## Test plan

- confirmed `@agentskit/doc-bridge@1.2.4` is public and MIT-licensed
- confirmed the Docusaurus adapter and real-clone smoke are present in the public repository
- confirmed the repository link returns HTTP 200
- confirmed there is no existing Doc Bridge entry or pull request
- ran `git diff --check`
- ran `oxfmt --check website/community/2-resources.mdx`

Disclosure: I maintain Doc Bridge and used an AI assistant to help research and prepare this one-line documentation contribution. I reviewed and validated the final change.