### PR TITLE
fix(utils): resolve site-relative paths in the eager Git VCS

### DIFF
--- a/packages/docusaurus-utils/src/vcs/__tests__/gitUtils.test.ts
+++ b/packages/docusaurus-utils/src/vcs/__tests__/gitUtils.test.ts
@@ -808,6 +808,23 @@ describe('VSC strategies', () => {
       });
     });
 
+    it('can read repo file info from a site-relative path', async () => {
+      const {vcs} = await initVsc();
+
+      // RouteMetadata.sourceFilePath is documented as relative to the site dir,
+      // and the sitemap plugin forwards it here unchanged. The map is keyed by
+      // absolute paths, so a relative path used to miss and silently return
+      // null, dropping <lastmod> from the sitemap.
+      await expect(vcs.getFileLastUpdateInfo('rootFile.md')).resolves.toEqual({
+        author: 'Seb',
+        timestamp: new Date('2020-06-19').getTime(),
+      });
+      await expect(vcs.getFileCreationInfo('rootFile.md')).resolves.toEqual({
+        author: 'Seb',
+        timestamp: new Date('2020-06-19').getTime(),
+      });
+    });
+
     it('can read submodule file', async () => {
       const {vcs, repoDir} = await initVsc();
 

--- a/packages/docusaurus-utils/src/vcs/__tests__/gitUtils.test.ts
+++ b/packages/docusaurus-utils/src/vcs/__tests__/gitUtils.test.ts
@@ -808,13 +808,10 @@ describe('VSC strategies', () => {
       });
     });
 
-    it('can read repo file info from a site-relative path', async () => {
+    // see https://github.com/facebook/docusaurus/issues/12322
+    it('can read repo file info from a relative path', async () => {
       const {vcs} = await initVsc();
 
-      // RouteMetadata.sourceFilePath is documented as relative to the site dir,
-      // and the sitemap plugin forwards it here unchanged. The map is keyed by
-      // absolute paths, so a relative path used to miss and silently return
-      // null, dropping <lastmod> from the sitemap.
       await expect(vcs.getFileLastUpdateInfo('rootFile.md')).resolves.toEqual({
         author: 'Seb',
         timestamp: new Date('2020-06-19').getTime(),

--- a/packages/docusaurus-utils/src/vcs/vcsGitEager.ts
+++ b/packages/docusaurus-utils/src/vcs/vcsGitEager.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {resolve, basename} from 'node:path';
+import {resolve, basename, isAbsolute} from 'node:path';
 import logger, {PerfLogger} from '@docusaurus/logger';
 import {
   getGitAllRepoRoots,
@@ -82,11 +82,22 @@ async function initialize({
 
 export function createVcsGitEagerConfig(): VcsConfig {
   let initPromise: Promise<InitializeResult> | null = null;
+  let initSiteDir: string | null = null;
 
   async function getGitFileInfo(filePath: string): Promise<GitFileInfo | null> {
     const init = (await initPromise)!;
     if (init.type === 'success') {
-      return init.filesMap.get(filePath) ?? null;
+      // The map is keyed by absolute paths, but callers may pass a path
+      // relative to the site dir. RouteMetadata.sourceFilePath in particular
+      // "is expected to be relative to the site directory", which is what the
+      // sitemap plugin forwards here. The ad-hoc strategy tolerates both
+      // because it shells out to `git log`, so a relative path silently
+      // returned null here instead.
+      const key =
+        isAbsolute(filePath) || !initSiteDir
+          ? filePath
+          : resolve(initSiteDir, filePath);
+      return init.filesMap.get(key) ?? null;
     } else if (init.reason === 'not-in-worktree') {
       throw new Error(
         `This Docusaurus site is outside any Git worktree.
@@ -114,6 +125,7 @@ Unable to read Git info for file ${logger.path(filePath)} `,
         return;
       }
 
+      initSiteDir = siteDir;
       initPromise = PerfLogger.async('Git Eager VCS init', () =>
         initialize({siteDir}),
       );

--- a/packages/docusaurus-utils/src/vcs/vcsGitEager.ts
+++ b/packages/docusaurus-utils/src/vcs/vcsGitEager.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {resolve, basename, isAbsolute} from 'node:path';
+import {resolve, basename} from 'node:path';
 import logger, {PerfLogger} from '@docusaurus/logger';
 import {
   getGitAllRepoRoots,
@@ -56,6 +56,7 @@ type InitializeResult =
   | {
       type: 'success';
       filesMap: GitFileInfoMap;
+      siteDir: string;
     }
   | {
       type: 'error';
@@ -74,7 +75,7 @@ async function initialize({
       return {type: 'error', reason: 'not-in-worktree'};
     }
     const filesMap = await loadAllGitFilesInfoMap(siteDir);
-    return {type: 'success', filesMap};
+    return {type: 'success', filesMap, siteDir};
   } catch (error) {
     return {type: 'error', reason: 'unknown', cause: error as Error};
   }
@@ -82,21 +83,11 @@ async function initialize({
 
 export function createVcsGitEagerConfig(): VcsConfig {
   let initPromise: Promise<InitializeResult> | null = null;
-  let initSiteDir: string | null = null;
 
   async function getGitFileInfo(filePath: string): Promise<GitFileInfo | null> {
     const init = (await initPromise)!;
     if (init.type === 'success') {
-      // The map is keyed by absolute paths, but callers may pass a path
-      // relative to the site dir. RouteMetadata.sourceFilePath in particular
-      // "is expected to be relative to the site directory", which is what the
-      // sitemap plugin forwards here. The ad-hoc strategy tolerates both
-      // because it shells out to `git log`, so a relative path silently
-      // returned null here instead.
-      const key =
-        isAbsolute(filePath) || !initSiteDir
-          ? filePath
-          : resolve(initSiteDir, filePath);
+      const key = resolve(init.siteDir, filePath);
       return init.filesMap.get(key) ?? null;
     } else if (init.reason === 'not-in-worktree') {
       throw new Error(
@@ -125,7 +116,6 @@ Unable to read Git info for file ${logger.path(filePath)} `,
         return;
       }
 
-      initSiteDir = siteDir;
       initPromise = PerfLogger.async('Git Eager VCS init', () =>
         initialize({siteDir}),
       );


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #12322) and the maintainers have approved on my working plan.

> Left unchecked deliberately: this is a small bug fix rather than a new API or substantial
> change, so no working plan was agreed beforehand. It does close #12322.

## Motivation

Fixes #12322. With `future.experimental_vcs: 'default-v2'`, `sitemap.xml` is generated without
any `<lastmod>` values, while `'git-ad-hoc'` and `'default-v1'` produce them correctly for the
same site and Git history.

`default-v2` selects the eager Git strategy in production. `vcsGitEager` keys its file map by
absolute paths:

```ts
// The Map keys should be absolute file paths, not relative Git paths
return [resolve(repoRoot, entry[0]), entry[1]];
```

but the lookup uses whatever path it is handed:

```ts
return init.filesMap.get(filePath) ?? null;
```

The sitemap plugin passes `route.metadata.sourceFilePath`, which `RouteMetadata` documents as
"expected to be relative to the site directory". So the lookup misses and returns `null`, and
`getRouteLastmod` drops `<lastmod>` for that route without any warning.

`git-ad-hoc` and `default-v1` are unaffected because they shell out to `git log -- <path>`, which
resolves a relative path itself.

This resolves the path against the site dir when it is not already absolute. Absolute paths keep
working unchanged, so `getFileCreationInfo` and existing callers are unaffected.

## Test Plan

**Unit test.** Added `can read repo file info from a site-relative path` to the existing
`VSC Git Eager Strategy` block. It fails on `main` and passes with this change. Every existing
eager test passes an absolute path via `path.join(repoDir, ...)`, which is why this gap was not
covered.

```
pnpm vitest run packages/docusaurus-utils/src/vcs packages/docusaurus-plugin-sitemap
Test Files  5 passed (5)
     Tests  94 passed (94)
```

`eslint`, `tsc --noEmit`, `oxfmt --list-different` and `cspell` are all clean on the two changed
files.

**End to end**, using the reproduction repository from the issue
([eMUQI/docusaurus-vcs-sitemap-repro](https://github.com/eMUQI/docusaurus-vcs-sitemap-repro)),
building the same site twice with only this patch differing:

| `@docusaurus/utils` | `<url>` | `<lastmod>` |
|---|---|---|
| unmodified | 1 | 0 |
| with this change | 1 | 1 |

Its `npm run verify:repro` asserts that `default-v2` produces zero `<lastmod>`, so with the fix
applied that assertion now fails, which is the intended outcome.

### Test links

Not applicable: this changes build-time sitemap metadata rather than anything rendered, so there
is no UI to preview.

## Disclosure

This change was written with AI assistance (Claude), per the AI policy in CONTRIBUTING.md. I have
reviewed every line, verified the root cause against the reproduction repository above, and can
explain and defend the change in review.
