### PR TITLE
fix(utils): strip MDX export blocks before heading detection in parseMarkdownContentTitle

### DIFF
--- a/packages/docusaurus-utils/src/markdownUtils.ts
+++ b/packages/docusaurus-utils/src/markdownUtils.ts
@@ -255,11 +255,11 @@ export function parseMarkdownContentTitle(
   const removeContentTitleOption = options?.removeContentTitle ?? false;
 
   const content = contentUntrimmed.trim();
-  // We only need to detect import statements that will be parsed by MDX as
-  // `import` nodes, as broken syntax can't render anyways. That means any block
-  // that has `import` at the very beginning and surrounded by empty lines.
+  // We only need to detect import/export statements that will be parsed by MDX
+  // as `import`/`export` nodes. That means any block that starts with `import`
+  // or `export` at the very beginning and is separated by empty lines.
   const contentWithoutImport = content
-    .replace(/^(?:import\s(?:.|\r?\n(?!\r?\n))*(?:\r?\n){2,})*/, '')
+    .replace(/^(?:(?:import|export)\s(?:.|\r?\n(?!\r?\n))*(?:\r?\n){2,})*/, '')
     .trim();
 
   const regularTitleMatch = /^#[ \t]+(?<title>[^ \t].*)(?:\r?\n|$)/.exec(


### PR DESCRIPTION
`parseMarkdownContentTitle` strips leading MDX `import` blocks via a regex before looking for `# h1`, but does not strip `export` declarations (e.g. `export function Author() {...}` or `export const meta = ...`). When an MDX file has an `export` before the heading, the stripped content still starts with `export ...`, the title regex finds no match at position 0, and Docusaurus falls back to the site name for `<title>` and the sidebar.

**Fix:** add `export` as an alternative alongside `import` in the existing regex. The change is minimal — `import\s` becomes `(?:import|export)\s` — and the existing import-stripping behaviour is preserved exactly.

Fixes #12331