### PR TITLE
fix(a11y): size external link icon based on browser/OS font-size

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Icon/ExternalLink/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/ExternalLink/index.tsx
@@ -16,8 +16,8 @@ import styles from './styles.module.css';
 const svgSprite = '#theme-svg-external-link';
 
 export default function IconExternalLink({
-  width = 13.5,
-  height = 13.5,
+  width = '0.84375rem',
+  height = '0.84375rem',
 }: Props): ReactNode {
   return (
     <svg

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/NavbarNavLink.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/NavbarNavLink.tsx
@@ -40,7 +40,7 @@ export default function NavbarNavLink({
             {label}
             {isExternalLink && (
               <IconExternalLink
-                {...(isDropdownLink && {width: 12, height: 12})}
+                {...(isDropdownLink && {width: '0.75rem', height: '0.75rem'})}
               />
             )}
           </>


### PR DESCRIPTION
_See commit message(s)!_

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- N/A **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

I recently tested SVGO.dev with different font-sizes via the OS and browser settings to see how it'd behave. 

Ideally anything that depends on the font-size should be sized relative to the font-size (`em`/`rem`), and anything that isn't can use any other unit (`%`/`vw`/`px`/etc.).

The external link icon on Docusaurus didn't behave as I expected. I believe this is an example of something that should be based on font-size. Do you see any issue with using `rem` instead of `px`?

The numbers I used are not the prettiest (as in the code, the UI looks fine), because I wanted the UI to look identical on the default font-size. But I can ofc round them if you'd prefer, though that would leave a subtle visual difference!

## Screenshots

To demonstrate this, I'll include screenshots of your footer:

| | Before | After |
|---|---|---|
| Extra Small | <img width="2850" height="435" alt="localhost_3000_" src="https://github.com/user-attachments/assets/f8ffd20e-8758-4410-a3cc-8261a9315301" /> | <img width="2850" height="428" alt="localhost_3000_" src="https://github.com/user-attachments/assets/0de0b11d-39cd-4ebe-acdf-6067ee97293c" /> |
| Normal / Default | <img width="2850" height="623" alt="localhost_3000_ (1)" src="https://github.com/user-attachments/assets/fbf52584-76d0-4a2b-8a86-4b7a2c3fd66d" /> | <img width="2850" height="623" alt="localhost_3000_ (1)" src="https://github.com/user-attachments/assets/b492b692-dd04-479d-b8d0-ac6ba09d8c62" /> |
| Extra Large | <img width="2775" height="870" alt="localhost_3000_ (2)" src="https://github.com/user-attachments/assets/d6765dfa-271e-4847-8626-d3628fa2b107" /> | <img width="2775" height="870" alt="localhost_3000_ (2)" src="https://github.com/user-attachments/assets/4cafffb5-61ba-489f-b6b3-f800ba3ea23e" /> |

Normal / Default will look identical between before and after. Before the icon didn't scale with font-size, so in **Extra Small** it looks quite large, and on **Extra Large** it looked quite small. Now, it always looks proportionate to the text the icon is accompanying.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

I've added no unit tests, as given the wide use of the icon, I thought it was fine to just refer to the footer.

I also have what is effectively this patch deployed to SVGO.dev, so it's being tested there:

- [github.com/svg/svgo:patches/@docusaurus__theme-classic.patch](https://github.com/svg/svgo.dev/blob/main/patches/%40docusaurus__theme-classic.patch)
- [SVGO.dev](https://svgo.dev)

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-12336--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

N/A