### PR TITLE
docs: fix two dead external links (Create React App, Eta syntax)

### DIFF
--- a/website/docs/api/docusaurus.config.js.mdx
+++ b/website/docs/api/docusaurus.config.js.mdx
@@ -879,7 +879,7 @@ export default {
 
 ### `ssrTemplate` {/* #ssrTemplate */}
 
-An HTML template written in [Eta's syntax](https://eta.js.org/docs/syntax#syntax-overview) that will be used to render your application. This can be used to set custom attributes on the `body` tags, additional `meta` tags, customize the `viewport`, etc. Please note that Docusaurus will rely on the template to be correctly structured in order to function properly, once you do customize it, you will have to make sure that your template is compliant with the requirements from upstream.
+An HTML template written in [Eta's syntax](https://eta.js.org/docs/syntax/template-syntax) that will be used to render your application. This can be used to set custom attributes on the `body` tags, additional `meta` tags, customize the `viewport`, etc. Please note that Docusaurus will rely on the template to be correctly structured in order to function properly, once you do customize it, you will have to make sure that your template is compliant with the requirements from upstream.
 
 - Type: `string`
 

--- a/website/docs/styling-layout.mdx
+++ b/website/docs/styling-layout.mdx
@@ -199,7 +199,7 @@ Some React components, such as the header and the sidebar, implement different J
 
 ## CSS modules {/* #css-modules */}
 
-To style your components using [CSS Modules](https://github.com/css-modules/css-modules), name your stylesheet files with the `.module.css` suffix (e.g. `welcome.module.css`). Webpack will load such CSS files as CSS modules and you have to reference the class names as properties of the imported CSS module (as opposed to using plain strings). This is similar to the convention used in [Create React App](https://facebook.github.io/create-react-app/docs/adding-a-css-modules-stylesheet).
+To style your components using [CSS Modules](https://github.com/css-modules/css-modules), name your stylesheet files with the `.module.css` suffix (e.g. `welcome.module.css`). Webpack will load such CSS files as CSS modules and you have to reference the class names as properties of the imported CSS module (as opposed to using plain strings). This is similar to the convention used in [Create React App](https://create-react-app.dev/docs/adding-a-css-modules-stylesheet/).
 
 ```css title="styles.module.css"
 .main {


### PR DESCRIPTION
## Motivation

Two links in the docs return 404. Both point at sites that reorganised after the docs were written.

| Page | Link | Before | After |
| --- | --- | --- | --- |
| `styling-layout` | Create React App CSS Modules | `facebook.github.io/create-react-app/...` -> **404** | `create-react-app.dev/docs/adding-a-css-modules-stylesheet/` -> 200 |
| `api/docusaurus.config.js` | Eta syntax | `eta.js.org/docs/syntax#syntax-overview` -> **404** | `eta.js.org/docs/syntax/template-syntax` -> 200 |

For Eta I used the **unversioned** path. `eta.js.org/docs/syntax/template-syntax` 302s to the current `/docs/4.x.x/...`, so it will not rot again on the next Eta major. The destination page is titled "Template Syntax", which is what the sentence refers to.

## Test Plan

I extracted all 432 external URLs from `website/docs` and checked each one. Beyond these two, everything either returns 200, is an intentional placeholder (`mysite.com`, `my-org.github.io`), or 403s because the host blocks automated requests (npmjs, StackOverflow, Algolia) - those are fine in a browser, so I left them alone.

## One I did not touch

`migration/v3.mdx` links an MDX v1 playground at `mdx-git-renovate-babel-monorepo-mdx.vercel.app/playground/`, which is also dead. That was an ephemeral Vercel preview for a Renovate branch that no longer exists, and I could not find a permanent MDX v1 playground to replace it with. Removing the bullet outright felt like a content decision for a maintainer rather than a link fix, so I left it and am flagging it here.