### PR TITLE
docs: fix grammar in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Meta has adopted a Code of Conduct that we expect project participants to adhere
 
 ## Get Involved
 
-There are many ways to contribute to Docusaurus, and many of them do not involve writing any code. Here's a few ideas to get started:
+There are many ways to contribute to Docusaurus, and many of them do not involve writing any code. Here are a few ideas to get started:
 
 - Simply start using Docusaurus. Go through the [Getting Started](https://docusaurus.io/docs/installation) guide. Does everything work as expected? If not, we're always looking for improvements. Let us know by [opening an issue](#issues).
 - Look through the [open issues](https://github.com/facebook/docusaurus/issues). Provide workarounds, ask for clarification, or suggest labels. Help [triage issues](#triaging-issues-and-pull-requests).


### PR DESCRIPTION
## Description

This PR fixes a grammatical error in the CONTRIBUTING.md file.

## Changes
- Changed 'Here's a few ideas' to 'Here are a few ideas' to correct subject-verb agreement
- The plural noun 'ideas' requires 'are' instead of 'is' (contracted as 'Here's')

## Testing
- Verified the change maintains the sentence meaning
- Checked that the fix improves grammatical correctness

## Type
- [x] Documentation improvement
- [ ] Bug fix
- [ ] New feature

This is a minor grammar fix that improves the documentation quality.