### PR TITLE
fix(vcs): handle MSYS/Git Bash POSIX paths on Windows

### DIFF
--- a/packages/docusaurus-utils/src/vcs/gitUtils.ts
+++ b/packages/docusaurus-utils/src/vcs/gitUtils.ts
@@ -275,6 +275,28 @@ export async function isGitInsideWorktree(cwd: string): Promise<boolean> {
   }
 }
 
+/**
+ * Normalizes MSYS/Git Bash paths on Windows from POSIX format to Windows format.
+ * For example: /c/Users/... -> C:\Users\...
+ * This fixes issues where Git on Windows (via MSYS/Git Bash) returns POSIX-style paths.
+ */
+function normalizeMSYSPath(gitPath: string): string {
+  // Only apply on Windows
+  if (process.platform !== 'win32') {
+    return gitPath;
+  }
+
+  // Match MSYS-style paths like /c/..., /d/..., /p/... etc.
+  const msysMatch = gitPath.match(/^\/([a-z])\/(.*)$/i);
+  if (msysMatch) {
+    const driveLetter = msysMatch[1]!.toUpperCase();
+    const restOfPath = msysMatch[2]!.replace(/\//g, '\\');
+    return `${driveLetter}:\\${restOfPath}`;
+  }
+
+  return gitPath;
+}
+
 export async function getGitRepoRoot(cwd: string): Promise<string> {
   const createErrorMessageBase = () => {
     return `Couldn't find the git repository root directory
@@ -303,7 +325,10 @@ The command returned exit code ${logger.code(result.exitCode)}: ${logger.subdue(
     );
   }
 
-  return fs.realpath.native(result.stdout.trim());
+  const gitPath = result.stdout.trim();
+  // Normalize MSYS paths before passing to fs.realpath
+  const normalizedPath = normalizeMSYSPath(gitPath);
+  return fs.realpath.native(normalizedPath);
 }
 
 // A Git "superproject" is a Git repository that contains submodules
@@ -347,7 +372,8 @@ The command returned exit code ${logger.code(result.exitCode)}: ${logger.subdue(
   // this command only works when inside submodules
   // otherwise it doesn't return anything when we are inside the main repo
   if (output) {
-    return fs.realpath.native(output);
+    const normalizedOutput = normalizeMSYSPath(output);
+    return fs.realpath.native(normalizedOutput);
   }
   return getGitRepoRoot(cwd);
 }


### PR DESCRIPTION
## Summary
This PR fixes a critical bug on Windows where builds fail due to incorrect Git POSIX path conversion.

## Fixes
Closes #11920

## Problem
When using Git on Windows with MSYS/Git Bash, git rev-parse --show-toplevel returns POSIX-style paths like /p/projets/my-repo. However, fs.realpath() expects Windows paths like P:\projets\my-repo, causing builds to fail with:

ENOENT: no such file or directory, realpath 'P:\p\projets\my-repo'

## Solution
Added normalizeMSYSPath() function that:
- Only runs on Windows (process.platform === 'win32')
- Detects MSYS-style paths matching /[drive]/...
- Converts them to proper Windows format DRIVE:\...
- Applies conversion before calling fs.realpath()

## Changes
- Added normalizeMSYSPath() helper function
- Modified getGitRepoRoot() to normalize paths
- Modified getGitSuperProjectRoot() to normalize paths

## Testing
This fix addresses the exact pattern described in #11920:
- Input: /p/projets/my-repo
- Output: P:\projets\my-repo

## Impact
- Fixes builds on Windows with Git Bash/MSYS
- No impact on Linux/macOS
- No impact on Windows with non-MSYS Git
- Backward compatible (only affects specific Windows+MSYS scenario)

## Type of Change
- Bug fix (fixes #11920)
- Windows compatibility
- Non-breaking change