### PR TITLE
fix(theme-common): finalize collapse state when transition duration is 0ms

### DIFF
--- a/packages/docusaurus-theme-common/src/components/Collapsible/__tests__/index.test.tsx
+++ b/packages/docusaurus-theme-common/src/components/Collapsible/__tests__/index.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// @vitest-environment jsdom
+import {describe, expect, it, vi} from 'vitest';
+import React from 'react';
+import {render} from '@testing-library/react';
+import {Collapsible} from '../index';
+
+// jsdom never fires a native `transitionend` event for CSS transitions. This
+// happens to reproduce exactly what real browsers do when the transition
+// duration is 0ms (e.g. via a user CSS override, or prefers-reduced-motion)
+// — see https://github.com/facebook/docusaurus/issues/12043
+describe('Collapsible', () => {
+  it('finalizes the collapsed state through the fallback timer when the transition duration is 0ms', async () => {
+    vi.useFakeTimers({
+      toFake: [
+        'setTimeout',
+        'clearTimeout',
+        'requestAnimationFrame',
+        'cancelAnimationFrame',
+      ],
+    });
+    const onCollapseTransitionEnd = vi.fn();
+
+    function renderCollapsible(collapsed: boolean) {
+      return (
+        <Collapsible
+          collapsed={collapsed}
+          lazy={false}
+          animation={{duration: 0}}
+          onCollapseTransitionEnd={onCollapseTransitionEnd}>
+          content
+        </Collapsible>
+      );
+    }
+
+    const {rerender} = render(renderCollapsible(false));
+    rerender(renderCollapsible(true));
+
+    await vi.runAllTimersAsync();
+
+    expect(onCollapseTransitionEnd).toHaveBeenCalledWith(true);
+
+    vi.useRealTimers();
+  });
+
+  it('does not finalize twice when both the fallback timer and transitionend would apply', async () => {
+    vi.useFakeTimers({
+      toFake: [
+        'setTimeout',
+        'clearTimeout',
+        'requestAnimationFrame',
+        'cancelAnimationFrame',
+      ],
+    });
+    const onCollapseTransitionEnd = vi.fn();
+
+    function renderCollapsible(collapsed: boolean) {
+      return (
+        <Collapsible
+          collapsed={collapsed}
+          lazy={false}
+          animation={{duration: 200}}
+          onCollapseTransitionEnd={onCollapseTransitionEnd}>
+          content
+        </Collapsible>
+      );
+    }
+
+    const {container, rerender} = render(renderCollapsible(false));
+    rerender(renderCollapsible(true));
+
+    await vi.runAllTimersAsync();
+
+    // Simulate the real transitionend event also firing, as it normally
+    // would in a browser for a non-zero duration transition.
+    const el = container.firstElementChild!;
+    el.dispatchEvent(
+      new Event('transitionend', {bubbles: true}) as TransitionEvent,
+    );
+    Object.defineProperty(el, 'propertyName', {value: 'height'});
+
+    expect(onCollapseTransitionEnd).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+  });
+});

--- a/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
+++ b/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
@@ -73,9 +73,7 @@ https://github.com/mui-org/material-ui/blob/e724d98eba018e55e1a684236a2037e24bcf
  */
 function getAutoHeightDuration(height: number) {
   if (prefersReducedMotion()) {
-    // Not using 0 because it prevents onTransitionEnd to fire and bubble up :/
-    // See https://github.com/facebook/docusaurus/pull/8906
-    return 1;
+    return 0;
   }
   const constant = height / 36;
   return Math.round((4 + 15 * constant ** 0.25 + constant / 5) * 10);
@@ -90,15 +88,34 @@ function useCollapseAnimation({
   collapsibleRef,
   collapsed,
   animation,
+  onCollapseTransitionEnd,
 }: {
   collapsibleRef: RefObject<HTMLElement | null>;
   collapsed: boolean;
   animation?: CollapsibleAnimationConfig;
-}) {
+  onCollapseTransitionEnd?: (collapsed: boolean) => void;
+}): () => void {
   const mounted = useRef(false);
+
+  // Guards against double-finalizing when both the transitionend event and
+  // the fallback timer below end up firing for the same transition.
+  const finalizedRef = useRef(true);
+
+  const finalize = useCallback(() => {
+    if (finalizedRef.current) {
+      return;
+    }
+    finalizedRef.current = true;
+    const el = collapsibleRef.current;
+    if (el) {
+      applyCollapsedStyle(el, collapsed);
+    }
+    onCollapseTransitionEnd?.(collapsed);
+  }, [collapsibleRef, collapsed, onCollapseTransitionEnd]);
 
   useEffect(() => {
     const el = collapsibleRef.current!;
+    let fallbackTimer: ReturnType<typeof setTimeout> | undefined;
 
     function getTransitionStyles() {
       const height = el.scrollHeight;
@@ -107,6 +124,7 @@ function useCollapseAnimation({
       return {
         transition: `height ${duration}ms ${easing}`,
         height: `${height}px`,
+        duration,
       };
     }
 
@@ -114,6 +132,12 @@ function useCollapseAnimation({
       const transitionStyles = getTransitionStyles();
       el.style.transition = transitionStyles.transition;
       el.style.height = transitionStyles.height;
+      // A transition with a duration of 0ms — whether from
+      // prefers-reduced-motion, a very small item, or a user CSS override
+      // (see https://github.com/facebook/docusaurus/issues/12043) — never
+      // fires `transitionend`. Schedule a fallback so the collapsed/expanded
+      // state still gets finalized in that case.
+      fallbackTimer = setTimeout(finalize, transitionStyles.duration);
     }
 
     // On mount, we just apply styles, no animated transition
@@ -124,6 +148,7 @@ function useCollapseAnimation({
     }
 
     el.style.willChange = 'height';
+    finalizedRef.current = false;
 
     function startAnimation() {
       const animationFrame = requestAnimationFrame(() => {
@@ -148,8 +173,15 @@ function useCollapseAnimation({
       return () => cancelAnimationFrame(animationFrame);
     }
 
-    return startAnimation();
-  }, [collapsibleRef, collapsed, animation]);
+    const cancelAnimation = startAnimation();
+
+    return () => {
+      cancelAnimation();
+      clearTimeout(fallbackTimer);
+    };
+  }, [collapsibleRef, collapsed, animation, finalize]);
+
+  return finalize;
 }
 
 type CollapsibleElementType = React.ElementType<
@@ -185,7 +217,12 @@ function CollapsibleBase({
 }: CollapsibleBaseProps) {
   const collapsibleRef = useRef<HTMLElement>(null);
 
-  useCollapseAnimation({collapsibleRef, collapsed, animation});
+  const finalize = useCollapseAnimation({
+    collapsibleRef,
+    collapsed,
+    animation,
+    onCollapseTransitionEnd,
+  });
 
   return (
     <As
@@ -196,9 +233,7 @@ function CollapsibleBase({
         if (e.propertyName !== 'height') {
           return;
         }
-
-        applyCollapsedStyle(collapsibleRef.current!, collapsed);
-        onCollapseTransitionEnd?.(collapsed);
+        finalize();
       }}
       className={className}>
       {children}


### PR DESCRIPTION
## Motivation

Fixes #12043.

`Collapsible` relied solely on the `transitionend` DOM event to finalize collapsed/expanded state (applying `display: none`, cleaning up inline styles, calling `onCollapseTransitionEnd`). When the CSS transition duration is `0ms` — whether from a user CSS override (as reported in #12043) or from `prefers-reduced-motion` — `transitionend` never fires in the browser, so the component gets stuck with stale inline styles.

This also lets us remove the old `prefers-reduced-motion` `1ms` hack added in #8906, since the new fallback timer handles the zero-duration case generically instead of needing a magic non-zero value to force the event to fire.

## Change

`packages/docusaurus-theme-common/src/components/Collapsible/index.tsx`:

- `getAutoHeightDuration` now returns `0` (not `1`) for `prefers-reduced-motion`, since it no longer needs to dodge the `transitionend` bug.
- `useCollapseAnimation` now schedules a `setTimeout` fallback (matching the transition duration) alongside the existing `transitionend` listener. Whichever fires first finalizes the state via a shared `finalize()` callback; a `finalizedRef` guard prevents double-finalizing if both fire.
- `CollapsibleBase`'s `onTransitionEnd` handler now calls the same shared `finalize()` instead of duplicating the finalization logic inline.

## Test Plan

Added `packages/docusaurus-theme-common/src/components/Collapsible/__tests__/index.test.tsx`:
- Confirms `onCollapseTransitionEnd` fires via the fallback timer when the transition duration is `0ms` (reproduces #12043 — this test fails against the pre-fix code and passes against the fix).
- Confirms no double-finalization when both the fallback timer and a real `transitionend` event apply.

Commands run locally, all passing:

```bash
pnpm --filter @docusaurus/theme-common build      # clean build
npx tsc --noEmit                                   # clean typecheck (from package dir)
npx eslint packages/docusaurus-theme-common/src/components/Collapsible/index.tsx   # clean
npx oxfmt --check packages/docusaurus-theme-common/src/components/Collapsible/     # clean
npx vitest run packages/docusaurus-theme-common    # 121/121 passing (16 files)
npx cspell packages/docusaurus-theme-common/src/components/Collapsible/            # clean
