### PR TITLE
feat(utils): safely parse front matter date in readLastUpdateData (Fixes #5691)

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/lastUpdateUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/lastUpdateUtils.test.ts
@@ -61,6 +61,14 @@ describe('readLastUpdateData', () => {
       expect(lastUpdatedBy).toBeNull();
       expect(lastUpdatedAt).toEqual(testTimestamp);
     });
+
+    it('handles invalid date string in front matter gracefully', async () => {
+      const {lastUpdatedAt, lastUpdatedBy} = await readUntrackedFile({
+        date: 'invalid-date-string',
+      });
+      expect(lastUpdatedAt).toBeNull();
+      expect(lastUpdatedBy).toBeNull();
+    });
   });
 
   it('read last time show author time', async () => {

--- a/packages/docusaurus-utils/src/lastUpdateUtils.ts
+++ b/packages/docusaurus-utils/src/lastUpdateUtils.ts
@@ -61,9 +61,10 @@ export async function readLastUpdateData(
   }
 
   const frontMatterAuthor = lastUpdateFrontMatter?.author;
-  const frontMatterTimestamp = lastUpdateFrontMatter?.date
-    ? new Date(lastUpdateFrontMatter.date).getTime()
-    : undefined;
+  const rawDate = lastUpdateFrontMatter?.date;
+  const parsedDate = rawDate ? new Date(rawDate).getTime() : undefined;
+  const frontMatterTimestamp =
+    parsedDate && !Number.isNaN(parsedDate) ? parsedDate : undefined;
 
   // We try to minimize git last update calls
   // We call it at most once


### PR DESCRIPTION
## Description
Fixes #5691 by ensuring invalid date strings in front matter `last_update.date` / `date` are safely handled in `readLastUpdateData` without propagating `NaN` timestamps or breaking VCS fallback lookups.

### Changes
1. Safely validate parsed timestamp via `Number.isNaN(parsedDate)` in `packages/docusaurus-utils/src/lastUpdateUtils.ts`.
2. Added unit test `handles invalid date string in front matter gracefully` in `packages/docusaurus-utils/src/__tests__/lastUpdateUtils.test.ts`.

## Test Plan
- Added unit test covering invalid front matter date strings.
