### PR TITLE
fix(utils): resolve relative paths in VscGitEager

### DIFF
--- a/packages/docusaurus-utils/src/vcs/vcsGitEager.ts
+++ b/packages/docusaurus-utils/src/vcs/vcsGitEager.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {resolve, basename} from 'node:path';
+import {resolve, basename, isAbsolute} from 'node:path';
 import logger, {PerfLogger} from '@docusaurus/logger';
 import {
   getGitAllRepoRoots,
@@ -82,11 +82,15 @@ async function initialize({
 
 export function createVcsGitEagerConfig(): VcsConfig {
   let initPromise: Promise<InitializeResult> | null = null;
+  let currentSiteDir: string;
 
   async function getGitFileInfo(filePath: string): Promise<GitFileInfo | null> {
     const init = (await initPromise)!;
     if (init.type === 'success') {
-      return init.filesMap.get(filePath) ?? null;
+      const absoluteFilePath = isAbsolute(filePath)
+        ? filePath
+        : resolve(currentSiteDir, filePath);
+      return init.filesMap.get(absoluteFilePath) ?? null;
     } else if (init.reason === 'not-in-worktree') {
       throw new Error(
         `This Docusaurus site is outside any Git worktree.
@@ -114,6 +118,7 @@ Unable to read Git info for file ${logger.path(filePath)} `,
         return;
       }
 
+      currentSiteDir = siteDir;
       initPromise = PerfLogger.async('Git Eager VCS init', () =>
         initialize({siteDir}),
       );


### PR DESCRIPTION
Fixes #12322.

The `vcsGitEager` map keys are absolute paths, but plugins like `content-docs` and `sitemap` use `aliasedSitePathToRelativePath` to generate relative `sourceFilePath` strings. When these relative paths were passed to `getFileLastUpdateInfo`, the map lookup failed and returned `null`.

This PR fixes this by keeping track of the `siteDir` upon initialization and resolving incoming relative paths against it before looking them up in the map.