### PR TITLE
fix(utils): preserve inline code containing XML-like text in excerpts

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
@@ -153,6 +153,22 @@ describe('createExcerpt', () => {
     );
   });
 
+  it('creates excerpt for inline code containing XML-like text', () => {
+    expect(
+      createExcerpt(dedent`
+          Removes the [\`<metadata>\`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/metadata) element from the document.
+        `),
+    ).toBe('Removes the <metadata> element from the document.');
+  });
+
+  it('creates excerpt for inline code containing XML-like text in a linkless sentence', () => {
+    expect(
+      createExcerpt(dedent`
+          Removes the \`<metadata>\` element from the document.
+        `),
+    ).toBe('Removes the <metadata> element from the document.');
+  });
+
   it('creates excerpt for heading specified with anchor-id syntax', () => {
     expect(
       createExcerpt(dedent`

--- a/packages/docusaurus-utils/src/markdownUtils.ts
+++ b/packages/docusaurus-utils/src/markdownUtils.ts
@@ -94,6 +94,10 @@ export function createExcerpt(fileString: string): string | undefined {
   let inImport = false;
   let inHTML = false;
   let lastCodeFence = '';
+  const inlineCodeSegments: string[] = [];
+
+  const inlineCodeToken = (index: number) =>
+    `\u0000excerpt-inline-code-${index}\u0000`;
 
   for (const fileLine of fileLines) {
     // An empty line marks the end of imports
@@ -142,7 +146,17 @@ export function createExcerpt(fileString: string): string | undefined {
       continue;
     }
 
-    const cleanedLine = fileLine
+    const lineWithProtectedInlineCode = fileLine.replace(
+      /`(?<text>.+?)`/g,
+      (_match, _text, offset, _input, groups) => {
+        const text = groups?.text ?? _text;
+        const token = inlineCodeToken(inlineCodeSegments.length);
+        inlineCodeSegments.push(text);
+        return token;
+      },
+    );
+
+    const cleanedLine = lineWithProtectedInlineCode
       // Remove HTML tags.
       .replace(/<[^>]*>/g, '')
       // Remove Title headers
@@ -169,6 +183,10 @@ export function createExcerpt(fileString: string): string | undefined {
       .replace(/\s?:(?:::|[^:\n])+:/g, '')
       // Remove custom Markdown heading id.
       .replace(/\{#*[\w-]+\}/, '')
+      .replace(
+        /\u0000excerpt-inline-code-(\d+)\u0000/g,
+        (_match, index: string) => inlineCodeSegments[Number(index)] ?? '',
+      )
       .trim();
 
     if (cleanedLine) {


### PR DESCRIPTION
Fix createExcerpt() so inline code survives the HTML-stripping pass, which was dropping text like `<metadata>` from excerpts.

Added regression tests for inline code containing XML-like text, both with and without a surrounding link.

Closes #11818