### PR TITLE
fix(content-blog): resolve anchor links in truncated blog previews

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/__tests__/blogUtils.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/blogUtils.test.ts
@@ -9,6 +9,7 @@ import {describe, expect, it, vi} from 'vitest';
 import {fromPartial} from '@total-typescript/shoehorn';
 import {
   truncate,
+  resolveTruncatedAnchorLinks,
   parseBlogFileName,
   paginateBlogPosts,
   applyProcessBlogPosts,
@@ -31,6 +32,52 @@ describe('truncate', () => {
       'aaa\nbbb\n ccc',
     );
     expect(truncate('', /<!-- truncate -->/)).toBe('');
+  });
+});
+
+describe('resolveTruncatedAnchorLinks', () => {
+  const permalink = '/blog/2021/01/01/my-post';
+
+  it('rebases a bare in-page anchor link to the post permalink', () => {
+    expect(
+      resolveTruncatedAnchorLinks('See [the section](#section).', permalink),
+    ).toBe('See [the section](/blog/2021/01/01/my-post#section).');
+  });
+
+  it('preserves a link title after the anchor', () => {
+    expect(
+      resolveTruncatedAnchorLinks('[x](#section "Title")', permalink),
+    ).toBe('[x](/blog/2021/01/01/my-post#section "Title")');
+  });
+
+  it('rebases an anchor inside angle brackets', () => {
+    expect(resolveTruncatedAnchorLinks('[x](<#section>)', permalink)).toBe(
+      '[x](</blog/2021/01/01/my-post#section>)',
+    );
+  });
+
+  it('rebases multiple anchor links', () => {
+    expect(
+      resolveTruncatedAnchorLinks('[a](#one) and [b](#two)', permalink),
+    ).toBe(
+      '[a](/blog/2021/01/01/my-post#one) and [b](/blog/2021/01/01/my-post#two)',
+    );
+  });
+
+  it('leaves non-anchor links untouched', () => {
+    // Relative and Markdown links are resolved elsewhere in the MDX pipeline.
+    expect(
+      resolveTruncatedAnchorLinks(
+        '[a](./other.md) [b](../x) [c](#)',
+        permalink,
+      ),
+    ).toBe('[a](./other.md) [b](../x) [c](#)');
+    expect(
+      resolveTruncatedAnchorLinks(
+        '[a](https://example.com#frag) [b](/blog/other#x)',
+        permalink,
+      ),
+    ).toBe('[a](https://example.com#frag) [b](/blog/other#x)');
   });
 });
 

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -47,6 +47,38 @@ export function truncate(fileString: string, truncateMarker: RegExp): string {
   return fileString.split(truncateMarker, 1).shift()!;
 }
 
+// Matches the destination of a Markdown inline link/image pointing to a bare
+// in-page anchor, e.g. the "#anchor" in "[text](#anchor)" (an optional title or
+// surrounding <> may follow). Other relative links (./x, ../x, x.md) are
+// intentionally excluded: they are resolved elsewhere in the MDX pipeline.
+const AnchorLinkTargetRegex = /(?<before>\]\(\s*<?)(?<hash>#[^\s)>]+)/g;
+
+/**
+ * In blog paginated list views (tags, authors, "/blog"...), a truncated post
+ * preview is rendered under the list page URL, not under the post permalink.
+ * A relative in-page anchor link such as `[jump](#section)` would then resolve
+ * against the list page (e.g. `/blog#section`) and lead nowhere.
+ *
+ * This rebases bare `#anchor` link targets found in a truncated preview to the
+ * post's own permalink, so those anchors keep pointing at the post in list
+ * views. Only bare anchors are rewritten; other relative links are handled by
+ * the regular MDX link-resolution plugins and are left untouched here.
+ *
+ * Note: like other string-level Markdown transforms in Docusaurus, this is a
+ * best-effort pass and does not skip anchors written inside code spans/blocks.
+ *
+ * See https://github.com/facebook/docusaurus/issues/9731
+ */
+export function resolveTruncatedAnchorLinks(
+  fileString: string,
+  permalink: string,
+): string {
+  return fileString.replace(
+    AnchorLinkTargetRegex,
+    (match, before: string, hash: string) => `${before}${permalink}${hash}`,
+  );
+}
+
 export function reportUntruncatedBlogPosts({
   blogPosts,
   onUntruncatedBlogPosts,

--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -171,6 +171,8 @@ export default async function pluginContentBlog(
     function createBlogMarkdownLoader(): RuleSetUseItem {
       const markdownLoaderOptions: BlogMarkdownLoaderOptions = {
         truncateMarker,
+        siteDir,
+        sourceToPermalink: contentHelpers.sourceToPermalink,
       };
       return {
         loader: path.resolve(__dirname, './markdownLoader.js'),

--- a/packages/docusaurus-plugin-content-blog/src/markdownLoader.ts
+++ b/packages/docusaurus-plugin-content-blog/src/markdownLoader.ts
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {truncate} from './blogUtils';
+import {aliasedSitePath} from '@docusaurus/utils';
+import {resolveTruncatedAnchorLinks, truncate} from './blogUtils';
 import type {BlogMarkdownLoaderOptions} from './types';
 import type {LoaderContext} from 'webpack';
 
@@ -28,6 +29,15 @@ export default function markdownLoader(
   // TODO truncate with the AST instead of the string ?
   if (truncated) {
     finalContent = truncate(finalContent, markdownLoaderOptions.truncateMarker);
+
+    // In list views the truncated preview is rendered under the list page URL,
+    // so in-page anchor links must be rebased to the post permalink (#9731).
+    const permalink = markdownLoaderOptions.sourceToPermalink.get(
+      aliasedSitePath(this.resourcePath, markdownLoaderOptions.siteDir),
+    );
+    if (permalink) {
+      finalContent = resolveTruncatedAnchorLinks(finalContent, permalink);
+    }
   }
 
   return callback(null, finalContent);

--- a/packages/docusaurus-plugin-content-blog/src/types.ts
+++ b/packages/docusaurus-plugin-content-blog/src/types.ts
@@ -11,4 +11,8 @@ export type BlogContentPaths = ContentPaths;
 
 export type BlogMarkdownLoaderOptions = {
   truncateMarker: RegExp;
+  siteDir: string;
+  // Mutable map (see contentHelpers), keyed by aliased source path.
+  // Used to rebase in-page anchor links in truncated previews, see #9731.
+  sourceToPermalink: Map<string, string>;
 };


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #9731) and the maintainers have approved on my working plan.

> This is a small, focused bug fix rather than a new API or substantial change, so the last box is left unchecked. It closes #9731.

## Motivation

Closes #9731 (see also #10287).

In blog paginated list views (`/blog`, tags pages, author pages), a post preview is rendered under the **list page** URL, not the post permalink. An in-page anchor link written above the truncate marker, e.g.

```md
Jump to [the details](#details) below.

{/* truncate */}

## Details
```

was left relative and therefore resolved against the list page — `/blog#details` — instead of the post, so clicking it in a preview leads nowhere. On the full post page the same link works, because it resolves against the post URL. `onBrokenAnchors` also reports these as broken.

## The fix

The blog markdown loader already truncates the preview inside its `?truncated=true` branch — the one place in the pipeline that knows it is producing a list-view preview (the full post page is a separate compilation with no query). There we now rebase bare `#anchor` link targets to the current post permalink, using the `source -> permalink` map the plugin already maintains for Markdown link resolution.

Only bare `#anchor` targets are rewritten. Other relative links (`./x`, `../x`, `x.md`) are intentionally left untouched — they are handled later in the MDX pipeline (`resolveMarkdownLinks` / `transformLinks`) — and absolute/external links are ignored. The full post page is not affected, so same-page anchors there remain native `<a href="#…">` links.

Changed files (all in `docusaurus-plugin-content-blog`):
- `blogUtils.ts` — new `resolveTruncatedAnchorLinks(content, permalink)` helper.
- `markdownLoader.ts` — call it in the `truncated` branch, resolving the current post permalink from `this.resourcePath`.
- `index.ts` / `types.ts` — pass `siteDir` and the `sourceToPermalink` map to the loader.

## Test Plan

**Unit tests** (`blogUtils.test.ts`, `describe('resolveTruncatedAnchorLinks')`): 5 cases covering bare anchors, a following title, `<…>`-wrapped targets, multiple anchors, and that non-anchor/absolute/external links are left untouched. `yarn test blogUtils` (vitest) is green; ESLint and the formatter pass.

**End-to-end** on a fresh `classic` site with a post containing `[the details section](#details)` above the truncate marker and a `## Details` heading below:

| | before | after |
|---|---|---|
| List view `/blog` | `<a href="#details">` (→ `/blog#details`, broken) | `<a href="/blog/…/post#details">` |
| Author page | `<a href="#details">` (broken) | `<a href="/blog/…/post#details">` |
| Post page | `<a href="#details">` | `<a href="#details">` (unchanged) |
| `onBrokenAnchors` build report | reports `/blog` → `#details` broken | no broken anchors |

### Test links

Deploy preview: https://deploy-preview-12364--docusaurus-2.netlify.app/

## Related issues/PRs

Closes #9731. Related: #10287.
