### PR TITLE
fix(content-docs): detect h1 title when export declaration precedes it

### DIFF
--- a/packages/docusaurus-utils/src/markdownUtils.ts
+++ b/packages/docusaurus-utils/src/markdownUtils.ts
@@ -255,11 +255,12 @@ export function parseMarkdownContentTitle(
   const removeContentTitleOption = options?.removeContentTitle ?? false;
 
   const content = contentUntrimmed.trim();
-  // We only need to detect import statements that will be parsed by MDX as
-  // `import` nodes, as broken syntax can't render anyways. That means any block
-  // that has `import` at the very beginning and surrounded by empty lines.
+  // We only need to detect import/export statements that will be parsed by MDX
+  // as `import` or `export` nodes, as broken syntax can't render anyways.
+  // That means any block that has `import` or `export` at the very beginning
+  // and surrounded by empty lines.
   const contentWithoutImport = content
-    .replace(/^(?:import\s(?:.|\r?\n(?!\r?\n))*(?:\r?\n){2,})*/, '')
+    .replace(/^(?:(?:import|export)\s(?:.|\r?\n(?!\r?\n))*(?:\r?\n){2,})*/, '')
     .trim();
 
   const regularTitleMatch = /^#[ \t]+(?<title>[^ \t].*)(?:\r?\n|$)/.exec(


### PR DESCRIPTION
## Summary\n\nWhen an MDX file has an `export` declaration (e.g. `export function Author()`) before the `# h1` heading, `parseMarkdownContentTitle` failed to detect the title. The page ended up using the site name instead of the h1 content.\n\n## Problem\n\n`parseMarkdownContentTitle` strips preamble declarations before searching for the h1, using this regex:\n\n```ts\n// Before\nconst contentWithoutImport = content\n  .replace(/^(?:import\\s(?:.|\\r?\\n(?!\\r?\\n))*(?:\\r?\\n){2,})*/, '')\n  .trim();\n```\n\nThe regex only handled `import` statements. When an `export` block (like a component definition) appeared before the heading, it was left in place, causing the title search to fail against the exported function body instead of the actual heading.\n\n**Example that fails before this fix:**\n\n```mdx\nimport PKG from '../../package.json';\n\nexport function Author() {\n  return <a href={`mailto:${PKG.author.email}`}>{PKG.author.name}</a>;\n}\n\n# Privacy Policy\n\nFor any questions, please email <Author />.\n```\n\n## Solution\n\nExtend the alternation from `import\\s` to `(?:import|export)\\s` so that `export` blocks followed by a blank line are also stripped before the heading search:\n\n```ts\n// After\nconst contentWithoutImport = content\n  .replace(/^(?:(?:import|export)\\s(?:.|\\r?\\n(?!\\r?\\n))*(?:\\r?\\n){2,})*/, '')\n  .trim();\n```\n\nFixes #12331