### PR TITLE
fix(minifier): Keep attribute quotes in the SWC HTML minifier

### DIFF
--- a/packages/docusaurus-bundler/src/minifyHtml.ts
+++ b/packages/docusaurus-bundler/src/minifyHtml.ts
@@ -88,6 +88,11 @@ async function getSwcMinifier(): Promise<HtmlMinifier> {
           // See https://github.com/swc-project/swc/issues/10994
           tagOmission: 'keep-head-and-body',
 
+          // Keep attribute quotes. WhatsApp and some RDFa parsers ignore
+          // og:image when the minifier emits property=og:image without quotes.
+          // See https://github.com/facebook/docusaurus/issues/12368
+          quotes: true,
+
           // Sorting these attributes (class) can lead to React hydration errors
           sortSpaceSeparatedAttributeValues: false,
           sortAttributes: false,


### PR DESCRIPTION
Fixes facebook/docusaurus#12368

The SWC HTML minifier drops quotes from attributes, so og:image becomes property=og:image. WhatsApp then ignores the image in link previews.

Passing quotes: true keeps quoted attributes while still using the fast SWC minifier. The Terser HTML minifier path already keeps quotes.