### PR TITLE
fix(utils): preserve hash symbols in heading titles when generating meta description

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
@@ -75,6 +75,44 @@ describe('createExcerpt', () => {
     ).toBe('Lorem ipsum dolor sit amet');
   });
 
+  it('creates excerpt for content with h1 containing hash symbols (C#, F#)', () => {
+    expect(
+      createExcerpt(dedent`
+          # C# Programming Guide
+
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ex urna, molestie et sagittis ut, varius ac justo.
+
+          Nunc porttitor libero nec vulputate venenatis. Nam nec rhoncus mauris. Morbi tempus est et nibh maximus, tempus venenatis arcu lobortis.
+        `),
+    ).toBe(
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ex urna, molestie et sagittis ut, varius ac justo.',
+    );
+    expect(
+      createExcerpt(dedent`
+          # Introduction to F# and C#
+
+          Learn functional and object-oriented programming.
+        `),
+    ).toBe('Learn functional and object-oriented programming.');
+  });
+
+  it('creates excerpt for content with h2 heading containing hash symbols (C#, F#)', () => {
+    expect(
+      createExcerpt(dedent`
+          ## C# is awesome
+
+          Nunc porttitor libero nec vulputate venenatis.
+        `),
+    ).toBe('C# is awesome');
+    expect(
+      createExcerpt(dedent`
+          ## F# Guide ##
+
+          Nunc porttitor libero nec vulputate venenatis.
+        `),
+    ).toBe('F# Guide');
+  });
+
   it('creates excerpt for content beginning with blockquote', () => {
     expect(
       createExcerpt(dedent`
@@ -329,6 +367,56 @@ Lorem Ipsum
     expect(parseMarkdownContentTitle(markdown)).toEqual({
       content: markdown,
       contentTitle: 'Markdown Title',
+    });
+  });
+
+  it('parses markdown h1 title with hash symbols (C#, F#)', () => {
+    const csharpMarkdown = dedent`
+
+          # C# Guide
+
+          Lorem Ipsum
+
+        `;
+    expect(parseMarkdownContentTitle(csharpMarkdown)).toEqual({
+      content: csharpMarkdown,
+      contentTitle: 'C# Guide',
+    });
+
+    const csharpOnlyMarkdown = dedent`
+
+          # C#
+
+          Lorem Ipsum
+
+        `;
+    expect(parseMarkdownContentTitle(csharpOnlyMarkdown)).toEqual({
+      content: csharpOnlyMarkdown,
+      contentTitle: 'C#',
+    });
+
+    const fsharpClosingHashMarkdown = dedent`
+
+          # F# Guide ##
+
+          Lorem Ipsum
+
+        `;
+    expect(parseMarkdownContentTitle(fsharpClosingHashMarkdown)).toEqual({
+      content: fsharpClosingHashMarkdown,
+      contentTitle: 'F# Guide',
+    });
+
+    const csharpAnchorMarkdown = dedent`
+
+          # C# {#csharp-anchor}
+
+          Lorem Ipsum
+
+        `;
+    expect(parseMarkdownContentTitle(csharpAnchorMarkdown)).toEqual({
+      content: csharpAnchorMarkdown,
+      contentTitle: 'C#',
     });
   });
 

--- a/packages/docusaurus-utils/src/markdownUtils.ts
+++ b/packages/docusaurus-utils/src/markdownUtils.ts
@@ -146,9 +146,10 @@ export function createExcerpt(fileString: string): string | undefined {
       // Remove HTML tags.
       .replace(/<[^>]*>/g, '')
       // Remove Title headers
-      .replace(/^#[^#]+#?/gm, '')
+      .replace(/^\s*#[ \t]+.*$/gm, '')
       // Remove Markdown + ATX-style headers
-      .replace(/^#{1,6}\s*(?<text>[^#]*?)\s*#{0,6}/gm, '$1')
+      .replace(/^\s*#{1,6}[ \t]+/gm, '')
+      .replace(/[ \t]+#+$/gm, '')
       // Remove emphasis.
       .replace(/(?<opening>[*_]{1,3})(?<text>.*?)\1/g, '$2')
       // Remove strikethroughs.
@@ -282,7 +283,7 @@ export function parseMarkdownContentTitle(
       contentTitle: toTextContentTitle(
         regularTitleMatch
           .groups!.title!.trim()
-          .replace(/\s*(?:\{#*[\w-]+\}|#+)$/, ''),
+          .replace(/(?:\s*\{#*[\w-]+\}|\s+#+)$/, ''),
       ).trim(),
     };
   }


### PR DESCRIPTION
Fixes #12305

### Motivation
When generating document excerpts or parsing markdown content titles from H1/H2 headings containing `#` symbols (such as programming languages like `C#` and `F#` or `#tag`), the previous regular expressions stripped or truncated text at the hash symbol, resulting in incorrect auto-generated meta descriptions (e.g. `C` instead of `C#`).

### Summary of Changes
1. **`createExcerpt`**: Updated header stripping regular expressions to only strip leading markdown hashes (`^\s*#{1,6}[\t ]+`) and whitespace-preceded closing ATX hashes (`[\t ]+#+$`), preserving in-text hashes like `C#` and `F#`.
2. **`parseMarkdownContentTitle`**: Adjusted closing hash stripping regex from `/\s*(?:\{#*[\w-]+\}|#+)$/` to `/(?:\s*\{#*[\w-]+\}|\s+#+)$/` so hashes attached to words without leading whitespace are preserved.
3. **Unit Tests**: Added test cases in `packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts` covering excerpt generation and content title parsing for `C#` and `F#` headings with and without custom anchor IDs.

### Test Plan
- Ran `npx vitest run packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts` — all 74 tests passing cleanly.