### PR TITLE
fix(ci): skip CI workflows that fail from forks

### DIFF
--- a/.github/workflows/lighthouse-report.yml
+++ b/.github/workflows/lighthouse-report.yml
@@ -68,6 +68,7 @@ jobs:
 
       - name: Add Lighthouse stats as comment
         id: comment_to_pr
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # 3.0.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-autofix.yml
+++ b/.github/workflows/lint-autofix.yml
@@ -55,5 +55,6 @@ jobs:
         run: git diff
 
       - uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           commit_message: 'refactor: apply lint autofix'


### PR DESCRIPTION
These 2 things always fail from forks so should be skipped