### PR TITLE
fix(vcs): normalize msys git paths on windows

### DIFF
--- a/packages/docusaurus-utils/src/vcs/__tests__/vcsGitEager.test.ts
+++ b/packages/docusaurus-utils/src/vcs/__tests__/vcsGitEager.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {describe, expect, it, vi} from 'vitest';
+import {normalizeGitRelativePath} from '../vcsGitEager';
+
+describe('normalizeGitRelativePath', () => {
+  it('keeps regular relative paths unchanged', () => {
+    const oldPlatform = process.platform;
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    expect(normalizeGitRelativePath('docs/intro.md')).toBe('docs/intro.md');
+    vi.spyOn(process, 'platform', 'get').mockReturnValue(oldPlatform);
+  });
+
+  it('drops MSYS drive prefixes on Windows', () => {
+    const oldPlatform = process.platform;
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    expect(normalizeGitRelativePath('/p/projets/my-repo')).toBe(
+      'projets/my-repo',
+    );
+    vi.spyOn(process, 'platform', 'get').mockReturnValue(oldPlatform);
+  });
+});

--- a/packages/docusaurus-utils/src/vcs/vcsGitEager.ts
+++ b/packages/docusaurus-utils/src/vcs/vcsGitEager.ts
@@ -15,6 +15,18 @@ import {
 import type {GitFileInfo, GitFileInfoMap} from './gitUtils';
 import type {VcsConfig} from '@docusaurus/types';
 
+export function normalizeGitRelativePath(filePath: string): string {
+  // MSYS/Git Bash can return `/x/...` paths that look absolute on Windows even
+  // though Git means "relative to the repo root on drive X".
+  if (process.platform === 'win32') {
+    const match = filePath.match(/^\/([a-z])\/(.*)/i);
+    if (match) {
+      return match[2] ?? '';
+    }
+  }
+  return filePath;
+}
+
 // The Map keys should be absolute file paths, not relative Git paths
 function resolveFileInfoMapPaths(
   repoRoot: string,
@@ -24,7 +36,7 @@ function resolveFileInfoMapPaths(
     entry: [string, GitFileInfo],
   ): [string, GitFileInfo] {
     // We just resolve the Git paths that are relative to the repo root
-    return [resolve(repoRoot, entry[0]), entry[1]];
+    return [resolve(repoRoot, normalizeGitRelativePath(entry[0])), entry[1]];
   }
 
   return new Map(Array.from(filesInfo.entries()).map(transformMapEntry));


### PR DESCRIPTION
## Summary

Normalize MSYS/Git Bash-style absolute paths returned by Git before resolving them against the repository root on Windows.

## Why

On Windows, a path such as `/p/projets/my-repo/docs/intro.md` can be interpreted by Node as a path on the current drive instead of a repository-relative path. This produces incorrect file locations when resolving eager Git metadata.

## Changes

- Add a focused `normalizeGitRelativePath` helper for Windows MSYS-style paths.
- Apply it while resolving eager Git file-info paths.
- Add regression tests for ordinary relative paths and `/p/...` paths.

## Test plan

- [x] `pnpm vitest run packages/docusaurus-utils/src/vcs/__tests__/vcsGitEager.test.ts`

Closes #11920