### PR TITLE
fix(test): factorize TagsPageLinkLabel component to fix conflicting i18n keys

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.tsx
@@ -7,10 +7,10 @@
 
 import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
-import Translate from '@docusaurus/Translate';
 import {
   PageMetadata,
   HtmlClassNameProvider,
+  TagsPageLinkLabel,
   ThemeClassNames,
 } from '@docusaurus/theme-common';
 import {useBlogTagsPostsPageTitle} from '@docusaurus/theme-common/internal';
@@ -47,11 +47,7 @@ function BlogTagsPostsPageContent({
         <Heading as="h1">{title}</Heading>
         {tag.description && <p>{tag.description}</p>}
         <Link href={tag.allTagsPath}>
-          <Translate
-            id="theme.tags.tagsPageLink"
-            description="The label of the link targeting the tag list page">
-            View All Tags
-          </Translate>
+          <TagsPageLinkLabel />
         </Link>
       </header>
       <BlogPostItems items={items} />

--- a/packages/docusaurus-theme-classic/src/theme/DocTagDocListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocTagDocListPage/index.tsx
@@ -12,9 +12,10 @@ import {
   PageMetadata,
   HtmlClassNameProvider,
   ThemeClassNames,
+  TagsPageLinkLabel,
   usePluralForm,
 } from '@docusaurus/theme-common';
-import Translate, {translate} from '@docusaurus/Translate';
+import {translate} from '@docusaurus/Translate';
 import SearchMetadata from '@theme/SearchMetadata';
 import type {Props} from '@theme/DocTagDocListPage';
 import Unlisted from '@theme/ContentVisibility/Unlisted';
@@ -88,11 +89,7 @@ function DocTagDocListPageContent({
               <Heading as="h1">{title}</Heading>
               {tag.description && <p>{tag.description}</p>}
               <Link href={tag.allTagsPath}>
-                <Translate
-                  id="theme.tags.tagsPageLink"
-                  description="The label of the link targeting the tag list page">
-                  View all tags
-                </Translate>
+                <TagsPageLinkLabel />
               </Link>
             </header>
             <section className="margin-vert--lg">

--- a/packages/docusaurus-theme-common/src/index.ts
+++ b/packages/docusaurus-theme-common/src/index.ts
@@ -66,6 +66,7 @@ export {useWindowSize} from './hooks/useWindowSize';
 
 export {
   translateTagsPageTitle,
+  TagsPageLinkLabel,
   listTagsByLetters,
   type TagLetterEntry,
 } from './utils/tagsUtils';

--- a/packages/docusaurus-theme-common/src/utils/tagsUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/tagsUtils.tsx
@@ -21,7 +21,7 @@ export function TagsPageLinkLabel(): ReactNode {
     <Translate
       id="theme.tags.tagsPageLink"
       description="The label of the link targeting the tag list page">
-      View All Tags
+      View all tags
     </Translate>
   );
 }

--- a/packages/docusaurus-theme-common/src/utils/tagsUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/tagsUtils.tsx
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {translate} from '@docusaurus/Translate';
+import type {ReactNode} from 'react';
+import Translate, {translate} from '@docusaurus/Translate';
 import type {TagsListItem} from '@docusaurus/utils';
 
 export const translateTagsPageTitle = (): string =>
@@ -14,6 +15,16 @@ export const translateTagsPageTitle = (): string =>
     message: 'Tags',
     description: 'The title of the tag list page',
   });
+
+export function TagsPageLinkLabel(): ReactNode {
+  return (
+    <Translate
+      id="theme.tags.tagsPageLink"
+      description="The label of the link targeting the tag list page">
+      View All Tags
+    </Translate>
+  );
+}
 
 export type TagLetterEntry = {letter: string; tags: TagsListItem[]};
 

--- a/packages/docusaurus-theme-translations/README.md
+++ b/packages/docusaurus-theme-translations/README.md
@@ -6,7 +6,7 @@ This package includes default translations for labels (like the pagination "Next
 
 Please help us provide exhaustive translations:
 
-- add new translation by running `pnpm --filter @docusaurus/theme-translations update %new_lang_code%`, then edit generated JSON files
+- add new translation by running `yarn workspace @docusaurus/theme-translations update %new_lang_code%`, then edit generated JSON files
 - double-check existent `language.json` file for bad or missing translations
 
 ## For maintainers:
@@ -14,7 +14,7 @@ Please help us provide exhaustive translations:
 After updating the theme code, you can "synchronize" the translations by running:
 
 ```bash
-pnpm --filter @docusaurus/theme-translations run update
+yarn workspace @docusaurus/theme-translations update
 ```
 
 Then, ask contributors to translate the newly added labels on this [issue](https://github.com/facebook/docusaurus/issues/3526)

--- a/packages/docusaurus-theme-translations/README.md
+++ b/packages/docusaurus-theme-translations/README.md
@@ -6,7 +6,7 @@ This package includes default translations for labels (like the pagination "Next
 
 Please help us provide exhaustive translations:
 
-- add new translation by running `yarn workspace @docusaurus/theme-translations update %new_lang_code%`, then edit generated JSON files
+- add new translation by running `pnpm --filter @docusaurus/theme-translations update %new_lang_code%`, then edit generated JSON files
 - double-check existent `language.json` file for bad or missing translations
 
 ## For maintainers:
@@ -14,7 +14,7 @@ Please help us provide exhaustive translations:
 After updating the theme code, you can "synchronize" the translations by running:
 
 ```bash
-yarn workspace @docusaurus/theme-translations update
+pnpm --filter @docusaurus/theme-translations run update
 ```
 
 Then, ask contributors to translate the newly added labels on this [issue](https://github.com/facebook/docusaurus/issues/3526)

--- a/packages/docusaurus-theme-translations/locales/ar/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/ar/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "مُحـرر مُبـاشر",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "مُحـرر مُبـاشر",
   "theme.Playground.result": "النتيجة"
 }

--- a/packages/docusaurus-theme-translations/locales/base/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/base/theme-common.json
@@ -158,7 +158,7 @@
   "theme.navbar.mobileVersionsDropdown.label___DESCRIPTION": "The label for the navbar versions dropdown on mobile view",
   "theme.tags.tagsListLabel": "Tags:",
   "theme.tags.tagsListLabel___DESCRIPTION": "The label alongside a tag list",
-  "theme.tags.tagsPageLink": "View all tags",
+  "theme.tags.tagsPageLink": "View All Tags",
   "theme.tags.tagsPageLink___DESCRIPTION": "The label of the link targeting the tag list page",
   "theme.tags.tagsPageTitle": "Tags",
   "theme.tags.tagsPageTitle___DESCRIPTION": "The title of the tag list page"

--- a/packages/docusaurus-theme-translations/locales/base/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/base/theme-common.json
@@ -158,7 +158,7 @@
   "theme.navbar.mobileVersionsDropdown.label___DESCRIPTION": "The label for the navbar versions dropdown on mobile view",
   "theme.tags.tagsListLabel": "Tags:",
   "theme.tags.tagsListLabel___DESCRIPTION": "The label alongside a tag list",
-  "theme.tags.tagsPageLink": "View All Tags",
+  "theme.tags.tagsPageLink": "View all tags",
   "theme.tags.tagsPageLink___DESCRIPTION": "The label of the link targeting the tag list page",
   "theme.tags.tagsPageTitle": "Tags",
   "theme.tags.tagsPageTitle___DESCRIPTION": "The title of the tag list page"

--- a/packages/docusaurus-theme-translations/locales/base/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/base/theme-live-codeblock.json
@@ -1,8 +1,8 @@
 {
-  "theme.Playground.liveEditor": "Live Editor",
-  "theme.Playground.liveEditor___DESCRIPTION": "The live editor label of the live codeblocks",
   "theme.Playground.buttons.reset": "Reset",
   "theme.Playground.buttons.reset___DESCRIPTION": "The reset button label for live code blocks",
+  "theme.Playground.liveEditor": "Live Editor",
+  "theme.Playground.liveEditor___DESCRIPTION": "The live editor label of the live codeblocks",
   "theme.Playground.result": "Result",
   "theme.Playground.result___DESCRIPTION": "The result label of the live codeblocks"
 }

--- a/packages/docusaurus-theme-translations/locales/bg/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/bg/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Live Editor",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Live Editor",
   "theme.Playground.result": "Result"
 }

--- a/packages/docusaurus-theme-translations/locales/bn/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/bn/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "লাইভ এডিটর",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "লাইভ এডিটর",
   "theme.Playground.result": "ফলাফল"
 }

--- a/packages/docusaurus-theme-translations/locales/cs/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/cs/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Live Editor",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Live Editor",
   "theme.Playground.result": "Výsledek"
 }

--- a/packages/docusaurus-theme-translations/locales/da/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/da/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Live editor",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Live editor",
   "theme.Playground.result": "Resultat"
 }

--- a/packages/docusaurus-theme-translations/locales/de/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/de/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Live Editor",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Live Editor",
   "theme.Playground.result": "Ergebnisse"
 }

--- a/packages/docusaurus-theme-translations/locales/es/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/es/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Editor en vivo",
   "theme.Playground.buttons.reset": "Restablecer",
+  "theme.Playground.liveEditor": "Editor en vivo",
   "theme.Playground.result": "Resultado"
 }

--- a/packages/docusaurus-theme-translations/locales/et/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/et/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Live Redaktor",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Live Redaktor",
   "theme.Playground.result": "Tulemus"
 }

--- a/packages/docusaurus-theme-translations/locales/fa/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/fa/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "ویرایشگر زنده",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "ویرایشگر زنده",
   "theme.Playground.result": "خروجی"
 }

--- a/packages/docusaurus-theme-translations/locales/fil/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/fil/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Live na Editor",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Live na Editor",
   "theme.Playground.result": "Resulta"
 }

--- a/packages/docusaurus-theme-translations/locales/fr/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/fr/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Éditeur en direct",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Éditeur en direct",
   "theme.Playground.result": "Résultat"
 }

--- a/packages/docusaurus-theme-translations/locales/he/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/he/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Live Editor",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Live Editor",
   "theme.Playground.result": "תוצאה"
 }

--- a/packages/docusaurus-theme-translations/locales/hi/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/hi/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "लाइव एडिटर",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "लाइव एडिटर",
   "theme.Playground.result": "परिणाम"
 }

--- a/packages/docusaurus-theme-translations/locales/hu/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/hu/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Interaktív szerkesztő",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Interaktív szerkesztő",
   "theme.Playground.result": "Eredmény"
 }

--- a/packages/docusaurus-theme-translations/locales/id/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/id/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Penyunting Langung",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Penyunting Langung",
   "theme.Playground.result": "Hasil"
 }

--- a/packages/docusaurus-theme-translations/locales/is/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/is/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Lifandi Ritill",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Lifandi Ritill",
   "theme.Playground.result": "Niðurstaða"
 }

--- a/packages/docusaurus-theme-translations/locales/it/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/it/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Editor dal vivo",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Editor dal vivo",
   "theme.Playground.result": "Risultato"
 }

--- a/packages/docusaurus-theme-translations/locales/ja/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/ja/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "ライブエディター",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "ライブエディター",
   "theme.Playground.result": "結果"
 }

--- a/packages/docusaurus-theme-translations/locales/ko/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/ko/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "라이브 에디터",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "라이브 에디터",
   "theme.Playground.result": "결과"
 }

--- a/packages/docusaurus-theme-translations/locales/nb/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/nb/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Live Editor",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Live Editor",
   "theme.Playground.result": "Resultat"
 }

--- a/packages/docusaurus-theme-translations/locales/nl/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/nl/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Live bewerken",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Live bewerken",
   "theme.Playground.result": "Resultaat"
 }

--- a/packages/docusaurus-theme-translations/locales/pl/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/pl/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Edytor live",
   "theme.Playground.buttons.reset": "Resetuj",
+  "theme.Playground.liveEditor": "Edytor live",
   "theme.Playground.result": "Rezultat"
 }

--- a/packages/docusaurus-theme-translations/locales/pt-BR/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/pt-BR/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Editor em tempo real",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Editor em tempo real",
   "theme.Playground.result": "Resultado"
 }

--- a/packages/docusaurus-theme-translations/locales/pt-PT/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/pt-PT/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Editor em tempo real",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Editor em tempo real",
   "theme.Playground.result": "Resultado"
 }

--- a/packages/docusaurus-theme-translations/locales/ru/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/ru/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Интерактивный редактор",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Интерактивный редактор",
   "theme.Playground.result": "Результат"
 }

--- a/packages/docusaurus-theme-translations/locales/sl/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/sl/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Urejanje kode v živo",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Urejanje kode v živo",
   "theme.Playground.result": "Rezultat"
 }

--- a/packages/docusaurus-theme-translations/locales/sr/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/sr/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Уређивач",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Уређивач",
   "theme.Playground.result": "Резултат"
 }

--- a/packages/docusaurus-theme-translations/locales/sv/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/sv/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Live-redigerare",
   "theme.Playground.buttons.reset": "Återställ",
+  "theme.Playground.liveEditor": "Live-redigerare",
   "theme.Playground.result": "Resultat"
 }

--- a/packages/docusaurus-theme-translations/locales/tk/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/tk/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Göni Redaktor",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Göni Redaktor",
   "theme.Playground.result": "Netije"
 }

--- a/packages/docusaurus-theme-translations/locales/tr/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/tr/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Canlı Düzenleyici",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Canlı Düzenleyici",
   "theme.Playground.result": "Sonuç"
 }

--- a/packages/docusaurus-theme-translations/locales/uk/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/uk/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Інтерактивний редактор",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Інтерактивний редактор",
   "theme.Playground.result": "Результат"
 }

--- a/packages/docusaurus-theme-translations/locales/ur/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/ur/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "لائیو ایڈیٹر",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "لائیو ایڈیٹر",
   "theme.Playground.result": "نتیجہ"
 }

--- a/packages/docusaurus-theme-translations/locales/vi/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/vi/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "Trình soạn thảo trực tuyến",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "Trình soạn thảo trực tuyến",
   "theme.Playground.result": "Kết quả"
 }

--- a/packages/docusaurus-theme-translations/locales/zh-Hans/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/zh-Hans/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "实时编辑器",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "实时编辑器",
   "theme.Playground.result": "结果"
 }

--- a/packages/docusaurus-theme-translations/locales/zh-Hant/theme-live-codeblock.json
+++ b/packages/docusaurus-theme-translations/locales/zh-Hant/theme-live-codeblock.json
@@ -1,5 +1,5 @@
 {
-  "theme.Playground.liveEditor": "即時編輯器",
   "theme.Playground.buttons.reset": "Reset",
+  "theme.Playground.liveEditor": "即時編輯器",
   "theme.Playground.result": "結果"
 }

--- a/packages/docusaurus-theme-translations/package.json
+++ b/packages/docusaurus-theme-translations/package.json
@@ -19,16 +19,16 @@
     "update": "node ./update.mjs"
   },
   "dependencies": {
-    "fs-extra": "^11.4.0",
-    "tslib": "^2.8.1"
+    "fs-extra": "^11.2.0",
+    "tslib": "^2.6.0"
   },
   "devDependencies": {
-    "@docusaurus/babel": "workspace:*",
-    "@docusaurus/core": "workspace:*",
-    "@docusaurus/logger": "workspace:*",
-    "@docusaurus/types": "workspace:*",
-    "@docusaurus/utils": "workspace:*",
-    "lodash": "^4.18.1"
+    "@docusaurus/babel": "3.10.1",
+    "@docusaurus/core": "3.10.1",
+    "@docusaurus/logger": "3.10.1",
+    "@docusaurus/types": "3.10.1",
+    "@docusaurus/utils": "3.10.1",
+    "lodash": "^4.17.21"
   },
   "engines": {
     "node": ">=24.14"

--- a/packages/docusaurus-theme-translations/package.json
+++ b/packages/docusaurus-theme-translations/package.json
@@ -19,16 +19,16 @@
     "update": "node ./update.mjs"
   },
   "dependencies": {
-    "fs-extra": "^11.2.0",
-    "tslib": "^2.6.0"
+    "fs-extra": "^11.4.0",
+    "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "@docusaurus/babel": "3.10.1",
-    "@docusaurus/core": "3.10.1",
-    "@docusaurus/logger": "3.10.1",
-    "@docusaurus/types": "3.10.1",
-    "@docusaurus/utils": "3.10.1",
-    "lodash": "^4.17.21"
+    "@docusaurus/babel": "workspace:*",
+    "@docusaurus/core": "workspace:*",
+    "@docusaurus/logger": "workspace:*",
+    "@docusaurus/types": "workspace:*",
+    "@docusaurus/utils": "workspace:*",
+    "lodash": "^4.18.1"
   },
   "engines": {
     "node": ">=24.14"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,7 +210,7 @@ importers:
     dependencies:
       '@argos-ci/cli':
         specifier: ^6.9.0
-        version: 6.9.0(@types/node@25.9.1)
+        version: 6.9.0(@types/node@25.9.1)(supports-color@7.2.0)
       '@argos-ci/playwright':
         specifier: ^7.4.6
         version: 7.4.6(@types/node@25.9.1)(supports-color@7.2.0)
@@ -818,7 +818,7 @@ importers:
         version: 3.0.3
       mdast-util-directive:
         specifier: 3.1.0
-        version: 3.1.0(supports-color@7.2.0)
+        version: 3.1.0
       rehype-stringify:
         specifier: ^10.0.0
         version: 10.0.1
@@ -1836,29 +1836,29 @@ importers:
   packages/docusaurus-theme-translations:
     dependencies:
       fs-extra:
-        specifier: ^11.2.0
-        version: 11.3.5
+        specifier: ^11.4.0
+        version: 11.4.0
       tslib:
-        specifier: ^2.6.0
+        specifier: ^2.8.1
         version: 2.8.1
     devDependencies:
       '@docusaurus/babel':
-        specifier: 3.10.1
+        specifier: workspace:*
         version: link:../docusaurus-babel
       '@docusaurus/core':
-        specifier: 3.10.1
+        specifier: workspace:*
         version: link:../docusaurus
       '@docusaurus/logger':
-        specifier: 3.10.1
+        specifier: workspace:*
         version: link:../docusaurus-logger
       '@docusaurus/types':
-        specifier: 3.10.1
+        specifier: workspace:*
         version: link:../docusaurus-types
       '@docusaurus/utils':
-        specifier: 3.10.1
+        specifier: workspace:*
         version: link:../docusaurus-utils
       lodash:
-        specifier: ^4.17.21
+        specifier: ^4.18.1
         version: 4.18.1
 
   packages/docusaurus-tsconfig:
@@ -8483,6 +8483,10 @@ packages:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
 
+  fs-extra@11.4.0:
+    resolution: {integrity: sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==}
+    engines: {node: '>=14.14'}
+
   fs-extra@9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
@@ -13708,7 +13712,7 @@ snapshots:
       jsonpointer: 5.0.1
       leven: 3.1.0
 
-  '@argos-ci/api-client@0.31.0':
+  '@argos-ci/api-client@0.31.0(supports-color@7.2.0)':
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       openapi-fetch: 0.17.0
@@ -13718,10 +13722,10 @@ snapshots:
 
   '@argos-ci/browser@6.4.5': {}
 
-  '@argos-ci/cli@6.9.0(@types/node@25.9.1)':
+  '@argos-ci/cli@6.9.0(@types/node@25.9.1)(supports-color@7.2.0)':
     dependencies:
-      '@argos-ci/api-client': 0.31.0
-      '@argos-ci/core': 6.8.1(@types/node@25.9.1)
+      '@argos-ci/api-client': 0.31.0(supports-color@7.2.0)
+      '@argos-ci/core': 6.8.1(@types/node@25.9.1)(supports-color@7.2.0)
       '@vercel/detect-agent': 1.2.5
       commander: 15.0.0
       open: 11.0.0
@@ -13730,9 +13734,9 @@ snapshots:
       - '@types/node'
       - supports-color
 
-  '@argos-ci/core@6.8.1(@types/node@25.9.1)':
+  '@argos-ci/core@6.8.1(@types/node@25.9.1)(supports-color@7.2.0)':
     dependencies:
-      '@argos-ci/api-client': 0.31.0
+      '@argos-ci/api-client': 0.31.0(supports-color@7.2.0)
       '@argos-ci/util': 4.1.0
       convict: 6.2.5
       debug: 4.4.3(supports-color@7.2.0)
@@ -13748,7 +13752,7 @@ snapshots:
   '@argos-ci/playwright@7.4.6(@types/node@25.9.1)(supports-color@7.2.0)':
     dependencies:
       '@argos-ci/browser': 6.4.5
-      '@argos-ci/core': 6.8.1(@types/node@25.9.1)
+      '@argos-ci/core': 6.8.1(@types/node@25.9.1)(supports-color@7.2.0)
       '@argos-ci/util': 4.1.0
       chalk: 6.0.0
       debug: 4.4.3(supports-color@7.2.0)
@@ -20659,6 +20663,12 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fs-extra@11.4.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
   fs-extra@9.1.0:
     dependencies:
       at-least-node: 1.0.0
@@ -22279,13 +22289,13 @@ snapshots:
 
   mathml-tag-names@4.0.0: {}
 
-  mdast-util-directive@3.1.0(supports-color@7.2.0):
+  mdast-util-directive@3.1.0:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -22300,14 +22310,14 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.3(supports-color@7.2.0):
+  mdast-util-from-markdown@2.0.3:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2(supports-color@7.2.0)
+      micromark: 4.0.2
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -22322,7 +22332,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       escape-string-regexp: 5.0.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-extension-frontmatter: 2.0.0
     transitivePeerDependencies:
@@ -22340,7 +22350,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
@@ -22349,7 +22359,7 @@ snapshots:
   mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -22359,7 +22369,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -22368,14 +22378,14 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
   mdast-util-gfm@3.1.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-gfm-autolink-literal: 2.0.1
       mdast-util-gfm-footnote: 2.1.0
       mdast-util-gfm-strikethrough: 2.0.0
@@ -22391,7 +22401,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       longest-streak: 3.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       unist-util-remove-position: 5.0.0
     transitivePeerDependencies:
@@ -22403,7 +22413,7 @@ snapshots:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -22416,7 +22426,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -22427,7 +22437,7 @@ snapshots:
 
   mdast-util-mdx@3.0.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-mdx-expression: 2.0.1
       mdast-util-mdx-jsx: 3.2.0
       mdast-util-mdxjs-esm: 2.0.1
@@ -22441,7 +22451,7 @@ snapshots:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -22837,7 +22847,7 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2(supports-color@7.2.0):
+  micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.13
       debug: 4.4.3(supports-color@7.2.0)
@@ -24689,7 +24699,7 @@ snapshots:
   remark-directive@3.0.1:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-directive: 3.1.0(supports-color@7.2.0)
+      mdast-util-directive: 3.1.0
       micromark-extension-directive: 3.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -24742,7 +24752,7 @@ snapshots:
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,7 +210,7 @@ importers:
     dependencies:
       '@argos-ci/cli':
         specifier: ^6.9.0
-        version: 6.9.0(@types/node@25.9.1)(supports-color@7.2.0)
+        version: 6.9.0(@types/node@25.9.1)
       '@argos-ci/playwright':
         specifier: ^7.4.6
         version: 7.4.6(@types/node@25.9.1)(supports-color@7.2.0)
@@ -818,7 +818,7 @@ importers:
         version: 3.0.3
       mdast-util-directive:
         specifier: 3.1.0
-        version: 3.1.0
+        version: 3.1.0(supports-color@7.2.0)
       rehype-stringify:
         specifier: ^10.0.0
         version: 10.0.1
@@ -1836,29 +1836,29 @@ importers:
   packages/docusaurus-theme-translations:
     dependencies:
       fs-extra:
-        specifier: ^11.4.0
-        version: 11.4.0
+        specifier: ^11.2.0
+        version: 11.3.5
       tslib:
-        specifier: ^2.8.1
+        specifier: ^2.6.0
         version: 2.8.1
     devDependencies:
       '@docusaurus/babel':
-        specifier: workspace:*
+        specifier: 3.10.1
         version: link:../docusaurus-babel
       '@docusaurus/core':
-        specifier: workspace:*
+        specifier: 3.10.1
         version: link:../docusaurus
       '@docusaurus/logger':
-        specifier: workspace:*
+        specifier: 3.10.1
         version: link:../docusaurus-logger
       '@docusaurus/types':
-        specifier: workspace:*
+        specifier: 3.10.1
         version: link:../docusaurus-types
       '@docusaurus/utils':
-        specifier: workspace:*
+        specifier: 3.10.1
         version: link:../docusaurus-utils
       lodash:
-        specifier: ^4.18.1
+        specifier: ^4.17.21
         version: 4.18.1
 
   packages/docusaurus-tsconfig:
@@ -8483,10 +8483,6 @@ packages:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
 
-  fs-extra@11.4.0:
-    resolution: {integrity: sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==}
-    engines: {node: '>=14.14'}
-
   fs-extra@9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
@@ -13712,7 +13708,7 @@ snapshots:
       jsonpointer: 5.0.1
       leven: 3.1.0
 
-  '@argos-ci/api-client@0.31.0(supports-color@7.2.0)':
+  '@argos-ci/api-client@0.31.0':
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       openapi-fetch: 0.17.0
@@ -13722,10 +13718,10 @@ snapshots:
 
   '@argos-ci/browser@6.4.5': {}
 
-  '@argos-ci/cli@6.9.0(@types/node@25.9.1)(supports-color@7.2.0)':
+  '@argos-ci/cli@6.9.0(@types/node@25.9.1)':
     dependencies:
-      '@argos-ci/api-client': 0.31.0(supports-color@7.2.0)
-      '@argos-ci/core': 6.8.1(@types/node@25.9.1)(supports-color@7.2.0)
+      '@argos-ci/api-client': 0.31.0
+      '@argos-ci/core': 6.8.1(@types/node@25.9.1)
       '@vercel/detect-agent': 1.2.5
       commander: 15.0.0
       open: 11.0.0
@@ -13734,9 +13730,9 @@ snapshots:
       - '@types/node'
       - supports-color
 
-  '@argos-ci/core@6.8.1(@types/node@25.9.1)(supports-color@7.2.0)':
+  '@argos-ci/core@6.8.1(@types/node@25.9.1)':
     dependencies:
-      '@argos-ci/api-client': 0.31.0(supports-color@7.2.0)
+      '@argos-ci/api-client': 0.31.0
       '@argos-ci/util': 4.1.0
       convict: 6.2.5
       debug: 4.4.3(supports-color@7.2.0)
@@ -13752,7 +13748,7 @@ snapshots:
   '@argos-ci/playwright@7.4.6(@types/node@25.9.1)(supports-color@7.2.0)':
     dependencies:
       '@argos-ci/browser': 6.4.5
-      '@argos-ci/core': 6.8.1(@types/node@25.9.1)(supports-color@7.2.0)
+      '@argos-ci/core': 6.8.1(@types/node@25.9.1)
       '@argos-ci/util': 4.1.0
       chalk: 6.0.0
       debug: 4.4.3(supports-color@7.2.0)
@@ -20663,12 +20659,6 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
-  fs-extra@11.4.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.1
-      universalify: 2.0.1
-
   fs-extra@9.1.0:
     dependencies:
       at-least-node: 1.0.0
@@ -22289,13 +22279,13 @@ snapshots:
 
   mathml-tag-names@4.0.0: {}
 
-  mdast-util-directive@3.1.0:
+  mdast-util-directive@3.1.0(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -22310,14 +22300,14 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.3:
+  mdast-util-from-markdown@2.0.3(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@7.2.0)
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -22332,7 +22322,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       escape-string-regexp: 5.0.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
       micromark-extension-frontmatter: 2.0.0
     transitivePeerDependencies:
@@ -22350,7 +22340,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
@@ -22359,7 +22349,7 @@ snapshots:
   mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -22369,7 +22359,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -22378,14 +22368,14 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
   mdast-util-gfm@3.1.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-gfm-autolink-literal: 2.0.1
       mdast-util-gfm-footnote: 2.1.0
       mdast-util-gfm-strikethrough: 2.0.0
@@ -22401,7 +22391,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       longest-streak: 3.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
       unist-util-remove-position: 5.0.0
     transitivePeerDependencies:
@@ -22413,7 +22403,7 @@ snapshots:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -22426,7 +22416,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -22437,7 +22427,7 @@ snapshots:
 
   mdast-util-mdx@3.0.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-mdx-expression: 2.0.1
       mdast-util-mdx-jsx: 3.2.0
       mdast-util-mdxjs-esm: 2.0.1
@@ -22451,7 +22441,7 @@ snapshots:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -22847,7 +22837,7 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2:
+  micromark@4.0.2(supports-color@7.2.0):
     dependencies:
       '@types/debug': 4.1.13
       debug: 4.4.3(supports-color@7.2.0)
@@ -24699,7 +24689,7 @@ snapshots:
   remark-directive@3.0.1:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-directive: 3.1.0
+      mdast-util-directive: 3.1.0(supports-color@7.2.0)
       micromark-extension-directive: 3.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -24752,7 +24742,7 @@ snapshots:
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:


### PR DESCRIPTION

## Motivation

We have the same label for docs/blog, the key is shared but the default translation was using different cases, leading to weird CI test failures due to race conditions


```tsx


          <Translate
            id="theme.tags.tagsPageLink"
            description="The label of the link targeting the tag list page">
            View All Tags
          </Translate>

                <Translate
                  id="theme.tags.tagsPageLink"
                  description="The label of the link targeting the tag list page">
                  View all tags
                </Translate>

```

I'm factoring it and keep the `View all tags` label to fix this


## Test Plan

CI
