### PR TITLE
chore(ci): argos no minify HTML to ease review

### DIFF
--- a/.github/workflows/argos.yml
+++ b/.github/workflows/argos.yml
@@ -62,7 +62,7 @@ jobs:
         run: pnpm argos:build
         env:
           # Easier HTML diffs to review on Argos
-          # an alternative could be to use Prettier
+          # an alternative could be to use Prettier/Oxfmt on build output
           SKIP_HTML_MINIFICATION: true
       - name: Upload Argos text snapshots
         run: pnpm argos:upload-text-snapshots

--- a/.github/workflows/argos.yml
+++ b/.github/workflows/argos.yml
@@ -53,11 +53,16 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm playwright install --with-deps chromium
 
-      - name: Build website fast
+      - name: Build website for screenshots
         run: pnpm argos:build
-
       - name: Take and upload Argos screenshots
         run: pnpm argos:screenshot
 
+      - name: Build website for text snapshots
+        run: pnpm argos:build
+        env:
+          # Easier HTML diffs to review on Argos
+          # an alternative could be to use Prettier
+          SKIP_HTML_MINIFICATION: true
       - name: Upload Argos text snapshots
         run: pnpm argos:upload-text-snapshots


### PR DESCRIPTION
Recent PR https://github.com/facebook/docusaurus/pull/12382 works but the minified HTML is not easy to review on Argos

Let's rebuild the site without html minified to make it easier to review

Note: I rebuild the site because the former build with html minified can help find React hydration errors logged by playwright, so I didn't want to disable minification here on purpose.