### PR TITLE
fix(utils): stop comments from leaking into the excerpt

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
@@ -303,6 +303,76 @@ describe('createExcerpt', () => {
       expect(createExcerpt('\u{FFFE}\u{FFFF}')).toBeUndefined();
     });
   });
+
+  describe('comments', () => {
+    // The excerpt becomes the page description, so anything left behind here
+    // is published in <meta name="description">, Open Graph tags and the blog
+    // feed. Comments are exactly the syntax authors use for text addressed to
+    // editors rather than readers, so a leak is worse than a cosmetic bug.
+
+    it('creates excerpt ignoring a multiline HTML comment', () => {
+      expect(
+        createExcerpt(dedent`
+          <!--
+            Copyright (c) Meta Platforms, Inc.
+          -->
+
+          # Guide
+
+          How to configure the sidebar.
+        `),
+      ).toBe('How to configure the sidebar.');
+    });
+
+    it('creates excerpt ignoring an HTML comment containing a closing bracket', () => {
+      expect(createExcerpt('<!-- a > b -->\n\nSome content.')).toBe(
+        'Some content.',
+      );
+    });
+
+    it('creates excerpt from the text following a comment', () => {
+      expect(createExcerpt('<!-- note\nmore --> Real text.')).toBe(
+        'Real text.',
+      );
+    });
+
+    it('creates excerpt ignoring an MDX comment', () => {
+      expect(createExcerpt('{/* note */}\n\nSome content.')).toBe(
+        'Some content.',
+      );
+    });
+
+    it('creates excerpt ignoring a multiline MDX comment', () => {
+      expect(createExcerpt('{/* note\nmore */}\n\nSome content.')).toBe(
+        'Some content.',
+      );
+    });
+
+    it('creates no excerpt for a document containing only a comment', () => {
+      expect(createExcerpt('<!-- only a comment -->')).toBeUndefined();
+    });
+
+    it('creates excerpt preserving comment syntax inside inline code', () => {
+      expect(createExcerpt('Write `<!-- note -->` to hide text.')).toBe(
+        'Write <!-- note --> to hide text.',
+      );
+      expect(createExcerpt('Write `{/* note */}` to hide text.')).toBe(
+        'Write {/* note */} to hide text.',
+      );
+    });
+
+    it('creates excerpt keeping comment syntax inside code blocks out of the way', () => {
+      expect(
+        createExcerpt(dedent`
+          \`\`\`html
+          <!-- an example comment
+          \`\`\`
+
+          Some content.
+        `),
+      ).toBe('Some content.');
+    });
+  });
 });
 
 describe('parseMarkdownContentTitle', () => {

--- a/packages/docusaurus-utils/src/markdownUtils.ts
+++ b/packages/docusaurus-utils/src/markdownUtils.ts
@@ -52,6 +52,59 @@ const MDXEscapingUtils = (function () {
   return {escapeMDX, unescapeMDX};
 })();
 
+// Comment syntaxes that must never reach the excerpt: authors use them for
+// notes addressed to editors rather than readers. Both forms can span multiple
+// lines, and both can contain the ">" that the tag-stripping regexes in
+// createExcerpt() key on, so neither can be matched by a per-line tag regex.
+const COMMENT_DELIMITERS = [
+  {open: '<!--', close: '-->'},
+  {open: '{/*', close: '*/}'},
+] as const;
+
+/**
+ * Removes comment spans from a line, carrying the "still inside a comment"
+ * state forward so a comment can span lines. Each excerpt gets its own
+ * stripper: the state belongs to one document, not to the module.
+ */
+function createCommentStripper() {
+  let openComment: (typeof COMMENT_DELIMITERS)[number] | undefined;
+
+  return function stripComments(line: string): string {
+    let remaining = line;
+    let result = '';
+    while (remaining) {
+      if (openComment) {
+        const end = remaining.indexOf(openComment.close);
+        // Unterminated: the rest of the line is comment, and so is the next.
+        if (end === -1) {
+          return result;
+        }
+        remaining = remaining.slice(end + openComment.close.length);
+        openComment = undefined;
+      } else {
+        // Open whichever delimiter comes first, so "{/*" inside an HTML
+        // comment doesn't hijack the span that is already open.
+        let opener: (typeof COMMENT_DELIMITERS)[number] | undefined;
+        let openerIndex = -1;
+        for (const delimiter of COMMENT_DELIMITERS) {
+          const index = remaining.indexOf(delimiter.open);
+          if (index !== -1 && (openerIndex === -1 || index < openerIndex)) {
+            openerIndex = index;
+            opener = delimiter;
+          }
+        }
+        if (!opener) {
+          return result + remaining;
+        }
+        result += remaining.slice(0, openerIndex);
+        remaining = remaining.slice(openerIndex + opener.open.length);
+        openComment = opener;
+      }
+    }
+    return result;
+  };
+}
+
 /**
  * Hacky temporary escape hatch for Crowdin bad MDX support
  * See https://docusaurus.io/docs/i18n/crowdin#mdx
@@ -130,6 +183,7 @@ export function createExcerpt(fileString: string): string | undefined {
   let inImport = false;
   let inHTML = false;
   let lastCodeFence = '';
+  const stripComments = createCommentStripper();
 
   for (const fileLine of fileLines) {
     // An empty line marks the end of imports
@@ -197,7 +251,7 @@ export function createExcerpt(fileString: string): string | undefined {
       return MDXEscapingUtils.unescapeMDX(str);
     }
 
-    const cleanedLine = preprocessLine(fileLine)
+    const cleanedLine = stripComments(preprocessLine(fileLine))
       // Remove HTML tags.
       .replace(/<[^>]*>/g, '')
       // Remove Title headers


### PR DESCRIPTION
## Motivation

`createExcerpt()` strips HTML with a per-line tag regex:

```js
.replace(/<[^>]*>/g, '')
```

That regex cannot see a comment. It stops at the first `>`, and it has no state to carry an unterminated comment onto the next line. A document that opens with a comment therefore excerpts the comment itself:

| document opens with | excerpt today | expected |
|---|---|---|
| `<!--`<br>`  Copyright (c) Meta Platforms, Inc.`<br>`-->` | `<!--` | `How to configure the sidebar.` |
| `<!-- TODO: rewrite this page`<br>`     once v4 ships -->` | `<!-- TODO: rewrite this page` | `Install the package.` |
| `<!-- a > b -->` | `b -->` | `Some content.` |
| `<!-- note`<br>`more --> Real text.` | `<!-- note` | `Real text.` |

MDX's `{/* ... */}` form leaks the same way, and leaks even on a **single** line — `{/* note */}` comes out as `{/ note /}` once the emphasis and heading-id rules have run on it.

This is not confined to the excerpt. Both content plugins fall back to it for the page description:

```js
const description = frontMatter.description ?? excerpt ?? '';
```

— [`docs.ts`](https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-plugin-content-docs/src/docs.ts) and [`blogUtils.ts`](https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-plugin-content-blog/src/blogUtils.ts). So for any doc or blog post without an explicit `description` front matter, the leaked comment is published in `<meta name="description">`, the Open Graph tags and the blog feed.

That is what makes this more than cosmetic. Comments are precisely the syntax authors use for text addressed to editors rather than readers — license headers, `prettier-ignore` markers, "do not translate", "TODO: rewrite this". Those are the strings that end up in the search snippet and the social preview.

## The fix

A small state machine strips both comment forms, tracking which delimiter is open so it survives across lines and so `{/*` inside an HTML comment can't hijack a span that is already open.

Placement matters: it runs **after** the inline-code escaping added in #11821. `escapeMDX` already escapes `<`, `>`, `!`, `{` and `*`, so by that point inline code cannot contain a literal `<!--` or `{/*`, and comment syntax written inside backticks stays intact for free. There's a test pinning that.

## Test Plan

8 tests added to the existing `createExcerpt` describe block. Reverting **only** `markdownUtils.ts` and keeping the tests turns 5 of them red, with exactly the values in the table above:

```
× creates excerpt ignoring a multiline HTML comment
    expected '<!--' to be 'How to configure the sidebar.'
× creates excerpt ignoring an HTML comment containing a closing bracket
    expected 'b -->' to be 'Some content.'
× creates excerpt from the text following a comment
    expected '<!-- note' to be 'Real text.'
× creates excerpt ignoring an MDX comment
    expected '{/ note /}' to be 'Some content.'
× creates excerpt ignoring a multiline MDX comment
    expected '{/* note' to be 'Some content.'
```

The other 3 pass before and after by design — they are regression guards for behaviour that is already correct: comment syntax inside inline code (#11821), comment syntax inside fenced code blocks, and a document that is nothing but a comment yielding no excerpt.

With the fix, `markdownUtils.test.ts` is 92/92 and the whole `docusaurus-utils` package is 407/408. The one failure is `gitUtils.test.ts > rejects for cwd of untracked dir`, which fails identically on a clean checkout here — it depends on whether the checkout's parent directory happens to be a git repo, and is unrelated to this change.

`oxfmt` and `eslint` are clean on both changed files (the 3 remaining `max-len` warnings in `markdownUtils.ts` are pre-existing, on the import/export comment block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
