### PR TITLE
fix(showcase): make showcase screenshots load lazily

### DIFF
--- a/website/src/pages/showcase/_components/ShowcaseCard/index.tsx
+++ b/website/src/pages/showcase/_components/ShowcaseCard/index.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import Translate from '@docusaurus/Translate';
-import Image from '@theme/IdealImage';
 import {Tags, TagList, type TagType, type User} from '@site/src/data/users';
 import {sortBy} from '@site/src/utils/jsUtils';
 import Heading from '@theme/Heading';
@@ -65,7 +64,7 @@ function ShowcaseCard({user}: {user: User}) {
   return (
     <li key={user.title} className="card shadow--md">
       <div className={clsx('card__image', styles.showcaseCardImage)}>
-        <Image img={image} alt={user.title} />
+        <img src={image} alt={user.title} loading="lazy" />
       </div>
       <div className="card__body">
         <div className={clsx(styles.showcaseCardHeader)}>


### PR DESCRIPTION
## Motivation

Because this is hosted on my personal account for now and I reached Netlify limits due to eager loading of these screenshots 😅, leading to my personal site being down until I pay.

<img width="1524" height="444" alt="CleanShot 2026-08-31 at 10 53 51@2x" src="https://github.com/user-attachments/assets/fc9491ec-9aa8-4fc0-a0ef-ef8190fd9850" />

---

For now, this is just a quick fix, but I'll have to refactor all that later and move this to an official Meta deployment. Unfortunately, this requires refactoring the whole thing because it's totally outdated, and it's better to rebuild this from scratch.