### PR TITLE
fix(mdx-loader): report vfile messages from Remark plugins

### DIFF
--- a/packages/docusaurus-mdx-loader/src/__tests__/loader.test.ts
+++ b/packages/docusaurus-mdx-loader/src/__tests__/loader.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {describe, expect, it, vi} from 'vitest';
+import {mdxLoader} from '../loader';
+import {DefaultMarkdownConfig} from './testUtils';
+import type {Options} from '../options';
+import type {WebpackCompilerName} from '@docusaurus/utils';
+import type {Root} from 'mdast';
+import type {Plugin} from 'unified';
+import type {LoaderContext} from 'webpack';
+
+const warningPlugin: Plugin<[], Root> = () => (_tree, file) => {
+  file.message('This is a Remark plugin warning');
+};
+
+async function runLoader({
+  fileContent,
+  remarkPlugins,
+  compilerName = 'client',
+}: {
+  fileContent: string;
+  remarkPlugins?: Options['remarkPlugins'];
+  compilerName?: WebpackCompilerName;
+}): Promise<string> {
+  const options: Options = {
+    markdownConfig: DefaultMarkdownConfig,
+    staticDirs: [],
+    siteDir: '/site',
+    remarkPlugins,
+  };
+  const filePath = '/site/docs/test.md';
+
+  return new Promise<string>((resolve, reject) => {
+    const context = {
+      resource: filePath,
+      resourcePath: filePath,
+      _compiler: {name: compilerName},
+      getOptions: () => options,
+      addDependency: () => {},
+      async: () => (error: Error | null, result?: string) =>
+        error ? reject(error) : resolve(result!),
+    } as unknown as LoaderContext<Options>;
+
+    mdxLoader.call(context, fileContent);
+  });
+}
+
+describe('mdxLoader', () => {
+  it('warns about messages reported by Remark plugins', async () => {
+    using warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await runLoader({
+      fileContent: '# Title',
+      remarkPlugins: [warningPlugin],
+    });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]![0]).toContain('This is a Remark plugin warning');
+  });
+
+  it('does not warn when Remark plugins report nothing', async () => {
+    using warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await runLoader({fileContent: '# Title'});
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/docusaurus-mdx-loader/src/__tests__/messages.test.ts
+++ b/packages/docusaurus-mdx-loader/src/__tests__/messages.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {describe, expect, it, vi} from 'vitest';
+import {reportMDXMessages} from '../messages';
+import type {SimpleProcessorResult} from '../processor';
+
+const filePath = '/site/docs/test.md';
+
+async function createMessages(
+  entries: {reason: string; place?: {line: number; column: number}}[],
+): Promise<SimpleProcessorResult['messages']> {
+  const {VFile} = await import('vfile');
+  const file = new VFile({path: filePath});
+  entries.forEach(({reason, place}) => {
+    file.message(reason, place ? {place} : undefined);
+  });
+  return file.messages;
+}
+
+describe('reportMDXMessages', () => {
+  it('warns about each message reported by Remark plugins', async () => {
+    using warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    reportMDXMessages({
+      messages: await createMessages([
+        {reason: 'Some warning', place: {line: 3, column: 5}},
+        {reason: 'Another warning'},
+      ]),
+      filePath,
+      compilerName: 'client',
+    });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = warn.mock.calls[0]![0] as string;
+    expect(message).toContain('Some warning');
+    expect(message).toContain('3:5');
+    expect(message).toContain('Another warning');
+  });
+
+  it('does not warn when no message is reported', async () => {
+    using warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    reportMDXMessages({
+      messages: await createMessages([]),
+      filePath,
+      compilerName: 'client',
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('does not warn for the server compiler, avoiding duplicate warnings', async () => {
+    using warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    reportMDXMessages({
+      messages: await createMessages([{reason: 'Some warning'}]),
+      filePath,
+      compilerName: 'server',
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/docusaurus-mdx-loader/src/__tests__/processor.test.ts
+++ b/packages/docusaurus-mdx-loader/src/__tests__/processor.test.ts
@@ -5,31 +5,55 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// import {createProcessor} from '../processor';
-// import type {Options} from '../loader';
+import {describe, expect, it} from 'vitest';
+import {createProcessorUncached} from '../processor';
+import {DefaultMarkdownConfig} from './testUtils';
+import type {Options} from '../options';
+import type {Root} from 'mdast';
+import type {Plugin} from 'unified';
 
-/*
-async function testProcess({
-  format,
-  options,
+async function process({
+  content,
+  remarkPlugins,
 }: {
-  format: 'md' | 'mdx';
-  options: Options;
+  content: string;
+  remarkPlugins?: Options['remarkPlugins'];
 }) {
-  return async (content: string) => {
-    const processor = await createProcessor({format, options});
-    return processor.process(content);
-  };
+  const processor = await createProcessorUncached({
+    options: {
+      markdownConfig: DefaultMarkdownConfig,
+      staticDirs: [],
+      siteDir: '/site',
+      remarkPlugins,
+    },
+    format: 'md',
+  });
+  return processor.process({
+    content,
+    filePath: '/site/docs/test.md',
+    frontMatter: {},
+    compilerName: 'client',
+  });
 }
- */
 
-import {describe, it} from 'vitest';
+describe('mdx processor', () => {
+  it('returns messages reported by Remark plugins', async () => {
+    const reportingPlugin: Plugin<[], Root> = () => (_tree, file) => {
+      file.message('This is a Remark plugin warning');
+    };
 
-describe('md processor', () => {
-  it('parses simple commonmark', async () => {
-    // TODO no tests for now, wait until ESM support
-    // Jest does not support well ESM modules
-    // It would require to vendor too much Unified modules as CJS
-    // See https://mdxjs.com/docs/troubleshooting-mdx/#esm
+    const result = await process({
+      content: '# Title',
+      remarkPlugins: [reportingPlugin],
+    });
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]!.reason).toBe('This is a Remark plugin warning');
+  });
+
+  it('returns no messages when Remark plugins report nothing', async () => {
+    const result = await process({content: '# Title'});
+
+    expect(result.messages).toEqual([]);
   });
 });

--- a/packages/docusaurus-mdx-loader/src/__tests__/testUtils.ts
+++ b/packages/docusaurus-mdx-loader/src/__tests__/testUtils.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {DEFAULT_PARSE_FRONT_MATTER} from '@docusaurus/utils';
+import type {MarkdownConfig} from '@docusaurus/types';
+
+export const DefaultMarkdownConfig: MarkdownConfig = {
+  format: 'mdx',
+  mermaid: false,
+  emoji: true,
+  preprocessor: undefined,
+  parseFrontMatter: DEFAULT_PARSE_FRONT_MATTER,
+  mdx1Compat: {comments: true, admonitions: true, headingIds: true},
+  anchors: {maintainCase: false},
+  remarkRehypeOptions: undefined,
+  hooks: {
+    onBrokenMarkdownLinks: 'warn',
+    onBrokenMarkdownImages: 'warn',
+    onUnusedMarkdownDirectives: 'warn',
+  },
+};

--- a/packages/docusaurus-mdx-loader/src/loader.ts
+++ b/packages/docusaurus-mdx-loader/src/loader.ts
@@ -18,6 +18,7 @@ import {
   createAssetsExportCode,
   extractContentTitleData,
 } from './utils';
+import {reportMDXMessages} from './messages';
 import type {WebpackCompilerName} from '@docusaurus/utils';
 import type {Options} from './options';
 import type {LoaderContext} from 'webpack';
@@ -55,6 +56,8 @@ async function loadMDX({
     options,
     compilerName,
   });
+
+  reportMDXMessages({messages: result.messages, filePath, compilerName});
 
   const contentTitle = extractContentTitleData(result.data);
 

--- a/packages/docusaurus-mdx-loader/src/messages.ts
+++ b/packages/docusaurus-mdx-loader/src/messages.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import logger from '@docusaurus/logger';
+import {toMessageRelativeFilePath} from '@docusaurus/utils';
+import type {SimpleProcessorResult} from './processor';
+import type {WebpackCompilerName} from '@docusaurus/utils';
+
+type VFileMessage = SimpleProcessorResult['messages'][number];
+
+// Returns " (line:column)" when position info is available
+function formatMessagePositionExtraMessage(message: VFileMessage): string {
+  const {line, column} = message;
+  return line && column
+    ? logger.interpolate` (number=${line}:number=${column})`
+    : '';
+}
+
+function formatMessage(message: VFileMessage): string {
+  return `- ${message.reason}${formatMessagePositionExtraMessage(message)}`;
+}
+
+/**
+ * Remark/Rehype plugins report non-fatal problems by attaching messages to the
+ * vfile instead of throwing. Docusaurus used to discard those messages, making
+ * plugin warnings invisible to users.
+ * See https://github.com/facebook/docusaurus/issues/9953
+ */
+export function reportMDXMessages({
+  messages,
+  filePath,
+  compilerName,
+}: {
+  messages: SimpleProcessorResult['messages'];
+  filePath: string;
+  compilerName: WebpackCompilerName;
+}): void {
+  // We only report messages for the client compiler
+  // This avoids emitting duplicate warnings in prod mode
+  // Note: the client compiler is used in both dev/prod modes
+  // See the same logic in the unusedDirectives Remark plugin
+  if (compilerName !== 'client' || messages.length === 0) {
+    return;
+  }
+
+  const relativePath = toMessageRelativeFilePath(filePath);
+
+  logger.warn`Docusaurus found ${
+    messages.length
+  } Markdown warnings in file path=${relativePath}
+${messages.map(formatMessage).join('\n')}`;
+}

--- a/packages/docusaurus-mdx-loader/src/processor.ts
+++ b/packages/docusaurus-mdx-loader/src/processor.ts
@@ -27,6 +27,7 @@ import type {PluginOptions as TransformLinksOptions} from './remark/transformLin
 import type {PluginOptions as TransformImageOptions} from './remark/transformImage';
 import type {PluginOptions as UnusedDirectivesOptions} from './remark/unusedDirectives';
 import type {ProcessorOptions} from '@mdx-js/mdx';
+import type {VFile} from 'vfile';
 
 // TODO as of April 2023, no way to import/re-export this ESM type easily :/
 // This might change soon, likely after TS 5.2
@@ -36,6 +37,11 @@ type Pluggable = any; // TODO fix this asap
 export type SimpleProcessorResult = {
   content: string;
   data: {[key: string]: unknown};
+  /**
+   * Warnings reported by Remark/Rehype plugins through the vfile API.
+   * See https://github.com/vfile/vfile#filemessagereason-options
+   */
+  messages: VFile['messages'];
 };
 
 // TODO alt interface because impossible to import type Processor (ESM + TS :/)
@@ -220,6 +226,7 @@ async function createProcessorFactory() {
         return mdxProcessor.process(vfile).then((result) => ({
           content: result.toString(),
           data: result.data,
+          messages: result.messages,
         }));
       },
     };


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #9953) and the maintainers have approved on my working plan.

> Disclosure: this change was written with AI assistance. I reviewed the code, ran the verification myself and take responsibility for it.

## Motivation

Fixes #9953

Remark and Rehype plugins report non-fatal problems by attaching messages to the vfile via `file.message(...)` rather than by throwing. Those messages accumulate on `result.messages`, but the MDX processor discarded them:

```ts
return mdxProcessor.process(vfile).then((result) => ({
  content: result.toString(),
  data: result.data,
}));
```

So warnings emitted by third-party Remark plugins through the standard Unified reporting API were invisible to users. Fatal messages (`file.fail(...)`) already throw and are surfaced by `compileToJSX`, so this only concerns the non-fatal path.

From the issue:

> Agree we should have that 👍
>
> Historically we never used those Unified/Vfile reporting APIs, but we should

## Changes

- `processor.ts` now exposes the vfile messages on `SimpleProcessorResult` instead of dropping them.
- New `reportMDXMessages()` in `messages.ts` formats and logs them, following the existing `logger` conventions.
- `loader.ts` calls it after compilation.

Reporting is restricted to the client compiler so prod builds do not emit each warning twice. This mirrors the existing logic in the `unusedDirectives` Remark plugin.

Example output, for a plugin calling `file.message('Some plugin warning', ...)`:

```
[WARNING] Docusaurus found 2 Markdown warnings in file "docs/test.md"
- Some plugin warning (3:5)
- Another warning without position
```

No new configuration option is introduced. If you would rather have this gated behind a `siteConfig.markdown.hooks` severity option than a plain warning, I am happy to follow up.

## Test Plan

New unit tests:

- `__tests__/processor.test.ts`: the processor returns messages reported by a Remark plugin. This file previously contained no tests, as the old TODO about Jest and ESM no longer applies under Vitest.
- `__tests__/messages.test.ts`: formatting including line and column, the empty case, and the server compiler case.
- `__tests__/loader.test.ts`: end to end through `mdxLoader`, asserting the warning reaches `console.warn`.

Verified locally:

- `vitest run`: 185 test files, 2965 tests passing
- `tsc --noEmit -p packages/docusaurus-mdx-loader/tsconfig.json`: clean
- `eslint "packages/docusaurus-mdx-loader/src/**/*.ts"`: no errors
- `oxfmt --list-different`: clean

Each test was confirmed to fail before the corresponding change was applied.

### Test links

This is a build-time logging change with no UI impact, so there is no relevant deploy preview page.

## Related issues/PRs

Fixes #9953
