### PR TITLE
docs: remove old versions of remark-math/rehype-katex on markdown plugin page

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-plugins.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-plugins.mdx
@@ -45,7 +45,7 @@ These are all typical use-cases of Remark plugins, which can also be a source of
 An MDX plugin is usually an npm package, so you install them like other npm packages using npm. Take the [math plugins](./markdown-features-math-equations.mdx) as an example.
 
 ```bash npm2yarn
-npm install --save remark-math@5 rehype-katex@6
+npm install --save remark-math rehype-katex
 ```
 
 <details>


### PR DESCRIPTION
These versions are outdated and might confuse users.

It's not even the versions we recommend using in the `/markdown-features-math-equations.mdx`, which remains the source of truth for adding math equation support