### PR TITLE
docs: add docusaurus-plugin-deskcrew to community resources

### DIFF
--- a/website/community/2-resources.mdx
+++ b/website/community/2-resources.mdx
@@ -53,6 +53,7 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [posthog-docusaurus](https://github.com/PostHog/posthog-docusaurus) - Integrate [PostHog](https://posthog.com/) product analytics with Docusaurus
 - [docusaurus-plugin-moesif](https://github.com/Moesif/docusaurus-plugin-moesif) - Adds [Moesif API Analytics](https://www.moesif.com/) to track user behavior and pinpoint where developers drop off in your activation funnel.
 - [docusaurus-plugin-yandex-metrica](https://github.com/sgromkov/docusaurus-plugin-yandex-metrica) - Adds [Yandex Metrika](https://metrika.yandex.ru/) counter for evaluating site traffic and analyzing user behavior.
+- [@deskcrew/docusaurus-plugin](https://github.com/webmilmind1/docusaurus-deskcrew) - Adds the [DeskCrew](https://deskcrew.io/integrations/docusaurus) support widget (live chat, AI answers from your docs, tickets) to every page from one plugin entry
 
 ### AI / Agents {/* #ai-agents */}
 


### PR DESCRIPTION
## Motivation

Adds @deskcrew/docusaurus-plugin to the Integrations list of community plugins. It adds a support widget (live chat, AI answers grounded in the docs, tickets) to every page from one plugin entry. Published on npm, MIT.

## Test plan

Docs-only change to website/community/2-resources.mdx.
