### PR TITLE
chore: add webpack-dev-middleware@7.4.6 to supply chain security trust downgrade exceptions

### DIFF
--- a/.github/workflows/security-supply-chain.yml
+++ b/.github/workflows/security-supply-chain.yml
@@ -74,6 +74,7 @@ jobs:
           trustPolicyExclude:
             - 'detect-port@1.6.1'
             - 'semver@6.3.1'
+            - 'webpack-dev-middleware@7.4.6'
           YAML
 
           sfw pnpm install || sfw pnpm install || sfw pnpm install


### PR DESCRIPTION


## Motivation

This fixes our supply chain security workflow that detected a trust downgrade in a dependency

```
[ERR_PNPM_TRUST_DOWNGRADE] High-risk trust downgrade for "webpack-dev-middleware@7.4.6" (possible package takeover)

This error happened while installing the dependencies of @docusaurus/core@3.10.1
 at webpack-dev-server@5.2.6
```


The downgrade seems legit so I allowlisted it in our supply chain security workflow.

Reported: https://github.com/webpack/webpack-dev-middleware/issues/2407