### PR TITLE
chore: Upgrade to Chokidar v5

### DIFF
--- a/admin/scripts/copyUntypedFiles.js
+++ b/admin/scripts/copyUntypedFiles.js
@@ -7,7 +7,7 @@
 
 import fs from 'fs-extra';
 import path from 'path';
-import chokidar from 'chokidar';
+import * as chokidar from 'chokidar';
 
 const srcDir = path.join(process.cwd(), 'src');
 const libDir = path.join(process.cwd(), 'lib');

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -41,7 +41,7 @@
     "@docusaurus/utils-common": "3.10.1",
     "@docusaurus/utils-validation": "3.10.1",
     "boxen": "^6.2.1",
-    "chokidar": "^3.5.3",
+    "chokidar": "^5.0.0",
     "cli-table3": "^0.6.3",
     "combine-promises": "^1.1.0",
     "commander": "^5.1.0",

--- a/packages/docusaurus/src/commands/start/start.ts
+++ b/packages/docusaurus/src/commands/start/start.ts
@@ -36,7 +36,7 @@ async function doStart(
 
   const reloadableSite = await createReloadableSite({siteDirParam, cliOptions});
 
-  setupSiteFileWatchers(
+  await setupSiteFileWatchers(
     {props: reloadableSite.get().props, cliOptions},
     ({plugin}) => {
       if (plugin) {

--- a/packages/docusaurus/src/commands/start/watcher.ts
+++ b/packages/docusaurus/src/commands/start/watcher.ts
@@ -6,7 +6,7 @@
  */
 
 import path from 'path';
-import chokidar from 'chokidar';
+import * as chokidar from 'chokidar';
 import {posixPath} from '@docusaurus/utils';
 import type {StartCLIOptions} from './start';
 import type {LoadedPlugin, Props} from '@docusaurus/types';
@@ -27,12 +27,18 @@ export function createPollingOptions(
   };
 }
 
-export type FileWatchEventName =
-  | 'add'
-  | 'addDir'
-  | 'change'
-  | 'unlink'
-  | 'unlinkDir';
+type ChokidarEventNames = keyof chokidar.FSWatcherEventMap;
+
+// We only subscribe to a subset of Chokidar events we care about
+const FileWatchEvents = [
+  'add',
+  'change',
+  'unlink',
+  'addDir',
+  'unlinkDir',
+] as const satisfies ChokidarEventNames[];
+
+export type FileWatchEventName = (typeof FileWatchEvents)[number];
 
 export type FileWatchEvent = {
   name: FileWatchEventName;
@@ -48,7 +54,7 @@ type WatchParams = {
  * Watch file system paths for changes and emit events
  * Returns an async handle to stop watching
  */
-export function watch(
+function watch(
   params: WatchParams,
   callback: (event: FileWatchEvent) => void,
 ): () => Promise<void> {
@@ -60,12 +66,18 @@ export function watch(
     ...options,
   });
 
-  fsWatcher.on('all', (name, eventPath) => callback({name, path: eventPath}));
+  console.log('watch', pathsToWatch);
+
+  FileWatchEvents.forEach((eventName) =>
+    fsWatcher.on(eventName, (eventPath) => {
+      callback({name: eventName, path: eventPath});
+    }),
+  );
 
   return () => fsWatcher.close();
 }
 
-export function getSitePathsToWatch({props}: {props: Props}): string[] {
+function getSitePathsToWatch({props}: {props: Props}): string[] {
   return [
     // TODO we should also watch all imported modules!
     //  Use https://github.com/vercel/nft ?
@@ -74,7 +86,7 @@ export function getSitePathsToWatch({props}: {props: Props}): string[] {
   ];
 }
 
-export function getPluginPathsToWatch({
+function getPluginPathsToWatch({
   siteDir,
   plugin,
 }: {

--- a/packages/docusaurus/src/commands/start/watcher.ts
+++ b/packages/docusaurus/src/commands/start/watcher.ts
@@ -7,7 +7,9 @@
 
 import path from 'path';
 import * as chokidar from 'chokidar';
-import {posixPath} from '@docusaurus/utils';
+import {Globby, posixPath} from '@docusaurus/utils';
+import picomatch from 'picomatch';
+
 import type {StartCLIOptions} from './start';
 import type {LoadedPlugin, Props} from '@docusaurus/types';
 
@@ -54,10 +56,10 @@ type WatchParams = {
  * Watch file system paths for changes and emit events
  * Returns an async handle to stop watching
  */
-function watch(
+async function watch(
   params: WatchParams,
   callback: (event: FileWatchEvent) => void,
-): () => Promise<void> {
+): Promise<() => Promise<void>> {
   const {pathsToWatch, siteDir, ...options} = params;
 
   const fsWatcher = chokidar.watch(pathsToWatch, {
@@ -66,7 +68,11 @@ function watch(
     ...options,
   });
 
-  console.log('watch', pathsToWatch);
+  console.log('watch glob', {
+    patterns: pathsToWatch,
+    scans: pathsToWatch.map((pattern) => picomatch.scan(pattern).base),
+    result: await Globby(pathsToWatch),
+  });
 
   FileWatchEvents.forEach((eventName) =>
     fsWatcher.on(eventName, (eventPath) => {
@@ -105,7 +111,7 @@ function getPluginPathsToWatch({
     .map(normalizeToSiteDir);
 }
 
-export function setupSiteFileWatchers(
+export async function setupSiteFileWatchers(
   {
     props,
     cliOptions,
@@ -117,7 +123,7 @@ export function setupSiteFileWatchers(
     plugin: LoadedPlugin | null;
     event: FileWatchEvent;
   }) => void,
-): void {
+): Promise<void> {
   const {siteDir} = props;
   const pollingOptions = createPollingOptions(cliOptions);
 
@@ -125,7 +131,7 @@ export function setupSiteFileWatchers(
   //  the getFilePathsToWatch lifecycle code might get updated
   //  so we should probably reset the watchers?
 
-  watch(
+  const siteWatcher = watch(
     {
       pathsToWatch: getSitePathsToWatch({props}),
       siteDir: props.siteDir,
@@ -134,8 +140,8 @@ export function setupSiteFileWatchers(
     (event) => callback({plugin: null, event}),
   );
 
-  props.plugins.forEach((plugin) => {
-    watch(
+  const pluginWatchers = props.plugins.map((plugin) => {
+    return watch(
       {
         pathsToWatch: getPluginPathsToWatch({plugin, siteDir}),
         siteDir,
@@ -144,4 +150,6 @@ export function setupSiteFileWatchers(
       (event) => callback({plugin, event}),
     );
   });
+
+  await Promise.all([siteWatcher, ...pluginWatchers]);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,8 +362,8 @@ importers:
         specifier: ^6.2.1
         version: 6.2.1
       chokidar:
-        specifier: ^3.5.3
-        version: 3.6.0
+        specifier: ^5.0.0
+        version: 5.0.0
       cli-table3:
         specifier: ^0.6.3
         version: 0.6.5
@@ -6772,10 +6772,6 @@ packages:
     resolution: {integrity: sha512-sdleLVfCjBtgO5cNjA2HVRvWBJAHs4zwenaCPMNJAJU0yNxpzj80IpjOIimkpkr+mhlA+how5poQtt53PygbHA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  binary-extensions@2.3.0:
-    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
-    engines: {node: '>=8'}
-
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -6984,10 +6980,6 @@ packages:
   cheerio@1.2.0:
     resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
     engines: {node: '>=20.18.1'}
-
-  chokidar@3.6.0:
-    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
-    engines: {node: '>= 8.10.0'}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -9146,10 +9138,6 @@ packages:
   is-bigint@1.1.0:
     resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
     engines: {node: '>= 0.4'}
-
-  is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
 
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
@@ -11595,10 +11583,6 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
-
-  readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
 
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
@@ -18545,8 +18529,6 @@ snapshots:
       read-cmd-shim: 5.0.0
       write-file-atomic: 6.0.0
 
-  binary-extensions@2.3.0: {}
-
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -18827,18 +18809,6 @@ snapshots:
       parse5-parser-stream: 7.1.2
       undici: 7.26.0
       whatwg-mimetype: 4.0.0
-
-  chokidar@3.6.0:
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.3
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
 
   chokidar@5.0.0:
     dependencies:
@@ -21371,10 +21341,6 @@ snapshots:
   is-bigint@1.1.0:
     dependencies:
       has-bigints: 1.1.0
-
-  is-binary-path@2.1.0:
-    dependencies:
-      binary-extensions: 2.3.0
 
   is-boolean-object@1.2.2:
     dependencies:
@@ -24471,10 +24437,6 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-
-  readdirp@3.6.0:
-    dependencies:
-      picomatch: 2.3.2
 
   readdirp@5.0.0: {}
 


### PR DESCRIPTION

## Motivation

Upgrade dependency for maintenance reasons

Changelogs:
- https://github.com/paulmillr/chokidar/releases/tag/4.0.0
- https://github.com/paulmillr/chokidar/releases/tag/5.0.0

The main breaking change is the drop of globbing support, which we unfortunately use:

https://github.com/paulmillr/chokidar#upgrading

## Stuck

Currently stuck because using Node glob/globby only resolves existing files that match patterns, but it won't help watching dirs when using `docs/**/*.{md,mdx}`, so additions/deletions won't be watched.

See also https://github.com/paulmillr/chokidar/discussions/1423

Code that removed glob support is not easy to understand/backport: https://github.com/paulmillr/chokidar/commit/cac97c6da1b54c5e4db17c599f2ca52e33591ac6#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80

A possible solution would be something like this:

```ts
import chokidar from 'chokidar';
import picomatch from 'picomatch';

function watchGlob(pattern: string) {
  const {base} = picomatch.scan(pattern); // 'docs/**/*.{md,mdx}' -> 'docs'
  const isMatch = picomatch(pattern); 

  return chokidar.watch(base || '.').on('all', (event, path) => {
    if (isMatch(path)) {
      // Docusaurus handling
    }
  });
}

watchGlob('docs/**/*.{md,mdx}');
```

## Test Plan

CI

Local tests: adding/editing/removing files/folders should trigger both site/plugin reloads. 


MDX editions should not just hot reload (handled by bundler) but also recompute metadata and adjust the experience accordingly.


### Test links

https://deploy-preview-12413--docusaurus-2.netlify.app/
