### PR TITLE
chore(v3): pin patched serialize-javascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,8 @@
     "typescript": "~6.0.2"
   },
   "resolutions": {
-    "**/pretty-format/react-is": "^19.2.4"
+    "**/pretty-format/react-is": "^19.2.4",
+    "**/serialize-javascript": "7.0.5"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16623,12 +16623,10 @@ send@0.19.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
-serialize-javascript@^6.0.0, serialize-javascript@^6.0.1:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
-  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
-  dependencies:
-    randombytes "^2.1.0"
+serialize-javascript@7.0.5, serialize-javascript@^6.0.0, serialize-javascript@^6.0.1:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.5.tgz#c798cc0552ffbb08981914a42a8756e339d0d5b1"
+  integrity sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==
 
 serve-handler@^6.1.7:
   version "6.1.7"


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the Contributing Guidelines on pull requests.
- [x] This is a dependency-only security maintenance change.
- [x] No API or user-facing behavior is changed.

## Motivation

The v3 maintenance branch currently resolves `serialize-javascript@6.0.2`,
which is affected by current security advisories.

The main branch already resolves a patched 7.x version.

## Changes

- pin `serialize-javascript` to `7.0.5` through Yarn resolutions;
- update the corresponding `yarn.lock` entry;
- keep the change scoped to the v3 maintenance branch.

This avoids upgrading `copy-webpack-plugin` and
`css-minimizer-webpack-plugin` across major versions just to obtain the
patched transitive dependency.

## Test Plan

- `yarn install --frozen-lockfile`
- `yarn why serialize-javascript`
- `yarn build:packages`
- `yarn test`

Full test suite result:

- 186 test suites passed
- 2920 tests passed
- 1031 snapshots passed
