### PR TITLE
fix(core): recognize arbitrary HTML anchors in broken anchor checker (AI-assisted)

### DIFF
--- a/packages/docusaurus/src/client/__tests__/extractHtmlAnchors.test.ts
+++ b/packages/docusaurus/src/client/__tests__/extractHtmlAnchors.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {describe, expect, it} from 'vitest';
+import {extractHtmlAnchors} from '../extractHtmlAnchors';
+
+describe('extractHtmlAnchors', () => {
+  it('extracts id attributes of arbitrary elements', () => {
+    expect(
+      extractHtmlAnchors(`
+        <h2 id="heading-anchor">Heading</h2>
+        <div id="div-anchor"/>
+        <span id='single-quote-anchor'>text</span>
+        <a id="link-id-anchor" href="#">link</a>
+      `),
+    ).toEqual([
+      'heading-anchor',
+      'div-anchor',
+      'single-quote-anchor',
+      'link-id-anchor',
+    ]);
+  });
+
+  it('extracts legacy named anchors', () => {
+    expect(
+      extractHtmlAnchors(`
+        <a name="anchor">Some Text</a>
+        <a name="self-closing-anchor"/>
+        <A NAME="uppercase-anchor"></A>
+      `),
+    ).toEqual(['anchor', 'self-closing-anchor', 'uppercase-anchor']);
+  });
+
+  it('extracts both id and name anchors from the same page', () => {
+    expect(
+      extractHtmlAnchors(`
+        <article>
+          <h2 id="section">Section</h2>
+          <a name="named">Named</a>
+        </article>
+      `),
+    ).toEqual(['section', 'named']);
+  });
+
+  it('deduplicates anchors', () => {
+    expect(
+      extractHtmlAnchors(`
+        <h2 id="same">One</h2>
+        <h3 id="same">Two</h3>
+        <a name="same">Three</a>
+      `),
+    ).toEqual(['same']);
+  });
+
+  it('ignores empty anchors', () => {
+    expect(
+      extractHtmlAnchors(`
+        <div id="">Empty</div>
+        <a name="">Empty</a>
+      `),
+    ).toEqual([]);
+  });
+
+  it('does not match id-like substrings of other attributes', () => {
+    expect(
+      extractHtmlAnchors(`
+        <div data-id="not-an-anchor">text</div>
+        <div aria-labelledby="not-an-anchor">text</div>
+        <input name="not-an-anchor"/>
+      `),
+    ).toEqual([]);
+  });
+
+  it('does not match id-looking text content', () => {
+    // React escapes quotes in text content, but let's be safe anyway
+    expect(extractHtmlAnchors(`<p>use id=&quot;foo&quot; here</p>`)).toEqual(
+      [],
+    );
+  });
+
+  it('decodes HTML entities in anchor values', () => {
+    expect(
+      extractHtmlAnchors(`<div id="a&amp;b&quot;c&#x27;d&#39;e">text</div>`),
+    ).toEqual([`a&b"c'd'e`]);
+  });
+
+  it('returns an empty array when there are no anchors', () => {
+    expect(extractHtmlAnchors('<div><p>No anchors here</p></div>')).toEqual([]);
+  });
+});

--- a/packages/docusaurus/src/client/extractHtmlAnchors.ts
+++ b/packages/docusaurus/src/client/extractHtmlAnchors.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Matches the `id` attribute of any HTML element: <h2 id="anchor">,
+// <div id="anchor"/>, <a id="anchor">...
+// Any element with an `id` is a valid fragment navigation target in browsers.
+const IdAttributeRegex = /\sid=(["'])(.*?)\1/gi;
+
+// Matches legacy named anchors: <a name="anchor">, <a name="anchor"/>
+// The `name` attribute on `<a>` is obsolete as per the HTML5 spec, but browsers
+// still honor it as a fragment navigation target, so we keep supporting it.
+const AnchorNameAttributeRegex = /<a\b[^<>]*\sname=(["'])(.*?)\1/gi;
+
+const NamedHtmlEntities: {[entityName: string]: string} = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+};
+
+// Attribute values extracted from HTML are HTML-escaped (React escapes them
+// during SSR). We decode them back so that they can be compared with the
+// raw anchor values collected through the useBrokenLinks() API.
+function decodeHtmlEntities(value: string): string {
+  return value.replace(
+    /&(#x?[0-9a-fA-F]+|amp|lt|gt|quot);/g,
+    (entity: string, code: string) => {
+      if (code in NamedHtmlEntities) {
+        return NamedHtmlEntities[code]!;
+      }
+      const isHexadecimal = /^#x/i.test(code);
+      const charCode = parseInt(
+        code.slice(isHexadecimal ? 2 : 1),
+        isHexadecimal ? 16 : 10,
+      );
+      return Number.isNaN(charCode) ? entity : String.fromCodePoint(charCode);
+    },
+  );
+}
+
+function extractAnchors(regex: RegExp, html: string): string[] {
+  const anchors: string[] = [];
+  // The regexes are global: reset lastIndex in case of reuse
+  regex.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(html)) !== null) {
+    const anchor = decodeHtmlEntities(match[2]!);
+    if (anchor !== '') {
+      anchors.push(anchor);
+    }
+  }
+  return anchors;
+}
+
+/**
+ * Extracts all the anchor targets of a rendered HTML page: the `id` attribute
+ * of any element, as well as legacy `<a name="...">` anchors.
+ *
+ * This is the source of truth browsers use for fragment (`#anchor`) navigation,
+ * and allows the broken anchors checker to automatically support arbitrary
+ * anchors such as `<div id="anchor"/>` or `<a name="anchor"/>` in MDX/React
+ * pages, without requiring explicit collection through useBrokenLinks().
+ *
+ * See https://github.com/facebook/docusaurus/issues/9808
+ */
+export function extractHtmlAnchors(html: string): string[] {
+  const anchors = new Set<string>([
+    ...extractAnchors(IdAttributeRegex, html),
+    ...extractAnchors(AnchorNameAttributeRegex, html),
+  ]);
+  return [...anchors];
+}

--- a/packages/docusaurus/src/client/serverEntry.tsx
+++ b/packages/docusaurus/src/client/serverEntry.tsx
@@ -16,6 +16,7 @@ import {
   createStatefulBrokenLinks,
   BrokenLinksProvider,
 } from './BrokenLinksContext';
+import {extractHtmlAnchors} from './extractHtmlAnchors';
 import {toPageCollectedMetadataInternal} from './serverHelmetUtils';
 import type {AppRenderer, PageCollectedDataInternal} from '../common';
 
@@ -41,6 +42,17 @@ const render: AppRenderer['render'] = async ({pathname}) => {
   );
 
   const html = await renderToHtml(app);
+
+  // The broken anchors checker only knows about anchors explicitly collected
+  // through the useBrokenLinks() API (e.g. by the <Heading/> theme component).
+  // We also extract anchor targets from the rendered HTML so that arbitrary
+  // anchors such as <div id="anchor"/> or legacy <a name="anchor"/> in
+  // MDX/React pages are automatically recognized, like browsers do for
+  // fragment navigation.
+  // See https://github.com/facebook/docusaurus/issues/9808
+  extractHtmlAnchors(html).forEach((anchor) =>
+    statefulBrokenLinks.collectAnchor(anchor),
+  );
 
   const {helmet} = helmetContext as FilledContext;
 

--- a/website/docs/api/docusaurus.config.js.mdx
+++ b/website/docs/api/docusaurus.config.js.mdx
@@ -408,7 +408,9 @@ The broken links detection is only available for a production build (`docusaurus
 
 - Type: `'ignore' | 'log' | 'warn' | 'throw'`
 
-The behavior of Docusaurus when it detects any broken anchor declared with the `Heading` component of Docusaurus.
+The behavior of Docusaurus when it detects any broken anchor.
+
+Anchors are automatically collected from your rendered HTML pages: any element `id` attribute (such as `<div id="anchor"/>`) as well as legacy `<a name="anchor"/>` named anchors are valid anchor targets, in addition to anchors explicitly collected through the [`useBrokenLinks()`](/docs/docusaurus-core#usebrokenlinks) API.
 
 By default, it prints a warning, to let you know about your broken anchors.
 


### PR DESCRIPTION
Fixes #9808

## Problem

The `onBrokenAnchors` checker only knew about anchors explicitly collected through the `useBrokenLinks()` API (e.g. by the `@theme/Heading` component). Valid anchors written directly in MDX/React pages — such as `<div id="anchor"/>`, `<h3 id="anchor">`, or legacy `<a name="anchor"/>` — were never collected, so links targeting them were wrongly reported as broken anchors during `docusaurus build`, even though the anchors work fine in the browser.

## Fix

During SSG (`packages/docusaurus/src/client/serverEntry.tsx`), anchor targets are now extracted from the fully rendered HTML page — the same source of truth browsers use for fragment navigation — and added to the collected anchors:

- new `extractHtmlAnchors()` util (`packages/docusaurus/src/client/extractHtmlAnchors.ts`) collects the `id` attribute of any element plus legacy `<a name="...">` anchors, with HTML-entity decoding, deduplication, and guards against false positives (`data-id`, text content, non-`<a>` `name` attributes)
- docs updated (`website/docs/api/docusaurus.config.js.mdx`): `onBrokenAnchors` no longer claims anchors must be "declared with the `Heading` component"

This matches the direction discussed in the issue (automatically supporting `<div id="anchor"/>`, `<a id="anchor"/>`, etc. in Markdown files, not just headings).

## Test plan

- New unit tests `packages/docusaurus/src/client/__tests__/extractHtmlAnchors.test.ts`: 9 tests pass (vitest) — arbitrary element ids, legacy `<a name>`, mixed pages, dedup, empty anchors, false-positive guards (`data-id`, `aria-labelledby`, text content), HTML-entity decoding
- `tsc --noEmit --strict` (with repo flags `noUncheckedIndexedAccess`, `erasableSyntaxOnly`): clean
- `oxfmt --list-different` on changed TS files: clean
- End-to-end logic simulation of the issue scenario: page HTML containing `<a name="anchor">` + link `#anchor` — before the fix the checker's anchor-matching logic reports `#anchor` as broken (reproduces the issue); after adding the HTML-extracted anchors, `#anchor` and `#custom-anchor` resolve while a genuinely missing `#missing` anchor is still reported as broken
- Full monorepo `yarn build` / jest suite not run here (deps not installed in this environment); CI will cover it

(AI-assisted)