### PR TITLE
feat(core): resolve Markdown file links across plugins (AI-assisted)

### DIFF
--- a/packages/docusaurus-mdx-loader/src/options.ts
+++ b/packages/docusaurus-mdx-loader/src/options.ts
@@ -24,6 +24,13 @@ export type Options = Partial<MDXOptions> & {
     frontMatter: {[key: string]: unknown};
   }) => {[key: string]: unknown};
   resolveMarkdownLink?: ResolveMarkdownLink;
+  /**
+   * Fallback used when `resolveMarkdownLink` can't resolve a Markdown link.
+   * It looks at the Markdown files of the whole site, not just those of the
+   * plugin owning the source file, and enables cross-plugin Markdown links.
+   * See https://github.com/facebook/docusaurus/issues/9117
+   */
+  resolveSiteMarkdownLink?: ResolveMarkdownLink;
 
   // Will usually be created by "createMDXLoaderItem"
   processors?: SimpleProcessors;

--- a/packages/docusaurus-mdx-loader/src/processor.ts
+++ b/packages/docusaurus-mdx-loader/src/processor.ts
@@ -130,11 +130,12 @@ async function createProcessorFactory() {
         } satisfies TransformImageOptions,
       ],
       // TODO merge this with transformLinks?
-      options.resolveMarkdownLink
+      options.resolveMarkdownLink || options.resolveSiteMarkdownLink
         ? [
             resolveMarkdownLinks,
             {
               resolveMarkdownLink: options.resolveMarkdownLink,
+              resolveSiteMarkdownLink: options.resolveSiteMarkdownLink,
               onBrokenMarkdownLinks:
                 options.markdownConfig.hooks.onBrokenMarkdownLinks,
             } satisfies ResolveMarkdownLinksOptions,

--- a/packages/docusaurus-mdx-loader/src/remark/resolveMarkdownLinks/__tests__/index.test.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/resolveMarkdownLinks/__tests__/index.test.ts
@@ -183,6 +183,70 @@ this is a code block
     `);
   });
 
+  describe('resolveSiteMarkdownLink', () => {
+    const resolveSiteMarkdownLink: PluginOptions['resolveSiteMarkdownLink'] = ({
+      linkPathname,
+    }) => `/SITE-RESOLVED---${linkPathname}`;
+
+    it('is used as a fallback when the plugin can not resolve the link', async () => {
+      /* language=markdown */
+      const content = `[link1](link1.mdx)`;
+
+      const result = await process(content, {
+        resolveMarkdownLink: () => null,
+        resolveSiteMarkdownLink,
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        "[link1](/SITE-RESOLVED---link1.mdx)
+        "
+      `);
+    });
+
+    it('is not used when the plugin resolves the link', async () => {
+      /* language=markdown */
+      const content = `[link1](link1.mdx)`;
+
+      const result = await process(content, {resolveSiteMarkdownLink});
+
+      expect(result).toMatchInlineSnapshot(`
+        "[link1](/RESOLVED---link1.mdx)
+        "
+      `);
+    });
+
+    it('is used when the plugin does not provide any resolver', async () => {
+      /* language=markdown */
+      const content = `[link1](link1.mdx)`;
+
+      const result = await process(content, {
+        resolveMarkdownLink: undefined,
+        resolveSiteMarkdownLink,
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        "[link1](/SITE-RESOLVED---link1.mdx)
+        "
+      `);
+    });
+
+    it('reports a broken link when no resolver can resolve the link', async () => {
+      /* language=markdown */
+      const content = `[link1](link1.mdx)`;
+
+      await expect(() =>
+        process(content, {
+          resolveMarkdownLink: () => null,
+          resolveSiteMarkdownLink: () => null,
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [Error: Markdown link with URL \`link1.mdx\` in source file "packages/docusaurus-mdx-loader/src/remark/resolveMarkdownLinks/__tests__/docs/myFile.mdx" (1:1) couldn't be resolved.
+        Make sure it references a local Markdown file that exists within the site.
+        To ignore this error, use the \`siteConfig.markdown.hooks.onBrokenMarkdownLinks\` option, or apply the \`pathname://\` protocol to the broken link URLs.]
+      `);
+    });
+  });
+
   describe('onBrokenMarkdownLinks', () => {
     async function processResolutionErrors(
       content: string,
@@ -202,7 +266,7 @@ this is a code block
         await expect(() => processResolutionErrors(content)).rejects
           .toThrowErrorMatchingInlineSnapshot(`
           [Error: Markdown link with URL \`link1.mdx\` in source file "packages/docusaurus-mdx-loader/src/remark/resolveMarkdownLinks/__tests__/docs/myFile.mdx" (1:1) couldn't be resolved.
-          Make sure it references a local Markdown file that exists within the current plugin.
+          Make sure it references a local Markdown file that exists within the site.
           To ignore this error, use the \`siteConfig.markdown.hooks.onBrokenMarkdownLinks\` option, or apply the \`pathname://\` protocol to the broken link URLs.]
         `);
       });
@@ -214,7 +278,7 @@ this is a code block
         await expect(() => processResolutionErrors(content)).rejects
           .toThrowErrorMatchingInlineSnapshot(`
           [Error: Markdown link with URL \`link1.md\` in source file "packages/docusaurus-mdx-loader/src/remark/resolveMarkdownLinks/__tests__/docs/myFile.mdx" (1:1) couldn't be resolved.
-          Make sure it references a local Markdown file that exists within the current plugin.
+          Make sure it references a local Markdown file that exists within the site.
           To ignore this error, use the \`siteConfig.markdown.hooks.onBrokenMarkdownLinks\` option, or apply the \`pathname://\` protocol to the broken link URLs.]
         `);
       });
@@ -253,11 +317,11 @@ this is a code block
           [
             [
               "[WARNING] Markdown link with URL \`link1.mdx\` in source file "packages/docusaurus-mdx-loader/src/remark/resolveMarkdownLinks/__tests__/docs/myFile.mdx" (2:1) couldn't be resolved.
-          Make sure it references a local Markdown file that exists within the current plugin.",
+          Make sure it references a local Markdown file that exists within the site.",
             ],
             [
               "[WARNING] Markdown link with URL \`dir/link3.md\` in source file "packages/docusaurus-mdx-loader/src/remark/resolveMarkdownLinks/__tests__/docs/myFile.mdx" (6:1) couldn't be resolved.
-          Make sure it references a local Markdown file that exists within the current plugin.",
+          Make sure it references a local Markdown file that exists within the site.",
             ],
           ]
         `);

--- a/packages/docusaurus-mdx-loader/src/remark/resolveMarkdownLinks/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/resolveMarkdownLinks/index.ts
@@ -38,7 +38,17 @@ export type ResolveMarkdownLink = (
 ) => string | null;
 
 export interface PluginOptions {
-  resolveMarkdownLink: ResolveMarkdownLink;
+  /**
+   * Resolves the link against the Markdown files of the plugin owning the
+   * source file. It has priority over `resolveSiteMarkdownLink`.
+   */
+  resolveMarkdownLink?: ResolveMarkdownLink;
+  /**
+   * Resolves the link against the Markdown files of the whole site, whatever
+   * plugin owns them. Used as a fallback, to support cross-plugin links.
+   * See https://github.com/facebook/docusaurus/issues/9117
+   */
+  resolveSiteMarkdownLink?: ResolveMarkdownLink;
   onBrokenMarkdownLinks: MarkdownConfig['hooks']['onBrokenMarkdownLinks'];
 }
 
@@ -57,7 +67,7 @@ function asFunction(
       )`Markdown link with URL code=${linkUrl} in source file path=${relativePath}${formatNodePositionExtraMessage(
         node,
       )} couldn't be resolved.
-Make sure it references a local Markdown file that exists within the current plugin.${extraHelp}`;
+Make sure it references a local Markdown file that exists within the site.${extraHelp}`;
     };
   } else {
     return (params) =>
@@ -96,7 +106,7 @@ function parseMarkdownLinkURLPath(link: string): URLPath | null {
 const plugin: Plugin<PluginOptions[], Root> = function plugin(
   options,
 ): Transformer<Root> {
-  const {resolveMarkdownLink} = options;
+  const {resolveMarkdownLink, resolveSiteMarkdownLink} = options;
 
   const onBrokenMarkdownLinks = asFunction(options.onBrokenMarkdownLinks);
 
@@ -112,10 +122,17 @@ const plugin: Plugin<PluginOptions[], Root> = function plugin(
 
       const sourceFilePath = file.path;
 
-      const permalink = resolveMarkdownLink({
+      const resolveParams = {
         sourceFilePath,
         linkPathname: linkURLPath.pathname,
-      });
+      };
+
+      // The plugin owning the source file resolves its own links in priority
+      // We only fall back to the site-wide registry for cross-plugin links
+      const permalink =
+        resolveMarkdownLink?.(resolveParams) ??
+        resolveSiteMarkdownLink?.(resolveParams) ??
+        null;
 
       if (permalink) {
         // This reapplies the link ?qs#hash part to the resolved pathname

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
@@ -124,6 +124,10 @@ const getPlugin = async (
       generatedFilesDir,
       i18n,
       localizationDir,
+      siteMarkdownLinks: {
+        sourceToPermalink: new Map(),
+        resolveMarkdownLink: () => null,
+      },
     } as LoadContext,
     validateOptions({
       validate: normalizePluginOptions as Validate<

--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -62,6 +62,7 @@ export default async function pluginContentBlog(
     siteConfig,
     generatedFilesDir,
     localizationDir,
+    siteMarkdownLinks,
     i18n: {currentLocale},
   } = context;
 
@@ -166,6 +167,7 @@ export default async function pluginContentBlog(
           contentPaths,
         });
       },
+      resolveSiteMarkdownLink: siteMarkdownLinks.resolveMarkdownLink,
     });
 
     function createBlogMarkdownLoader(): RuleSetUseItem {

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -83,7 +83,8 @@ export default async function pluginContentDocs(
   context: LoadContext,
   options: PluginOptions,
 ): Promise<Plugin<LoadedContent>> {
-  const {siteDir, generatedFilesDir, baseUrl, siteConfig} = context;
+  const {siteDir, generatedFilesDir, baseUrl, siteConfig, siteMarkdownLinks} =
+    context;
   // Mutate options to resolve sidebar path according to siteDir
   options.sidebarPath = resolveSidebarPathOption(siteDir, options.sidebarPath);
 
@@ -169,6 +170,7 @@ export default async function pluginContentDocs(
             contentPaths: version,
           });
         },
+        resolveSiteMarkdownLink: siteMarkdownLinks.resolveMarkdownLink,
       },
     });
   }

--- a/packages/docusaurus-plugin-content-pages/src/index.ts
+++ b/packages/docusaurus-plugin-content-pages/src/index.ts
@@ -31,7 +31,7 @@ export default async function pluginContentPages(
   context: LoadContext,
   options: PluginOptions,
 ): Promise<Plugin<LoadedContent | null>> {
-  const {siteConfig, siteDir, generatedFilesDir} = context;
+  const {siteConfig, siteDir, generatedFilesDir, siteMarkdownLinks} = context;
 
   const contentPaths = createPagesContentPaths({context, options});
   const contentHelpers = createContentHelpers();
@@ -92,6 +92,7 @@ export default async function pluginContentPages(
             contentPaths,
           });
         },
+        resolveSiteMarkdownLink: siteMarkdownLinks.resolveMarkdownLink,
       },
     });
   }

--- a/packages/docusaurus-types/src/context.d.ts
+++ b/packages/docusaurus-types/src/context.d.ts
@@ -49,6 +49,41 @@ export type SiteStorage = {
 
 export type GlobalData = {[pluginName: string]: {[pluginId: string]: unknown}};
 
+/**
+ * A site-wide registry of the Markdown files of all the content plugins.
+ *
+ * Content plugins own a registry of their own Markdown files, and use it to
+ * resolve the Markdown links found in their own content. This site-wide
+ * registry is the fallback used when a Markdown link can't be resolved within
+ * the plugin owning the source file, and permits cross-plugin Markdown links.
+ *
+ * See https://github.com/facebook/docusaurus/issues/9117
+ */
+export type SiteMarkdownLinks = {
+  /**
+   * Aliased source file path (`@site/docs/intro.mdx`) to permalink (`/docs/
+   * intro`) of all the Markdown files of the site, whatever plugin owns them.
+   *
+   * /!\ This map is mutable: it is emptied and refilled on each site reload.
+   * The identity of the `SiteMarkdownLinks` object holding it remains stable
+   * for the whole dev server lifetime, because the MDX loader receives it
+   * through `configureWebpack()`, which only runs once.
+   */
+  sourceToPermalink: Map<string, string>;
+
+  /**
+   * Resolves a Markdown link pathname against `sourceToPermalink`, looking at
+   * the Markdown files of the whole site. Returns `null` when the link can't
+   * be resolved to any Markdown file of the site.
+   */
+  resolveMarkdownLink: (params: {
+    /** Absolute path of the source file containing the Markdown link. */
+    sourceFilePath: string;
+    /** The link pathname to resolve, such as `./intro.mdx`. */
+    linkPathname: string;
+  }) => string | null;
+};
+
 export type LoadContext = {
   siteDir: string;
   siteVersion: string | undefined;
@@ -80,6 +115,12 @@ export type LoadContext = {
    * The bundler used to build the site (Webpack or Rspack)
    */
   currentBundler: CurrentBundler;
+
+  /**
+   * Site-wide Markdown files registry, used by content plugins as a fallback
+   * to resolve Markdown links pointing to files owned by other plugins.
+   */
+  siteMarkdownLinks: SiteMarkdownLinks;
 };
 
 export type Props = LoadContext & {

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -39,6 +39,7 @@ export {
   GlobalData,
   LoadContext,
   SiteStorage,
+  SiteMarkdownLinks,
   Props,
 } from './context';
 

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/site.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/site.test.ts.snap
@@ -174,6 +174,10 @@ exports[`loadSite > custom-i18n-site > loads site 1`] = `
   },
   "siteConfigPath": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/custom-i18n-site/docusaurus.config.js",
   "siteDir": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/custom-i18n-site",
+  "siteMarkdownLinks": {
+    "resolveMarkdownLink": [Function],
+    "sourceToPermalink": Map {},
+  },
   "siteMetadata": {
     "docusaurusVersion": "<CURRENT_VERSION>",
     "pluginVersions": {},
@@ -342,6 +346,10 @@ exports[`loadSite > simple-site-with-baseUrl > loads site - custom config 1`] = 
   },
   "siteConfigPath": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl/docusaurus.config.custom.js",
   "siteDir": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl",
+  "siteMarkdownLinks": {
+    "resolveMarkdownLink": [Function],
+    "sourceToPermalink": Map {},
+  },
   "siteMetadata": {
     "docusaurusVersion": "<CURRENT_VERSION>",
     "pluginVersions": {},
@@ -510,6 +518,10 @@ exports[`loadSite > simple-site-with-baseUrl > loads site - custom outDir 1`] = 
   },
   "siteConfigPath": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl/docusaurus.config.js",
   "siteDir": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl",
+  "siteMarkdownLinks": {
+    "resolveMarkdownLink": [Function],
+    "sourceToPermalink": Map {},
+  },
   "siteMetadata": {
     "docusaurusVersion": "<CURRENT_VERSION>",
     "pluginVersions": {},
@@ -678,6 +690,10 @@ exports[`loadSite > simple-site-with-baseUrl > loads site 1`] = `
   },
   "siteConfigPath": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl/docusaurus.config.js",
   "siteDir": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl",
+  "siteMarkdownLinks": {
+    "resolveMarkdownLink": [Function],
+    "sourceToPermalink": Map {},
+  },
   "siteMetadata": {
     "docusaurusVersion": "<CURRENT_VERSION>",
     "pluginVersions": {},
@@ -912,6 +928,10 @@ exports[`loadSite > simple-site-with-baseUrl-i18n > loads site -  locale fr + cu
   },
   "siteConfigPath": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl-i18n/docusaurus.config.js",
   "siteDir": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl-i18n",
+  "siteMarkdownLinks": {
+    "resolveMarkdownLink": [Function],
+    "sourceToPermalink": Map {},
+  },
   "siteMetadata": {
     "docusaurusVersion": "<CURRENT_VERSION>",
     "pluginVersions": {},
@@ -1146,6 +1166,10 @@ exports[`loadSite > simple-site-with-baseUrl-i18n > loads site - custom outDir 1
   },
   "siteConfigPath": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl-i18n/docusaurus.config.js",
   "siteDir": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl-i18n",
+  "siteMarkdownLinks": {
+    "resolveMarkdownLink": [Function],
+    "sourceToPermalink": Map {},
+  },
   "siteMetadata": {
     "docusaurusVersion": "<CURRENT_VERSION>",
     "pluginVersions": {},
@@ -1380,6 +1404,10 @@ exports[`loadSite > simple-site-with-baseUrl-i18n > loads site - locale de 1`] =
   },
   "siteConfigPath": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl-i18n/docusaurus.config.js",
   "siteDir": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl-i18n",
+  "siteMarkdownLinks": {
+    "resolveMarkdownLink": [Function],
+    "sourceToPermalink": Map {},
+  },
   "siteMetadata": {
     "docusaurusVersion": "<CURRENT_VERSION>",
     "pluginVersions": {},
@@ -1614,6 +1642,10 @@ exports[`loadSite > simple-site-with-baseUrl-i18n > loads site - locale en 1`] =
   },
   "siteConfigPath": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl-i18n/docusaurus.config.js",
   "siteDir": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl-i18n",
+  "siteMarkdownLinks": {
+    "resolveMarkdownLink": [Function],
+    "sourceToPermalink": Map {},
+  },
   "siteMetadata": {
     "docusaurusVersion": "<CURRENT_VERSION>",
     "pluginVersions": {},
@@ -1848,6 +1880,10 @@ exports[`loadSite > simple-site-with-baseUrl-i18n > loads site - locale es 1`] =
   },
   "siteConfigPath": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl-i18n/docusaurus.config.js",
   "siteDir": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl-i18n",
+  "siteMarkdownLinks": {
+    "resolveMarkdownLink": [Function],
+    "sourceToPermalink": Map {},
+  },
   "siteMetadata": {
     "docusaurusVersion": "<CURRENT_VERSION>",
     "pluginVersions": {},
@@ -2082,6 +2118,10 @@ exports[`loadSite > simple-site-with-baseUrl-i18n > loads site - locale fr 1`] =
   },
   "siteConfigPath": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl-i18n/docusaurus.config.js",
   "siteDir": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl-i18n",
+  "siteMarkdownLinks": {
+    "resolveMarkdownLink": [Function],
+    "sourceToPermalink": Map {},
+  },
   "siteMetadata": {
     "docusaurusVersion": "<CURRENT_VERSION>",
     "pluginVersions": {},
@@ -2316,6 +2356,10 @@ exports[`loadSite > simple-site-with-baseUrl-i18n > loads site - locale it 1`] =
   },
   "siteConfigPath": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl-i18n/docusaurus.config.js",
   "siteDir": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl-i18n",
+  "siteMarkdownLinks": {
+    "resolveMarkdownLink": [Function],
+    "sourceToPermalink": Map {},
+  },
   "siteMetadata": {
     "docusaurusVersion": "<CURRENT_VERSION>",
     "pluginVersions": {},
@@ -2550,6 +2594,10 @@ exports[`loadSite > simple-site-with-baseUrl-i18n > loads site 1`] = `
   },
   "siteConfigPath": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl-i18n/docusaurus.config.js",
   "siteDir": "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/__fixtures__/loadSiteFixtures/simple-site-with-baseUrl-i18n",
+  "siteMarkdownLinks": {
+    "resolveMarkdownLink": [Function],
+    "sourceToPermalink": Map {},
+  },
   "siteMetadata": {
     "docusaurusVersion": "<CURRENT_VERSION>",
     "pluginVersions": {},

--- a/packages/docusaurus/src/server/__tests__/siteMarkdownLinks.test.ts
+++ b/packages/docusaurus/src/server/__tests__/siteMarkdownLinks.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {describe, expect, it} from 'vitest';
+import {
+  createSiteMarkdownLinks,
+  updateSiteMarkdownLinks,
+} from '../siteMarkdownLinks';
+import type {RouteConfig} from '@docusaurus/types';
+
+function route(
+  path: string,
+  sourceFilePath?: string,
+  routes?: RouteConfig[],
+): RouteConfig {
+  return {
+    path,
+    component: '@theme/Component',
+    ...(sourceFilePath && {metadata: {sourceFilePath}}),
+    ...(routes && {routes}),
+  };
+}
+
+function createRegistry(routes: RouteConfig[], siteDir: string = '.') {
+  const siteMarkdownLinks = createSiteMarkdownLinks({siteDir});
+  updateSiteMarkdownLinks({siteMarkdownLinks, routes});
+  return siteMarkdownLinks;
+}
+
+describe('updateSiteMarkdownLinks', () => {
+  it('collects the Markdown files of all the plugins', () => {
+    const {sourceToPermalink} = createRegistry([
+      route('/docs', undefined, [
+        route('/docs/intro', 'docs/intro.md'),
+        route('/docs/api', 'docs/api.mdx'),
+      ]),
+      route('/blog/hello', 'blog/hello.md'),
+      route('/about', 'src/pages/about.md'),
+    ]);
+
+    expect(sourceToPermalink).toEqual(
+      new Map(
+        Object.entries({
+          '@site/docs/intro.md': '/docs/intro',
+          '@site/docs/api.mdx': '/docs/api',
+          '@site/blog/hello.md': '/blog/hello',
+          '@site/src/pages/about.md': '/about',
+        }),
+      ),
+    );
+  });
+
+  it('ignores routes without Markdown source file', () => {
+    const {sourceToPermalink} = createRegistry([
+      route('/'),
+      route('/about', 'src/pages/about.tsx'),
+      route('/markdown', 'src/pages/markdown.md'),
+    ]);
+
+    expect(sourceToPermalink).toEqual(
+      new Map(Object.entries({'@site/src/pages/markdown.md': '/markdown'})),
+    );
+  });
+
+  it('keeps the first route for duplicated source files', () => {
+    // Multiple plugin instances can read the same content dir
+    const {sourceToPermalink} = createRegistry([
+      route('/docs/intro', 'docs/intro.md'),
+      route('/docs-copy/intro', 'docs/intro.md'),
+    ]);
+
+    expect(sourceToPermalink).toEqual(
+      new Map(Object.entries({'@site/docs/intro.md': '/docs/intro'})),
+    );
+  });
+
+  it('refreshes the registry in place on site reloads', () => {
+    const siteMarkdownLinks = createSiteMarkdownLinks({siteDir: '.'});
+    const {sourceToPermalink} = siteMarkdownLinks;
+
+    updateSiteMarkdownLinks({
+      siteMarkdownLinks,
+      routes: [route('/docs/intro', 'docs/intro.md')],
+    });
+    updateSiteMarkdownLinks({
+      siteMarkdownLinks,
+      routes: [route('/docs/intro2', 'docs/intro2.md')],
+    });
+
+    // The MDX loader keeps a reference to the initial objects on reloads
+    expect(siteMarkdownLinks.sourceToPermalink).toBe(sourceToPermalink);
+    expect(sourceToPermalink).toEqual(
+      new Map(Object.entries({'@site/docs/intro2.md': '/docs/intro2'})),
+    );
+  });
+});
+
+describe('createSiteMarkdownLinks - resolveMarkdownLink', () => {
+  const {resolveMarkdownLink} = createRegistry([
+    route('/docs/intro', 'docs/intro.md'),
+    route('/docs/api/uri', 'docs/api/uri.mdx'),
+    route('/blog/hello', 'blog/hello.md'),
+    route('/about', 'src/pages/about.md'),
+  ]);
+
+  function test(sourceFilePath: string, linkPathname: string) {
+    return resolveMarkdownLink({sourceFilePath, linkPathname});
+  }
+
+  it('resolves cross-plugin relative links', () => {
+    expect(test('docs/intro.md', '../blog/hello.md')).toBe('/blog/hello');
+    expect(test('blog/hello.md', '../docs/intro.md')).toBe('/docs/intro');
+    expect(test('docs/api/uri.mdx', '../../src/pages/about.md')).toBe('/about');
+  });
+
+  it('resolves same-plugin relative links', () => {
+    expect(test('docs/intro.md', './api/uri.mdx')).toBe('/docs/api/uri');
+    expect(test('docs/api/uri.mdx', '../intro.md')).toBe('/docs/intro');
+  });
+
+  it('resolves site absolute links', () => {
+    expect(test('docs/intro.md', '/blog/hello.md')).toBe('/blog/hello');
+    expect(test('blog/hello.md', '/docs/api/uri.mdx')).toBe('/docs/api/uri');
+  });
+
+  it('resolves @site aliased links', () => {
+    expect(test('docs/intro.md', '@site/blog/hello.md')).toBe('/blog/hello');
+  });
+
+  it('returns null for unresolvable links', () => {
+    expect(test('docs/intro.md', './doesNotExist.md')).toBeNull();
+    expect(test('docs/intro.md', '../blog/hello.js')).toBeNull();
+  });
+});

--- a/packages/docusaurus/src/server/site.ts
+++ b/packages/docusaurus/src/server/site.ts
@@ -28,6 +28,10 @@ import {generateSiteFiles} from './codegen/codegen';
 import {getRoutesPaths, handleDuplicateRoutes} from './routes';
 import {createSiteStorage} from './storage';
 import {emitSiteMessages} from './siteMessages';
+import {
+  createSiteMarkdownLinks,
+  updateSiteMarkdownLinks,
+} from './siteMarkdownLinks';
 import type {LoadPluginsResult} from './plugins/plugins';
 import type {
   DocusaurusConfig,
@@ -35,6 +39,7 @@ import type {
   LoadContext,
   Props,
   PluginIdentifier,
+  SiteMarkdownLinks,
 } from '@docusaurus/types';
 
 export type LoadContextParams = {
@@ -61,6 +66,16 @@ export type LoadContextParams = {
    * provided value over the inferred one, letting you override it.
    */
   automaticBaseUrlLocalizationDisabled?: boolean;
+
+  /**
+   * The site-wide Markdown files registry to reuse, if any.
+   *
+   * On site reloads (`docusaurus start`), a brand new `LoadContext` is created,
+   * but the bundler config isn't recreated: the MDX loader keeps a reference to
+   * the registry object it received on the initial load. We must therefore keep
+   * mutating that very object instead of creating a new one.
+   */
+  siteMarkdownLinks?: SiteMarkdownLinks;
 };
 
 export type LoadSiteParams = LoadContextParams & {
@@ -87,6 +102,7 @@ export async function loadContext(
     locale,
     config: customConfigFilePath,
     automaticBaseUrlLocalizationDisabled,
+    siteMarkdownLinks = createSiteMarkdownLinks({siteDir: params.siteDir}),
   } = params;
   const generatedFilesDir = path.resolve(siteDir, GENERATED_FILES_DIR_NAME);
 
@@ -170,6 +186,7 @@ export async function loadContext(
     i18n,
     codeTranslations,
     currentBundler,
+    siteMarkdownLinks,
   };
 }
 
@@ -190,6 +207,7 @@ function createSiteProps(
     localizationDir,
     codeTranslations: siteCodeTranslations,
     currentBundler,
+    siteMarkdownLinks,
   } = context;
 
   const {headTags, preBodyTags, postBodyTags} = loadHtmlTags({
@@ -206,6 +224,8 @@ function createSiteProps(
 
   handleDuplicateRoutes(routes, siteConfig.onDuplicateRoutes);
   const routesPaths = getRoutesPaths(routes, baseUrl);
+
+  updateSiteMarkdownLinks({siteMarkdownLinks, routes});
 
   return {
     siteConfig,
@@ -227,6 +247,7 @@ function createSiteProps(
     postBodyTags,
     codeTranslations,
     currentBundler,
+    siteMarkdownLinks,
   };
 }
 
@@ -305,6 +326,10 @@ export async function reloadSite(site: Site): Promise<Site> {
   return loadSite({
     ...site.params,
     isReload: true,
+    // The bundler config is not recreated on reload: the MDX loader still holds
+    // a reference to the previous site-wide Markdown links registry, so we have
+    // to keep refreshing that same object.
+    siteMarkdownLinks: site.props.siteMarkdownLinks,
   });
 }
 

--- a/packages/docusaurus/src/server/siteMarkdownLinks.ts
+++ b/packages/docusaurus/src/server/siteMarkdownLinks.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {flattenRoutes, resolveMarkdownLinkPathname} from '@docusaurus/utils';
+import type {SourceToPermalink} from '@docusaurus/utils';
+import type {RouteConfig, SiteMarkdownLinks} from '@docusaurus/types';
+
+const MarkdownExtensionRegex = /\.mdx?$/i;
+
+/**
+ * Creates the site-wide Markdown files registry.
+ *
+ * The returned object is mutable, and its identity is stable on purpose: the
+ * content plugins hand it over to the MDX loader in `configureWebpack()`, which
+ * only runs once, while the registry content is refreshed on every site reload.
+ * See `updateSiteMarkdownLinks()`.
+ */
+export function createSiteMarkdownLinks({
+  siteDir,
+}: {
+  siteDir: string;
+}): SiteMarkdownLinks {
+  const sourceToPermalink: SourceToPermalink = new Map();
+
+  return {
+    sourceToPermalink,
+    resolveMarkdownLink: ({sourceFilePath, linkPathname}) =>
+      resolveMarkdownLinkPathname(linkPathname, {
+        sourceFilePath,
+        sourceToPermalink,
+        siteDir,
+        // The site-wide registry is not scoped to any plugin content dir:
+        // relative/absolute links are resolved against the site dir.
+        contentPaths: {contentPath: siteDir, contentPathLocalized: undefined},
+      }),
+  };
+}
+
+/**
+ * Refreshes the site-wide Markdown files registry from the site routes.
+ *
+ * Content plugins already attach the `sourceFilePath` of the Markdown file a
+ * route was created from (see `RouteMetadata`), so we don't need any extra
+ * plugin lifecycle to collect the Markdown files of the whole site.
+ */
+export function updateSiteMarkdownLinks({
+  siteMarkdownLinks,
+  routes,
+}: {
+  siteMarkdownLinks: SiteMarkdownLinks;
+  routes: RouteConfig[];
+}): void {
+  const {sourceToPermalink} = siteMarkdownLinks;
+  sourceToPermalink.clear();
+  flattenRoutes(routes).forEach((route) => {
+    const sourceFilePath = route.metadata?.sourceFilePath;
+    if (!sourceFilePath || !MarkdownExtensionRegex.test(sourceFilePath)) {
+      return;
+    }
+    // Route metadata source file paths are site-relative posix paths
+    const aliasedSourceFilePath = `@site/${sourceFilePath}`;
+    // On duplicates, the first route wins: this can happen for sites using
+    // multiple plugin instances reading the same content dir.
+    if (!sourceToPermalink.has(aliasedSourceFilePath)) {
+      sourceToPermalink.set(aliasedSourceFilePath, route.path);
+    }
+  });
+}

--- a/website/_dogfooding/_blog tests/2025-01-01-cross-plugin-links.mdx
+++ b/website/_dogfooding/_blog tests/2025-01-01-cross-plugin-links.mdx
@@ -1,0 +1,18 @@
+---
+title: Cross-plugin Markdown links
+date: 2025-01-01
+---
+
+Markdown links can also target files owned by another plugin, see [#9117](https://github.com/facebook/docusaurus/issues/9117)
+
+{/* truncate */}
+
+[../\_docs tests/tests/links/target.mdx](<../_docs tests/tests/links/target.mdx>)
+
+[../\_pages tests/linking/page-a.md](<../_pages tests/linking/page-a.md>)
+
+[../../docs/introduction.mdx](../../docs/introduction.mdx)
+
+[/docs/introduction.mdx](/docs/introduction.mdx)
+
+[@site/\_docs tests/tests/links/target.mdx](<@site/_dogfooding/_docs tests/tests/links/target.mdx>)

--- a/website/_dogfooding/_docs tests/tests/links/test-markdown-links.mdx
+++ b/website/_dogfooding/_docs tests/tests/links/test-markdown-links.mdx
@@ -43,6 +43,20 @@ lines
 
 [![Image with ./target.mdx link](/img/slash-introducing.svg)](./target.mdx)
 
+## Cross-plugin links
+
+Markdown links can also target files owned by another plugin, see [#9117](https://github.com/facebook/docusaurus/issues/9117)
+
+[../../../\_blog tests/2023-08-05.mdx](<../../../_blog tests/2023-08-05.mdx>)
+
+[../../../\_pages tests/linking/page-a.md](<../../../_pages tests/linking/page-a.md>)
+
+[../../../../docs/introduction.mdx](../../../../docs/introduction.mdx)
+
+[/docs/introduction.mdx](/docs/introduction.mdx)
+
+[@site/\_pages tests/linking/page-a.md](<@site/_dogfooding/_pages tests/linking/page-a.md>)
+
 ## Unresolvable links
 
 [https://github.com/facebook/docusaurus/blob/main/README.md](https://github.com/facebook/docusaurus/blob/main/README.md)

--- a/website/_dogfooding/_pages tests/linking/index.md
+++ b/website/_dogfooding/_pages tests/linking/index.md
@@ -19,6 +19,15 @@ This folder contains test pages to verify markdown file path links work correctl
 - [`/page-a.md`](/linking/page-a.md)
 - [`/nested/page-b.md`](/linking/nested/page-b.md)
 
+## Cross-plugin file path links
+
+Links to Markdown files owned by another plugin, see [#9117](https://github.com/facebook/docusaurus/issues/9117)
+
+- [`../../_docs tests/tests/links/target.mdx`](<../../_docs tests/tests/links/target.mdx>)
+- [`../../_blog tests/2023-08-05.mdx`](<../../_blog tests/2023-08-05.mdx>)
+- [`../../../docs/introduction.mdx`](../../../docs/introduction.mdx)
+- [`/docs/introduction.mdx`](/docs/introduction.mdx)
+
 ## Site alias file path links
 
 - [`@site/_dogfooding/_pages tests/linking/index.md`](<@site/_dogfooding/_pages tests/linking/index.md>)

--- a/website/docs/guides/markdown-features/markdown-features-links.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-links.mdx
@@ -15,7 +15,7 @@ There are two ways of adding a link to another page: through a **URL path** and 
 
 URL paths are unprocessed by Docusaurus, and you can see them as directly rendering to `<a href="./installation">`, i.e. it will be resolved according to the page's URL location, rather than its file-system location.
 
-If you want to reference another Markdown file **included by the same plugin**, you could use the relative path of the document you want to link to. Docusaurus' Markdown loader will convert the file path to the target file's URL path (and hence remove the `.md` extension).
+If you want to reference another Markdown file **of your site**, you could use the relative path of the document you want to link to. Docusaurus' Markdown loader will convert the file path to the target file's URL path (and hence remove the `.md` extension).
 
 For example, if you are in `docs/folder/doc1.md` and you want to reference `docs/folder/doc2.md`, `docs/folder/subfolder/doc3.md`, and `docs/otherFolder/doc4.md`:
 
@@ -49,8 +49,23 @@ Using relative _file_ paths (with `.md` extensions) instead of relative _URL_ li
 - A [versioned doc](../docs/versioning.mdx) will link to another doc of the exact same version
 - Relative URL links are very likely to break if you update the [`trailingSlash` config](../../api/docusaurus.config.js.mdx#trailingSlash)
 
+## Cross-plugin links
+
+Markdown file references also work across plugins: a blog post can link to a doc, a doc can link to a standalone page, and so on.
+
+Docusaurus resolves a Markdown link in two steps:
+
+1. It looks for the target file in the plugin instance **owning the source file**, using the resolution rules described above.
+2. If it can't find it, it looks for the target file in **the whole site**, using the site directory as the content root.
+
+The second step only kicks in for cross-plugin links, so the links of a plugin keep resolving in priority to the content of that plugin, notably for [versioned docs](../docs/versioning.mdx) and [localized content](../../i18n/i18n-introduction.mdx).
+
+```md title="blog/2024-01-01-post.md"
+Read our [installation doc](../docs/installation.mdx) first.
+```
+
 :::warning
 
-Markdown file references only work when the source and target files are processed by the same plugin instance. This is a technical limitation of our Markdown processing architecture and will be fixed in the future. If you are linking files between plugins (e.g. linking to a doc page from a blog post), you have to use URL links.
+Cross-plugin absolute file paths (`[link](/docs/target.mdx)`) are resolved from the site directory, and are **not portable**: you would need to update them manually if you create new doc versions or localize them.
 
 :::


### PR DESCRIPTION
Closes #9117

<!-- AI-assisted -->
This PR was written with AI assistance (AI-assisted).

## Motivation

Markdown file references such as `[link](../blog/post.md)` could only be resolved
against the Markdown files of the plugin instance owning the source file. Linking a
doc to a blog post, or a page to a doc, was impossible — the docs even documented the
limitation.

Building on @slorber's "core maintains a file path → URL path mapping" suggestion in
the issue.

## Implementation

- Core builds a **site-wide Markdown files registry** from the route metadata
  (`sourceFilePath`, available on every content route since #10457). No new plugin
  lifecycle is needed, and multi-instance / versioned / localized content works out of
  the box. Third-party content plugins join automatically as soon as they set
  `sourceFilePath` on their routes.
- The registry is exposed on `LoadContext` (`siteMarkdownLinks`) and handed over to the
  MDX loader by the docs/blog/pages plugins through a new optional
  `resolveSiteMarkdownLink` option.
- The `resolveMarkdownLinks` remark plugin tries the **plugin's own resolver first** and
  only falls back to the site-wide registry. Existing links therefore keep resolving
  exactly as before; only links that are broken today start resolving.
- The registry object identity is stable and its content is refreshed in place, because
  the bundler config (and thus the MDX loader options) is only created once, while
  `reloadSite()` creates a brand new `LoadContext` on every dev reload.

Relative, site-absolute (`/docs/intro.md`) and `@site/`-aliased links are all supported.

## Test Plan

- New unit tests for the registry (`siteMarkdownLinks.test.ts`) including the
  refresh-in-place invariant used by dev reloads.
- New remark plugin tests for the fallback: plugin resolves / site-wide fallback
  resolves / neither resolves.
- Dogfooding: cross-plugin links added to the docs, pages and blog test instances
  (docs → blog + pages + site docs, pages → docs + blog, and a new blog post → docs +
  pages). Since `onBrokenMarkdownLinks` defaults to `throw`, the website build itself
  asserts they all resolve.
- `pnpm test`, `pnpm lint:js`, `pnpm lint:style`, `pnpm lint:spelling`,
  `pnpm build:packages` and `pnpm build:website:fast` all pass.

Docs updated: `markdown-features-links.mdx` now has a "Cross-plugin links" section
replacing the warning that said this wasn't possible.
