### PR TITLE
chore: future-proof e2e test script for npm `min-release-age > 0`

### DIFF
--- a/admin/scripts/test-release.sh
+++ b/admin/scripts/test-release.sh
@@ -56,7 +56,9 @@ cd ..
 echo Generating test-website in `pwd`
 
 # Build skeleton website with new version
-npm_config_registry="$CUSTOM_REGISTRY_URL" npx --yes --loglevel silly create-docusaurus@"$NEW_VERSION" test-website classic --javascript $EXTRA_OPTS
+npm_config_registry="$CUSTOM_REGISTRY_URL" \
+  npm_config_min_release_age_exclude='create-docusaurus,@docusaurus/*,stylelint-copyright' \
+  npx --yes --loglevel silly create-docusaurus@"$NEW_VERSION" test-website classic --javascript $EXTRA_OPTS
 
 
 # Stop Docker container


### PR DESCRIPTION

## Motivation

In https://github.com/facebook/docusaurus/pull/12436, I was wondering why the e2e workflow was fixed on the CI, but not on my computer when running it manually.

It turns out it's because I added this to my `.npmrc` for security reasons:

```
# Needed security until default change
min-release-age=7
```

However, it prevents Verdaccio-published Docusaurus packages from installating due to a fresh publish.

The solution is supposed to be:

```
# Cooldown exclusions for Docusaurus packages
min-release-age-exclude[]=create-docusaurus
min-release-age-exclude[]=@docusaurus/*
min-release-age-exclude[]=stylelint-copyright
```

But unfortunately, there's a bug in npm 11/12, and those exclusions do not apply to `npx` or `npm exec` commands: https://github.com/npm/cli/issues/9765

I'm still adding those to the script because we'll likely need it for other users like me, or when npm turns release cooldown delays on by default (not in v12, probably later).

The alternative would be `npm_config_min_release_age=0 npx ...`, but I don't like this because there's a risk of installing newly published malicious packages from npm when running that script.

## Test Plan

N/A - can't test yet, unfortunately
