### PR TITLE
feat(core): support React 19 browser() in BrowserOnly

### DIFF
--- a/packages/docusaurus/src/client/exports/BrowserOnly.tsx
+++ b/packages/docusaurus/src/client/exports/BrowserOnly.tsx
@@ -5,60 +5,99 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {Suspense, use, type ReactNode} from 'react';
+'use client';
+
+import React, {Suspense, isValidElement, type ReactNode} from 'react';
 import * as ReactDOM from 'react-dom';
 import useIsBrowser from '@docusaurus/useIsBrowser';
+import type {Props as DocusaurusProps} from '@docusaurus/BrowserOnly';
 
-export interface BrowserOnlyProps {
-  children?: ReactNode | (() => ReactNode);
-  fallback?: ReactNode;
+export interface Props extends DocusaurusProps {
+  /**
+   * Optional explanation or reason factory for why this component is browser-only.
+   * On React 19.3+, this is passed to `react-dom`'s `browser(reason)` API and
+   * becomes the `cause` of the Error delivered to `onBrowserBailout`.
+   */
   reason?: string | (() => unknown);
 }
 
-// Feature detect React DOM's native browser() API
-const hasNativeBrowser = typeof (ReactDOM as any).browser === 'function';
+type ReactWithUse = typeof React & {
+  use?: <T>(usable: unknown) => T;
+};
 
-function ModernBrowserOnlyInner({
+type ReactDOMWithBrowser = typeof ReactDOM & {
+  browser?: (reason?: string | (() => unknown)) => unknown;
+};
+
+const reactUse = (React as ReactWithUse).use;
+const reactDomBrowser = (ReactDOM as ReactDOMWithBrowser).browser;
+const hasBrowserApi =
+  typeof reactUse === 'function' && typeof reactDomBrowser === 'function';
+
+function BrowserOnlyModernContent({
   children,
   reason,
 }: {
-  children?: ReactNode | (() => ReactNode);
+  children?: () => ReactNode;
   reason?: string | (() => unknown);
-}) {
-  use((ReactDOM as any).browser(reason));
-  return <>{typeof children === 'function' ? children() : children}</>;
+}): ReactNode {
+  reactUse!(
+    reactDomBrowser!(
+      reason ??
+        (() =>
+          new Error(
+            'This component was marked as browser-only using Docusaurus <BrowserOnly>.',
+          )),
+    ),
+  );
+
+  return <>{children?.()}</>;
 }
 
-function LegacyBrowserOnly({
-  children,
-  fallback = null,
-}: {
-  children?: ReactNode | (() => ReactNode);
-  fallback?: ReactNode;
-}) {
+function BrowserOnlyModern({children, fallback, reason}: Props): ReactNode {
+  return (
+    <Suspense fallback={fallback ?? null}>
+      <BrowserOnlyModernContent reason={reason}>
+        {children}
+      </BrowserOnlyModernContent>
+    </Suspense>
+  );
+}
+
+function BrowserOnlyLegacy({children, fallback}: Props): ReactNode {
   const isBrowser = useIsBrowser();
 
   if (isBrowser) {
-    return <>{typeof children === 'function' ? children() : children}</>;
+    return <>{children?.()}</>;
   }
 
-  return <>{fallback}</>;
+  return fallback ?? null;
 }
 
-export default function BrowserOnly({
-  children,
-  fallback = null,
-  reason = 'Component requires browser-only APIs.',
-}: BrowserOnlyProps): ReactNode {
-  if (hasNativeBrowser) {
-    return (
-      <Suspense fallback={fallback}>
-        <ModernBrowserOnlyInner reason={reason}>
-          {children}
-        </ModernBrowserOnlyInner>
-      </Suspense>
+function validateChildren(children: unknown): void {
+  if (
+    typeof children !== 'function' &&
+    process.env.NODE_ENV === 'development'
+  ) {
+    throw new Error(
+      `Docusaurus error: The children of <BrowserOnly> must be a "render function", e.g. <BrowserOnly>{() => <span>{window.location.href}</span>}</BrowserOnly>.\n` +
+        `Current type: ${isValidElement(children) ? 'React element' : typeof children}`,
     );
   }
+}
 
-  return <LegacyBrowserOnly fallback={fallback}>{children}</LegacyBrowserOnly>;
+export default function BrowserOnly(props: Props): ReactNode {
+  const {children, fallback} = props;
+
+  validateChildren(children);
+
+  if (typeof children !== 'function') {
+    return fallback ?? null;
+  }
+
+  if (hasBrowserApi) {
+    return <BrowserOnlyModern {...props} />;
+  }
+
+  return <BrowserOnlyLegacy {...props} />;
 }

--- a/packages/docusaurus/src/client/exports/BrowserOnly.tsx
+++ b/packages/docusaurus/src/client/exports/BrowserOnly.tsx
@@ -5,25 +5,60 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {isValidElement, type ReactNode} from 'react';
+import React, {Suspense, use, type ReactNode} from 'react';
+import * as ReactDOM from 'react-dom';
 import useIsBrowser from '@docusaurus/useIsBrowser';
-import type {Props} from '@docusaurus/BrowserOnly';
 
-// Similar comp to the one described here:
-// https://www.joshwcomeau.com/react/the-perils-of-rehydration/#abstractions
-export default function BrowserOnly({children, fallback}: Props): ReactNode {
+export interface BrowserOnlyProps {
+  children?: ReactNode | (() => ReactNode);
+  fallback?: ReactNode;
+  reason?: string | (() => unknown);
+}
+
+// Feature detect React DOM's native browser() API
+const hasNativeBrowser = typeof (ReactDOM as any).browser === 'function';
+
+function ModernBrowserOnlyInner({
+  children,
+  reason,
+}: {
+  children?: ReactNode | (() => ReactNode);
+  reason?: string | (() => unknown);
+}) {
+  use((ReactDOM as any).browser(reason));
+  return <>{typeof children === 'function' ? children() : children}</>;
+}
+
+function LegacyBrowserOnly({
+  children,
+  fallback = null,
+}: {
+  children?: ReactNode | (() => ReactNode);
+  fallback?: ReactNode;
+}) {
   const isBrowser = useIsBrowser();
 
   if (isBrowser) {
-    if (
-      typeof children !== 'function' &&
-      process.env.NODE_ENV === 'development'
-    ) {
-      throw new Error(`Docusaurus error: The children of <BrowserOnly> must be a "render function", e.g. <BrowserOnly>{() => <span>{window.location.href}</span>}</BrowserOnly>.
-Current type: ${isValidElement(children) ? 'React element' : typeof children}`);
-    }
-    return <>{children?.()}</>;
+    return <>{typeof children === 'function' ? children() : children}</>;
   }
 
-  return fallback ?? null;
+  return <>{fallback}</>;
+}
+
+export default function BrowserOnly({
+  children,
+  fallback = null,
+  reason = 'Component requires browser-only APIs.',
+}: BrowserOnlyProps): ReactNode {
+  if (hasNativeBrowser) {
+    return (
+      <Suspense fallback={fallback}>
+        <ModernBrowserOnlyInner reason={reason}>
+          {children}
+        </ModernBrowserOnlyInner>
+      </Suspense>
+    );
+  }
+
+  return <LegacyBrowserOnly fallback={fallback}>{children}</LegacyBrowserOnly>;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

This PR updates `BrowserOnly` to support React 19's new `use(browser())` API while keeping full backward compatibility with React 18.

### Why this is needed:
- **Prevents unnecessary re-renders**: The old `useEffect` implementation always forces a double-render cycle on the client after initial mount.
- **Improves CLS (Cumulative Layout Shift)**: In React 19, `browser()` gracefully bails out during SSR to a native `<Suspense>` fallback, eliminating visual flicker and layout shifts during hydration.
- **Zero breaking changes**: The component API (`BrowserOnlyProps`) remains exactly the same.
- **Full backward compatibility**: Automatically detects React 18 environments and falls back to the legacy `useEffect` behavior.


Extremely sorry if I made any mistakes

